### PR TITLE
Add Build class as a member of Job

### DIFF
--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -1,0 +1,41 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+from cibyl.cli.argument import Argument
+from cibyl.models.attribute import AttributeValue
+
+
+class Build:
+    """General model for a job build """
+    def __init__(self, build_id: str, status: str = None):
+        id_argument = Argument(name='--build-id', arg_type=str,
+                               description="Build id")
+        self.build_id = AttributeValue(name="build_id", attr_type=str,
+                                       value=build_id, arguments=[id_argument])
+        status_argument = Argument(name='--build-status', arg_type=str,
+                                   description="Build status")
+        self.status = AttributeValue(name="status", attr_type=str,
+                                     value=status,
+                                     arguments=[status_argument])
+
+    def __str__(self):
+        build_str = f"Build: {self.build_id.value}"
+        if self.status.value:
+            build_str += f"\n  Status: {self.status.value}"
+        return build_str
+
+    def __eq__(self, other):
+        return self.build_id.value == other.build_id.value

--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -38,4 +38,6 @@ class Build:
         return build_str
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
         return self.build_id.value == other.build_id.value

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -47,6 +47,8 @@ class Job:
         return job_str
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
         return self.name.value == other.name.value
 
     def add_build(self, build: Build):

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -1,6 +1,4 @@
 """
-Model a CI job
-"""
 #    Copyright 2022 Red Hat
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -14,39 +12,47 @@ Model a CI job
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+"""
 
 from cibyl.cli.argument import Argument
-from cibyl.models.attribute import AttributeValue
+from cibyl.models.attribute import AttributeListValue, AttributeValue
+from cibyl.models.ci.build import Build
 
 
 class Job:
     """
         General model for a CI job. Holds basic information such as its
-        name, status and url.
+        name, builds and url.
 
     """
-    def __init__(self, name: str, status: str = None, url: str = None):
+    def __init__(self, name: str, url: str = None):
         name_argument = Argument(name='--job-name', arg_type=str,
                                  description="Job name")
         self.name = AttributeValue(name="name", attr_type=str, value=name,
                                    arguments=[name_argument])
-        status_argument = Argument(name='--job-status', arg_type=str,
-                                   description="Job status")
-        self.status = AttributeValue(name="status", attr_type=str,
-                                     value=status,
-                                     arguments=[status_argument])
         url_argument = Argument(name='--job-url', arg_type=str,
                                 description="Job URL")
         self.url = AttributeValue(name="url", attr_type=str, value=url,
                                   arguments=[url_argument])
+        builds_argument = Argument(name='--builds', arg_type=str,
+                                   description="Job builds")
+        self.builds = AttributeListValue(name="builds",
+                                         attr_type=Build,
+                                         arguments=[builds_argument])
 
     def __str__(self):
         job_str = f"Job: {self.name.value}"
-        if self.status.value:
-            job_str += f"\n  Status: {self.status.value}"
         if self.url.value:
             job_str += f"\n  URL: {self.url.value}"
         return job_str
 
     def __eq__(self, other):
         return self.name.value == other.name.value
+
+    def add_build(self, build: Build):
+        """Add a build to the job.
+
+        :param build: Build to add to the job
+        :type build: Build
+        """
+        self.builds.append(build)

--- a/cibyl/models/ci/pipeline.py
+++ b/cibyl/models/ci/pipeline.py
@@ -35,4 +35,6 @@ class Pipeline:
         return f"Pipeline {self.name.value}"
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
         return self.name.value == other.name.value

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -62,6 +62,8 @@ class System:
         self.jobs.append(job)
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
         return self.name.value == other.name.value
 
 
@@ -90,4 +92,6 @@ class JenkinsSystem(System):
         super().__init__(name, "jenkins")
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
         return self.name.value == other.name.value

--- a/tests/models/test_build.py
+++ b/tests/models/test_build.py
@@ -1,0 +1,82 @@
+"""
+# Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import unittest
+
+from cibyl.models.ci.build import Build
+
+
+class TestBuild(unittest.TestCase):
+    """Testing Build CI model"""
+
+    def setUp(self):
+        self.build_id = 'test-build'
+        self.build_status = 'FAILURE'
+        self.build = Build(build_id=self.build_id)
+        self.second_build = Build(build_id=self.build_id)
+
+    def test_build_id(self):
+        """Testing new Build id attribute"""
+        self.assertTrue(
+            hasattr(self.build, 'build_id'),
+            msg="Build lacks build_id attribute")
+
+        self.assertEqual(
+            self.build.build_id.value, self.build_id,
+            msg=f"Build id is {self.build.build_id.value}. \
+Should be {self.build_id}")
+
+    def test_build_status(self):
+        """Testing new Build status attribute"""
+        self.assertTrue(
+            hasattr(self.build, 'status'), msg="Build lacks status attribute")
+
+        self.assertEqual(
+            self.build.status.value, None,
+            msg=f"Build default status is {self.build.status.value}. \
+Should be None")
+
+        self.assertEqual(
+            self.second_build.status.value, None,
+            msg=f"Build default status is {self.second_build.status.value}.\
+ Should be None")
+
+        self.build.status.value = self.build_status
+
+        self.assertEqual(
+            self.build.status.value, self.build_status,
+            msg="New build status is {self.build.status.value}. \
+Should be {self.build_status}")
+
+    def test_builds_comparison(self):
+        """Testing new Build instances comparison."""
+        self.assertEqual(
+            self.build, self.second_build,
+            msg=f"Builds {self.build.build_id.value} and \
+{self.second_build.build_id.value} are not equal")
+
+    def test_build_str(self):
+        """Testing Build __str__ method"""
+        self.assertEqual(str(self.build), f'Build: {self.build_id}')
+
+        self.assertEqual(
+            str(self.second_build),
+            f'Build: {self.build_id}')
+
+        self.second_build.status.value = self.build_status
+
+        self.assertEqual(
+                str(self.second_build),
+                f'Build: {self.build_id}\n  Status: {self.build_status}')

