### PR TITLE
Extend parser with arguments from the CI environments

### DIFF
--- a/cibyl/cli/argument.py
+++ b/cibyl/cli/argument.py
@@ -23,3 +23,4 @@ class Argument():
     name: str
     arg_type: object
     description: str
+    nargs: int = 1

--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -40,14 +40,16 @@ def main():
     # arguments from the CI models based on the loaded configuration file
     config_file_path = get_config_file_path(sys.argv)
 
-    orchestartor = Orchestrator(config_file_path)
-    orchestartor.load_configuration()
-    orchestartor.create_ci_environments()
+    orchestrator = Orchestrator(config_file_path)
+    orchestrator.load_configuration()
+    orchestrator.create_ci_environments()
+    for env in orchestrator.environments:
+        orchestrator.extend_parser(attributes=env.API)
     # We can parse user's arguments only after we have loaded the
     # configuration and extended based on it the parser with arguments
     # from the CI models
-    orchestartor.parser.parse()
-    orchestartor.run_query()
+    orchestrator.parser.parse()
+    orchestrator.run_query()
 
 
 if __name__ == "__main__":

--- a/cibyl/models/attribute.py
+++ b/cibyl/models/attribute.py
@@ -24,7 +24,7 @@ class AttributeValue():
 
     name: str
     attr_type: object
-    value: object
+    value: object = None
     arguments: list[Argument] = None
 
 

--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -13,23 +13,28 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-
+# pylint: disable=no-member
 from cibyl.cli.argument import Argument
-from cibyl.models.attribute import AttributeValue
+from cibyl.models.model import Model
 
 
-class Build:
+class Build(Model):
     """General model for a job build """
+    API = {
+        'build_id': {
+            'attr_type': str,
+            'arguments': [Argument(name='--build-id', arg_type=str,
+                                   description="Build ID")]
+        },
+        'status': {
+            'attr_type': str,
+            'arguments': [Argument(name='--build-status', arg_type=str,
+                                   description="Build status")]
+        },
+    }
+
     def __init__(self, build_id: str, status: str = None):
-        id_argument = Argument(name='--build-id', arg_type=str,
-                               description="Build id")
-        self.build_id = AttributeValue(name="build_id", attr_type=str,
-                                       value=build_id, arguments=[id_argument])
-        status_argument = Argument(name='--build-status', arg_type=str,
-                                   description="Build status")
-        self.status = AttributeValue(name="status", attr_type=str,
-                                     value=status,
-                                     arguments=[status_argument])
+        super().__init__({'build_id': build_id, 'status': status})
 
     def __str__(self):
         build_str = f"Build: {self.build_id.value}"

--- a/cibyl/models/ci/environment.py
+++ b/cibyl/models/ci/environment.py
@@ -13,24 +13,32 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+# pylint: disable=no-member
 from cibyl.cli.argument import Argument
-from cibyl.models.attribute import AttributeListValue, AttributeValue
+from cibyl.models.attribute import AttributeListValue
 from cibyl.models.ci.system import System
+from cibyl.models.model import Model
 
 
-class Environment():
+class Environment(Model):
     """Represents a CI environment with one or more CI systems."""
 
-    def __init__(self, name, systems=None):
+    API = {
+        'name': {
+            'attr_type': str,
+            'arguments': [Argument(name='--env-name', arg_type=str,
+                                   description="Name of the environment")]
+        },
+        'systems': {
+            'attr_type': System,
+            'attribute_value_class': AttributeListValue,
+            'arguments': [Argument(name='--systems', arg_type=str,
+                                   description="Systems of the environment")]
+        }
+    }
 
