### PR TITLE
Fixing problems with Pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,14 @@ repos:
     rev: 3.8.3
     hooks:
       - id: flake8
-  - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.5.3
+  - repo: local
     hooks:
       - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        require_serial: true
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.24.2
     hooks:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,4 @@
+[DESIGN]
+
+# Increasing the inheritance depth so that standard classes can be extended (See R0901)
+max-parents=15

--- a/cibyl/models/attribute.py
+++ b/cibyl/models/attribute.py
@@ -33,7 +33,7 @@ class AttributeListValue(AttributeValue):
 
     def __init__(self, name, arguments=None, attr_type=None, value=None):
 
-        super(AttributeListValue, self).__init__(
+        super().__init__(
             name=name, arguments=arguments, attr_type=attr_type, value=value)
 
         if isinstance(value, list):

--- a/cibyl/models/ci/environment.py
+++ b/cibyl/models/ci/environment.py
@@ -38,5 +38,5 @@ class Environment():
 
     def __str__(self):
         string = ""
-        string += "Environment: {}\n".format(self.name.value)
+        string += f"Environment: {self.name.value}\n"
         return string

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -63,7 +63,7 @@ class ZuulSystem(System):
         Model a Zuul CI system.
     """
     def __init__(self, name: str):
-        super(ZuulSystem, self).__init__(name, "zuul")
+        super().__init__(name, "zuul")
         pipeline_argument = Argument(name='--pipelines', arg_type=str,
                                      description="System pipelines")
         self.pipelines = AttributeListValue(name="pipelines",
@@ -84,7 +84,7 @@ class JenkinsSystem(System):
         Model a Jenkins CI system.
     """
     def __init__(self, name: str):
-        super(JenkinsSystem, self).__init__(name, "jenkins")
+        super().__init__(name, "jenkins")
 
     def __eq__(self, other):
         return self.name.value == other.name.value

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -32,10 +32,11 @@ class TestEnvironment(unittest.TestCase):
         test_name_bool = hasattr(self.env, attribute_name)
         self.assertTrue(
             test_name_bool,
-            msg="Environment lacks an attribute: {}".format(attribute_name))
-        self.assertEqual(self.env.name.value, self.name,
-                         msg="Environment name is {} instead of {}".format(
-                             self.env.name.value, self.name))
+            msg=f"Environment lacks an attribute: {attribute_name}")
+        self.assertEqual(
+            self.env.name.value, self.name,
+            msg=f"Environment name is {self.env.name.value} \
+instead of {self.name}")
 
     def test_new_environment_systems(self):
         """Testing new Environment name systems attribute"""
@@ -43,7 +44,7 @@ class TestEnvironment(unittest.TestCase):
         test_name_bool = hasattr(self.env, attribute_name)
         self.assertTrue(
             test_name_bool,
-            msg="Environment lacks an attribute: {}".format(attribute_name))
+            msg=f"Environment lacks an attribute: {attribute_name}")
 
     def test_add_systems(self):
         """Testing adding systems to environment"""

--- a/tests/models/test_job.py
+++ b/tests/models/test_job.py
@@ -35,8 +35,8 @@ class TestJob(unittest.TestCase):
 
         self.assertEqual(
             self.job.name.value, self.job_name,
-            msg="Job name is {}. Should be {}".format(
-                self.job.name.value, self.job_name))
+            msg=f"Job name is {self.job.name.value}. \
+Should be {self.job_name}")
 
     def test_job_status(self):
         """Testing new Job status attribute"""
@@ -45,20 +45,20 @@ class TestJob(unittest.TestCase):
 
         self.assertEqual(
             self.job.status.value, None,
-            msg="Job default status is {}. Should be {}".format(
-                self.job.status.value, None))
+            msg=f"Job default status is {self.job.status.value}. \
+Should be {None}")
 
         self.assertEqual(
             self.second_job.status.value, self.job_status,
-            msg="Job default status is {}. Should be {}".format(
-                self.second_job.status.value, self.job_status))
+            msg="Job default status is {self.second_job.status.value}.\
+ Should be {self.job_status}")
 
         self.job.status.value = self.job_status
 
         self.assertEqual(
             self.job.status.value, self.job_status,
-            msg="New job status is {}. Should be {}".format(
-                self.job.status.value, self.job_status))
+            msg="New job status is {self.job.status.value}. \
+Should be {self.job_status}")
 
     def test_job_url(self):
         """Testing new Job url attribute"""