--- a/tests/models/test_job.py
+++ b/tests/models/test_job.py
@@ -15,6 +15,7 @@
 """
 import unittest
 
+from cibyl.models.ci.build import Build
 from cibyl.models.ci.job import Job
 
 
@@ -25,8 +26,9 @@ class TestJob(unittest.TestCase):
         self.job_name = 'test-job'
         self.job_status = 'FAILURE'
         self.job_url = 'http://ci_system/test-job'
+        self.builds = [Build("1")]
         self.job = Job(name=self.job_name)
-        self.second_job = Job(name=self.job_name, status=self.job_status)
+        self.second_job = Job(name=self.job_name)
 
     def test_job_name(self):
         """Testing new Job name attribute"""
@@ -38,27 +40,27 @@ class TestJob(unittest.TestCase):
             msg=f"Job name is {self.job.name.value}. \
 Should be {self.job_name}")
 
-    def test_job_status(self):
-        """Testing new Job status attribute"""
+    def test_job_builds(self):
+        """Testing new Job builds attribute"""
         self.assertTrue(
-            hasattr(self.job, 'status'), msg="Job lacks status attribute")
+            hasattr(self.job, 'builds'), msg="Job lacks builds attribute")
 
         self.assertEqual(
-            self.job.status.value, None,
-            msg=f"Job default status is {self.job.status.value}. \
-Should be {None}")
+            self.job.builds.value, [],
+            msg=f"Job default builds is {self.job.builds.value}. \
+Should be []")
 
         self.assertEqual(
-            self.second_job.status.value, self.job_status,
-            msg="Job default status is {self.second_job.status.value}.\
- Should be {self.job_status}")
+            self.second_job.builds.value, [],
+            msg="Job default builds are {self.second_job.builds.value}.\
+ Should be []")
 
-        self.job.status.value = self.job_status
+        self.job.builds.value = self.builds
 
         self.assertEqual(
-            self.job.status.value, self.job_status,
-            msg="New job status is {self.job.status.value}. \
-Should be {self.job_status}")
+            self.job.builds.value, self.builds,
+            msg="New job builds are {self.job.builds.value}. \
+Should be {self.builds}")
 
     def test_job_url(self):
         """Testing new Job url attribute"""
@@ -89,10 +91,10 @@ Should be {self.job_url}")
 
         self.assertEqual(
             str(self.second_job),
-            f'Job: {self.job_name}\n  Status: {self.job_status}')
+            f'Job: {self.job_name}')
 
         self.second_job.url.value = self.job_url
 
         self.assertEqual(str(self.second_job),
                          f'Job: {self.job_name}\n  \
-Status: {self.job_status}\n  URL: {self.job_url}')
+URL: {self.job_url}')


### PR DESCRIPTION
A Job can hold multiple builds, and a build will contain most of the
information of the job, like the status.