-        self.name = AttributeValue(
-            name='name', attr_type=str, value=name,
-            arguments=[Argument(name='--env-name', arg_type=str,
-                                description="Name of the environment")])
-        self.systems = AttributeListValue(
-            name='name', attr_type=System, value=systems,
-            arguments=[Argument(name='--systems', arg_type=str,
-                                description="Systems of the environment")])
+    def __init__(self, name, systems=None):
+        super().__init__({'name': name, 'systems': systems})
 
     def add_system(self, name: str, system_type: str, jobs_scope: str = None,
                    sources: list = None):

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -1,3 +1,4 @@
+# pylint: disable=no-member
 """
 #    Copyright 2022 Red Hat
 #
@@ -13,32 +14,40 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-
 from cibyl.cli.argument import Argument
-from cibyl.models.attribute import AttributeListValue, AttributeValue
+from cibyl.models.attribute import AttributeListValue
 from cibyl.models.ci.build import Build
+from cibyl.models.model import Model
 
 
-class Job:
+class Job(Model):
     """
         General model for a CI job. Holds basic information such as its
         name, builds and url.
 
     """
-    def __init__(self, name: str, url: str = None):
-        name_argument = Argument(name='--job-name', arg_type=str,
-                                 description="Job name")
-        self.name = AttributeValue(name="name", attr_type=str, value=name,
-                                   arguments=[name_argument])
-        url_argument = Argument(name='--job-url', arg_type=str,
-                                description="Job URL")
-        self.url = AttributeValue(name="url", attr_type=str, value=url,
-                                  arguments=[url_argument])
-        builds_argument = Argument(name='--builds', arg_type=str,
-                                   description="Job builds")
-        self.builds = AttributeListValue(name="builds",
-                                         attr_type=Build,
-                                         arguments=[builds_argument])
+    API = {
+        'name': {
+            'attr_type': str,
+            'arguments': [Argument(name='--job-name', arg_type=str,
+                                   description="Job name")]
+        },
+        'url': {
+            'attr_type': str,
+            'arguments': [Argument(name='--job-url', arg_type=str,
+                                   description="Job URL")]
+        },
+        'builds': {
+            'attr_type': Build,
+            'attribute_value_class': AttributeListValue,
+            'arguments': [Argument(name='--builds', arg_type=str,
+                                   description="Job builds")]
+        }
+    }
+
+    def __init__(self, name: str, url: str = None, builds: list[Build] = None):
+        super().__init__({'name': name, 'url': url,
+                          'builds': builds})
 
     def __str__(self):
         job_str = f"Job: {self.name.value}"

--- a/cibyl/models/ci/pipeline.py
+++ b/cibyl/models/ci/pipeline.py
@@ -1,5 +1,4 @@
-"""
-Model a CI pipeline
+# pylint: disable=no-member
 """
 #    Copyright 2022 Red Hat
 #
@@ -14,22 +13,35 @@ Model a CI pipeline
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
+"""
 from cibyl.cli.argument import Argument
-from cibyl.models.attribute import AttributeValue
+from cibyl.models.attribute import AttributeListValue
+from cibyl.models.ci.job import Job
+from cibyl.models.model import Model
 
 
-class Pipeline:
-    """
-        General model for a CI pipeline. Holds basic information such as its
-        name.
+class Pipeline(Model):
+    """Represents a Zuul pipeline"""
 
-    """
-    def __init__(self, name: str):
-        name_argument = Argument(name='--job-name', arg_type=str,
-                                 description="Job name")
-        self.name = AttributeValue(name="name", attr_type=str, value=name,
-                                   arguments=[name_argument])
+    API = {
+        'name': {
+            'attr_type': str,
+            'arguments': [Argument(name='--pipeline-name', arg_type=str,
+                                   description="System name")]
+        },
+        'jobs': {
+            'attr_type': Job,
+            'attribute_value_class': AttributeListValue,
+            'arguments': [Argument(name='--jobs', arg_type=str,
+                                   description="Pipeline jobs")]
+        }
+    }
+
+    def __init__(self, name: str, jobs: list[Job] = None):
+        super().__init__(attributes={'name': name,
+                                     'jobs': jobs})
+        self.name.value = name
+        self.jobs.value = jobs
 
     def __str__(self):
         return f"Pipeline {self.name.value}"

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -13,45 +13,58 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-
+# pylint: disable=no-member
 from cibyl.cli.argument import Argument
-from cibyl.models.attribute import AttributeListValue, AttributeValue
+from cibyl.models.attribute import AttributeListValue
 from cibyl.models.ci.job import Job
 from cibyl.models.ci.pipeline import Pipeline
+from cibyl.models.model import Model
 from cibyl.sources.source import Source
 
 
-class System:
+class System(Model):
     """General model for a CI system.
 
     Holds basic information such as its name, type and which jobs it has.
     """
