### PR TITLE
Ignoring PyCharm's cache files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Jetbrains IDEA
+.idea/


### PR DESCRIPTION
Ignoring the '.idea/' folder so that it is safe to use Jetbrains IDEs.