### PR TITLE
Explicitly declare dependencies for each venv.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,19 +9,21 @@ requires =
 
 [testenv]
 usedevelop = True
-install_cmd = pip install -U {opts} {packages}
-deps =
-    -r {toxinidir}/requirements.txt
-    -r {toxinidir}/test-requirements.txt
+install_command = pip install -U {opts} {packages}
 
 [testenv:linters]
 deps =
     pre-commit>=1.21.0
     pylint>=2.12.0
+    -r {toxinidir}/requirements.txt
+    -r {toxinidir}/test-requirements.txt
 commands =
     python -m pre_commit run -a
 
 [testenv:unit]
+deps =
+    -r {toxinidir}/requirements.txt
+    -r {toxinidir}/test-requirements.txt
 commands =
     python -m unittest
 
@@ -30,6 +32,9 @@ python =
     3.9: py39
 
 [testenv:coverage]
+deps =
+    -r {toxinidir}/requirements.txt
+    -r {toxinidir}/test-requirements.txt
 commands =
     coverage run -m unittest discover
     coverage report --fail-under=90


### PR DESCRIPTION
This fixes a problem with tox where some dependencies defined on the requirements.txt file where not being downloaded.

Support for 'requirements.txt' files on tox is still considered experimental, so it would not surprise me that it would be a bug on it.

Additionally, I have changed 'install_cmd' for 'install_command', which is the correct name for the command -> https://tox.wiki/en/latest/config.html?highlight=install_command#conf-install_command

This fix is meant to allow https://github.com/rhos-infra/cibyl/pull/27 to pass CI.