+    API = {
+        'name': {
+            'attr_type': str,
+            'arguments': [Argument(name='--system-name', arg_type=str,
+                                   description="System name")]
+        },
+        'system_type': {
+            'attr_type': str,
+            'arguments': [Argument(name='--system-type', arg_type=str,
+                                   description="System type")]
+        },
+        'jobs': {
+            'attr_type': Job,
+            'attribute_value_class': AttributeListValue,
+            'arguments': [Argument(name='--jobs', arg_type=str,
+                                   description="System jobs")]
+        },
+        'jobs_scope': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'sources': {
+            'attr_type': Source,
+            'attribute_value_class': AttributeListValue,
+            'arguments': [Argument(name='--sources', arg_type=str,
+                                   description="Source name")]
+        }
+    }
 
-    def __init__(self, name: str, system_type: str, jobs_scope: str = "*",
-                 sources: list = None):
-        name_argument = Argument(name='--system-name', arg_type=str,
-                                 description="System name")
-        self.name = AttributeValue(name="name", attr_type=str, value=name,
-                                   arguments=[name_argument])
-
-        type_argument = Argument(name='--system-type', arg_type=str,
-                                 description="System type")
-        self.type = AttributeValue(name="type", attr_type=str,
-                                   value=system_type,
-                                   arguments=[type_argument])
-
-        jobs_argument = Argument(name='--jobs', arg_type=str,
-                                 description="System jobs")
-        self.jobs = AttributeListValue(name="jobs", attr_type=Job,
-                                       arguments=[jobs_argument])
-
-        self.jobs_scope = AttributeValue(name='jobs_scope', attr_type=str,
-                                         value=jobs_scope)
-        self.sources = AttributeListValue(name='sources', attr_type=Source,
-                                          value=sources)
+    def __init__(self, name: str,  # pylint: disable=too-many-arguments
+                 system_type: str, jobs: list[Job] = None,
+                 jobs_scope: str = "*", sources: list = None):
+        super().__init__({'name': name, 'system_type': system_type,
+                          'jobs': jobs, 'jobs_scope': jobs_scope,
+                          'sources': sources})
 
     def __str__(self):
-        return f"System {self.name.value} of type {self.type.value}"
+        return f"System {self.name.value} of type {self.system_type.value}"
 
     def add_job(self, job: Job):
         """Add a job to the CI system

--- a/cibyl/models/model.py
+++ b/cibyl/models/model.py
@@ -1,0 +1,32 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from cibyl.models.attribute import AttributeValue
+
+
+# pylint: disable=too-few-public-methods
+class Model:
+    """Represents a base class inherited by CI and product models."""
+
+    API = {}
+
+    def __init__(self, attributes):
+        for attribute_name, attribute_dict in self.API.items():
+            attribute_class = attribute_dict.get('attribute_value_class',
+                                                 AttributeValue)
+            setattr(self, attribute_name, attribute_class(
+                name=attribute_name, value=attributes[attribute_name],
+                arguments=attribute_dict.get('arguments', []),
+                attr_type=attribute_dict.get('attr_type')))

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -67,3 +67,15 @@ class Orchestrator:
     def run_query():
         """Execute query based on provided arguments."""
         LOG.debug("running query...")
+
+    def extend_parser(self, attributes,
+                      group_name='Environment'):
+        """Extend parser with arguments from CI models."""
+        for attr_dict in attributes.values():
+            arguments = attr_dict.get('arguments')
+            if arguments:
+                self.parser.extend(arguments, group_name)
+                class_type = attr_dict.get('attr_type')
+                if class_type not in [str, list, dict, int] and \
+                   hasattr(class_type, 'API'):
+                    self.extend_parser(class_type.API, class_type.__name__)

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -13,10 +13,11 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+import argparse
 from unittest import TestCase
 
+from cibyl.cli.argument import Argument
 from cibyl.cli.parser import Parser
-from cibyl.models.ci.environment import Environment
 
 
 class TestParser(TestCase):
@@ -25,6 +26,8 @@ class TestParser(TestCase):
     def setUp(self):
         self.parser = Parser()
         self.default_debug = False
+        self.test_argument = Argument('--test', arg_type=str,
+                                      description='test')
 
     def test_parser_plugin_argument(self):
         """Testing parser plugin argument"""
@@ -44,12 +47,17 @@ class TestParser(TestCase):
             ['--config', '/some/path'])
         self.assertEqual(parsed_args.config_file_path, '/some/path')
 
-    def test_parser_extend(self):
-        """Testing parser extend method"""
-        self.assertEqual(self.parser.extend([]), None)
-        self.assertEqual(self.parser.extend([Environment("test_env")]), None)
-
     def test_parser_parse_args(self):
         """Testing parser extend method"""
         parsed_args_ns = self.parser.parse()
         self.assertEqual(vars(parsed_args_ns).get('debug'), self.default_debug)
+
+    def test_parser_get_group(self):
+        """Testing parser get_group method"""
+        group = self.parser.get_group("test")
+        self.assertIsNone(group)
+
+        self.parser.extend([self.test_argument], 'test')
+        group = self.parser.get_group("test")
+        # pylint: disable=protected-access
+        self.assertIsInstance(group, argparse._ArgumentGroup)

--- a/tests/models/test_build.py
+++ b/tests/models/test_build.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+# pylint: disable=no-member
 import unittest
 
 from cibyl.models.ci.build import Build

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+# pylint: disable=no-member
 import unittest
 
 from cibyl.models.ci.environment import Environment

--- a/tests/models/test_job.py
+++ b/tests/models/test_job.py
@@ -19,6 +19,7 @@ from cibyl.models.ci.build import Build
 from cibyl.models.ci.job import Job
 
 
+# pylint: disable=no-member
 class TestJob(unittest.TestCase):
     """Testing Job CI model"""
 

--- a/tests/models/test_pipeline.py
+++ b/tests/models/test_pipeline.py
@@ -18,6 +18,7 @@ import unittest
 from cibyl.models.ci.pipeline import Pipeline
 
 
+# pylint: disable=no-member
 class TestPipeline(unittest.TestCase):
     """Testing Pipeline CI model"""
 

--- a/tests/models/test_system.py
+++ b/tests/models/test_system.py
@@ -1,6 +1,4 @@
 """
