### PR TITLE
Add initial publisher

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -50,6 +50,7 @@ def main():
     # from the CI models
     orchestrator.parser.parse()
     orchestrator.run_query()
+    orchestrator.publisher.publish(orchestrator.environments)
 
 
 if __name__ == "__main__":

--- a/cibyl/models/ci/environment.py
+++ b/cibyl/models/ci/environment.py
@@ -46,7 +46,9 @@ class Environment(Model):
         self.systems.append(System(name=name, system_type=system_type,
                                    jobs_scope=jobs_scope, sources=sources))
 
-    def __str__(self):
+    def __str__(self, indent=0):
         string = ""
         string += f"Environment: {self.name.value}\n"
+        for system in self.systems:
+            string += system.__str__(indent + 2)
         return string

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -49,8 +49,8 @@ class Job(Model):
         super().__init__({'name': name, 'url': url,
                           'builds': builds})
 
-    def __str__(self):
-        job_str = f"Job: {self.name.value}"
+    def __str__(self, indent=0):
+        job_str = indent*' ' + f"Job: {self.name.value}"
         if self.url.value:
             job_str += f"\n  URL: {self.url.value}"
         return job_str

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -63,8 +63,12 @@ class System(Model):
                           'jobs': jobs, 'jobs_scope': jobs_scope,
                           'sources': sources})
 
-    def __str__(self):
-        return f"System {self.name.value} of type {self.system_type.value}"
+    def __str__(self, indent=0):
+        string = indent*' ' + f"System: {self.name.value} \
+(type: {self.system_type.value})\n"
+        for job in self.jobs:
+            string += job.__str__()
+        return string
 
     def add_job(self, job: Job):
         """Add a job to the CI system

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -19,6 +19,7 @@ from cibyl.cli.parser import Parser
 from cibyl.config import Config
 from cibyl.exceptions.config import InvalidConfiguration
 from cibyl.models.ci.environment import Environment
+from cibyl.publisher import Publisher
 
 LOG = logging.getLogger(__name__)
 
@@ -44,6 +45,7 @@ class Orchestrator:
         """Orchestrator constructor method"""
         self.config = Config(path=config_file_path)
         self.parser = Parser()
+        self.publisher = Publisher()
         if not environments:
             self.environments = []
 

--- a/cibyl/publisher.py
+++ b/cibyl/publisher.py
@@ -1,0 +1,35 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import logging
+
+LOG = logging.getLogger(__name__)
+
+
+# pylint: disable=too-few-public-methods
+class Publisher:
+    """Represents a publisher which is responsible for publishing the data
+    collected by the application in the chosen format and to the chosen
+    location
+    """
+
+    @staticmethod
+    def publish(environments, dest="terminal"):
+        """Publishes the data of the given environments to the
+        chosen destination.
+        """
+        if dest == "terminal":
+            for env in environments:
+                print(env)

--- a/tests/models/test_system.py
+++ b/tests/models/test_system.py
@@ -98,10 +98,10 @@ class TestZuulSystem(unittest.TestCase):
     def test_system_str(self):
         """Testing ZuulSystem __str__ method"""
         self.assertEqual(str(self.system),
-                         f"System {self.name} of type zuul")
+                         f"System: {self.name} (type: zuul)\n")
 
         self.assertEqual(str(self.other_system),
-                         f"System {self.name} of type zuul")
+                         f"System: {self.name} (type: zuul)\n")
 
     def test_add_pipeline(self):
         """Testing ZuulSystem add pipeline method"""
@@ -154,10 +154,10 @@ class TestJenkinsSystem(unittest.TestCase):
     def test_system_str(self):
         """Testing JenkinsSystem __str__ method"""
         self.assertEqual(str(self.system),
-                         f"System {self.name} of type jenkins")
+                         f"System: {self.name} (type: jenkins)\n")
 
         self.assertEqual(str(self.other_system),
-                         f"System {self.name} of type jenkins")
+                         f"System: {self.name} (type: jenkins)\n")
 
     def test_add_job(self):
         """Testing adding a new job to a system"""

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,0 +1,36 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import patch
+
+from cibyl.models.ci.environment import Environment
+from cibyl.publisher import Publisher
+
+
+class TestOrchestrator(TestCase):
+    """Testing publisher component"""
+
+    def setUp(self):
+        self.publisher = Publisher()
+        self.env_name = "env1"
+        self.environment = Environment(self.env_name)
+
+    @patch('builtins.print')
+    def test_publisher_publish(self, mock_print):
+        """Testing Publisher publish method"""
+        self.publisher.publish(environments=[self.environment],
+                               dest="terminal")
+        mock_print.assert_called_with(self.environment)


### PR DESCRIPTION
The publisher is the component responsible for publishing
the gathered data by the application during its execution.

We start with simple use case of publishing (or printing) the
data to the terminal. In the future publisher might support
additional formats and destinations (e.g. email, DB, etc.)