@@ -67,32 +67,32 @@ class TestJob(unittest.TestCase):
 
         self.assertEqual(
             self.job.url.value, None,
-            msg="Job default url is {}. Should be {}".format(
-                self.job.url.value, None))
+            msg=f"Job default url is {self.job.url.value}. Should be {None}")
 
         self.job.url.value = self.job_url
 
         self.assertEqual(
             self.job.url.value, self.job_url,
-            msg="New job url is {}. Should be {}".format(
-                self.job.url.value, self.job_url))
+            msg=f"New job url is {self.job.url.value}. \
+Should be {self.job_url}")
 
     def test_jobs_comparison(self):
         """Testing new Job instances comparison."""
         self.assertEqual(
             self.job, self.second_job,
-            msg="Jobs {} and {} are not equal".format(
-                self.job.name.value, self.second_job.name.value))
+            msg=f"Jobs {self.job.name.value} and \
+{self.second_job.name.value} are not equal")
 
     def test_job_str(self):
         """Testing Job __str__ method"""
-        self.assertEqual(str(self.job), 'Job: {}'.format(self.job.name.value))
+        self.assertEqual(str(self.job), f'Job: {self.job.name.value}')
 
-        self.assertEqual(str(self.second_job), 'Job: {}\n  Status: {}'.format(
-            self.job_name, self.job_status))
+        self.assertEqual(
+            str(self.second_job),
+            f'Job: {self.job_name}\n  Status: {self.job_status}')
 
         self.second_job.url.value = self.job_url
 
         self.assertEqual(str(self.second_job),
-                         'Job: {}\n  Status: {}\n  URL: {}'.format(
-                             self.job_name, self.job_status, self.job_url))
+                         f'Job: {self.job_name}\n  \
+Status: {self.job_status}\n  URL: {self.job_url}')

--- a/tests/models/test_pipeline.py
+++ b/tests/models/test_pipeline.py
@@ -33,15 +33,15 @@ class TestPipeline(unittest.TestCase):
 
         self.assertEqual(
             self.pipeline.name.value, self.pipeline_name,
-            msg="Pipeline name is {}. Should be {}".format(
-                self.pipeline.name.value, self.pipeline_name))
+            msg=f"Pipeline name is {self.pipeline.name.value}. \
+Should be {self.pipeline_name}")
 
     def test_pipelines_comparison(self):
         """Testing new Pipeline instances comparison."""
         self.assertEqual(
             self.pipeline, self.second_pipeline,
-            msg="Pipelines {} and {} are not equal".format(
-                self.pipeline.name.value, self.second_pipeline.name.value))
+            msg=f"Pipelines {self.pipeline.name.value} and \
+{self.second_pipeline.name.value} are not equal")
 
     def test_pipeline_str(self):
         """Testing Pipeline __str__ method"""

--- a/tests/models/test_system.py
+++ b/tests/models/test_system.py
@@ -92,8 +92,8 @@ class TestZuulSystem(unittest.TestCase):
         """Testing new ZuulSystem instances comparison"""
         self.assertEqual(
             self.system, self.other_system,
-            msg="Jobs {} and {} are not equal".format(
-                self.system.name.value, self.system.name.value))
+            msg="Systems {self.system.name.value} and \
+{self.system.name.value} are not equal")
 
     def test_system_str(self):
         """Testing ZuulSystem __str__ method"""
@@ -147,8 +147,8 @@ class TestJenkinsSystem(unittest.TestCase):
         """Testing new JenkinsSystem instances comparison"""
         self.assertEqual(
             self.system, self.other_system,
-            msg="Jobs {} and {} are not equal".format(
-                self.system.name.value, self.system.name.value))
+            msg=f"Systems {self.system.name.value} and \
+{self.system.name.value} are not equal")
 
     def test_system_str(self):
         """Testing JenkinsSystem __str__ method"""

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
 [testenv:linters]
 deps =
     pre-commit>=1.21.0
+    pylint>=2.12.0
 commands =
     python -m pre_commit run -a
 
@@ -26,7 +27,7 @@ commands =
 
 [gh-actions]
 python =
-  3.9: py39
+    3.9: py39
 
 [testenv:coverage]
 commands =


### PR DESCRIPTION
Making the following changes to Pylint's execution during the pre-commit hook:
* Increased the number of parents so that there is more flexibility on what we can inherit.
* Making Pylint run locally to fix the 'unable to import' error. Here is some information regarding the change:
  * https://github.com/pre-commit/mirrors-pylint
  * https://pre-commit.com/#repository-local-hooks
  * https://pylint.pycqa.org/en/latest/user_guide/pre-commit-integration.html

It is also recommended for Flake8 and any other tool that depends on context to be run locally, but as long as we have no problem with them I have not done so.

It is very possible that this change brings new linting warnings.