-    Tests for System CI model
-"""
 # Copyright 2022 Red Hat
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -14,7 +12,8 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
+"""
+# pylint: disable=no-member
 import unittest
 
 from cibyl.models.ci.job import Job
@@ -26,9 +25,9 @@ class TestSystem(unittest.TestCase):
     """Testing the System class"""
     def setUp(self):
         self.name = "test"
-        self.type = "test_type"
-        self.system = System(self.name, self.type)
-        self.other_system = System(self.name, self.type)
+        self.system_type = "test_type"
+        self.system = System(self.name, self.system_type)
+        self.other_system = System(self.name, self.system_type)
 
     def test_new_system_name(self):
         """Testing the name attribute of the System class"""
@@ -46,12 +45,12 @@ class TestSystem(unittest.TestCase):
     def test_new_system_type(self):
         """Testing the type attribute of the System class"""
         system = System("test", "test_type")
-        attribute_name = 'type'
+        attribute_name = 'system_type'
         test_name_bool = hasattr(system, attribute_name)
         self.assertTrue(
             test_name_bool,
             msg=f"System lacks an attribute: {attribute_name}")
-        type_name = system.type.value
+        type_name = system.system_type.value
         msg_str = f"System type should be test_type, not {type_name}"
         self.assertEqual(type_name, "test_type", msg=msg_str)
 
@@ -82,8 +81,9 @@ class TestZuulSystem(unittest.TestCase):
     def test_new_system_type(self):
         """Testing the type attribute of the ZuulSystem class"""
         self.assertTrue(
-            hasattr(self.system, 'type'), msg="System lacks type attribute")
-        system_type = self.system.type.value
+            hasattr(self.system, 'system_type'),
+            msg="System lacks type attribute")
+        system_type = self.system.system_type.value
         error_msg = f"System type should be zuul, not {system_type}"
         self.assertEqual(self.system.name.value, self.name,
                          msg=error_msg)
@@ -137,8 +137,9 @@ class TestJenkinsSystem(unittest.TestCase):
     def test_new_system_type(self):
         """Testing the type attribute of the JenkinsSystem class"""
         self.assertTrue(
-            hasattr(self.system, 'type'), msg="System lacks type attribute")
-        system_type = self.system.type.value
+            hasattr(self.system, 'system_type'),
+            msg="System lacks type attribute")
+        system_type = self.system.system_type.value
         error_msg = f"System type should be jenkins, not {system_type}"
         self.assertEqual(self.system.name.value, self.name,
                          msg=error_msg)


### PR DESCRIPTION
Initial parser is updated with additional arguments from
the different CI models created after the configuration
is loaded.

Each argument belongs to its own parser group which determined
by the type of the object it belongs to. Basically, each CI model
has its own group in the parser.
