### PR TITLE
Associate model arguments with functions

### DIFF
--- a/cibyl/cli/argument.py
+++ b/cibyl/cli/argument.py
@@ -16,6 +16,7 @@
 from dataclasses import dataclass
 
 
+# pylint: disable=too-many-instance-attributes
 @dataclass
 class Argument():
     """Represents Parser's argument"""
@@ -24,3 +25,7 @@ class Argument():
     arg_type: object
     description: str
     nargs: int = 1
+    func: str = None
+    populated: bool = False
+    level: int = 0
+    value: object = None

--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -43,12 +43,14 @@ def main():
     orchestrator = Orchestrator(config_file_path)
     orchestrator.load_configuration()
     orchestrator.create_ci_environments()
+    # Add arguments from CI & product models to the parser of the app
     for env in orchestrator.environments:
         orchestrator.extend_parser(attributes=env.API)
     # We can parse user's arguments only after we have loaded the
     # configuration and extended based on it the parser with arguments
     # from the CI models
-    orchestrator.parser.parse()
+    orchestrator.parser.app_args, orchestrator.parser.ci_args = \
+        orchestrator.parser.parse()
     orchestrator.run_query()
     orchestrator.publisher.publish(orchestrator.environments)
 

--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -16,7 +16,32 @@
 import argparse
 import logging
 
+from cibyl.cli.argument import Argument
+
 LOG = logging.getLogger(__name__)
+
+
+class CustomAction(argparse.Action):
+    """Custom argparse.Action that allows in addition, to specify
+    whether an argument data is populated, the function associated
+    with the argument and the level in the models.
+    """
+    def __init__(self, *args, func=None, populated=False, level=-1, **kwargs):
+        """
+        argparse custom action.
+        :param func: the function the argument is associated with
+        """
+        self.func = func
+        self.level = level
+        self.populated = populated
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, Argument(
+            name=self.dest, description=self.help, arg_type=self.type,
+            nargs=self.nargs, level=self.level, func=self.func,
+            populated=self.populated,
+            value=values))
 
 
 class Parser:
@@ -26,7 +51,13 @@ class Parser:
     attributes.
     """
 
-    def __init__(self):
+    def __init__(self, ci_args: dict = None, app_args: dict = None):
+        self.ci_args = ci_args
+        if not ci_args:
+            self.ci_args = {}
+        self.app_args = app_args
+        if not app_args:
+            self.app_args = {}
         self.argument_parser = argparse.ArgumentParser()
         self.__add_arguments()
 
@@ -40,10 +71,23 @@ class Parser:
         self.argument_parser.add_argument(
             '--plugin', '-p', dest="plugin", default="openstack")
 
-    def parse(self):
-        """Parses arguments"""
-        # First item is the namespace of the parsed known arguments
-        return self.argument_parser.parse_known_args()[0]
+    def parse(self, arguments=None):
+        """Parses app_arguments
+
+        :return: application general arguments (config, debug) and models'
+                 arguments (jobs, systems, etc.)
+        :rtype: dictionary (both)
+        """
+        # First item is the namespace of the parsed known arguments (we ignore
+        # the arguments we are not familiar with)
+        known_arguments = self.argument_parser.parse_known_args(arguments)[0]
+        # Keep only the used arguments
+        ci_arguments = {arg_name: arg_value for arg_name, arg_value in vars(
+            known_arguments).items() if isinstance(arg_value, Argument)}
+        app_arguments = {arg_name: arg_value for arg_name, arg_value in vars(
+            known_arguments).items() if arg_value and not isinstance(
+                arg_value, Argument)}
+        return app_arguments, ci_arguments
 
     def get_group(self, group_name: str):
         """Returns the argument parser group based on a given group_name
@@ -63,7 +107,7 @@ class Parser:
                 return action_group
         return None
 
-    def extend(self, arguments: list, group_name: str):
+    def extend(self, arguments: list, group_name: str, level: int = 0):
         """Adds arguments to a specific argument parser group.
 
         :param arguments: A list of argument objects
@@ -81,6 +125,9 @@ class Parser:
             for arg in arguments:
                 group.add_argument(
                     arg.name, type=arg.arg_type,
-                    help=arg.description, nargs=arg.nargs)
+                    help=arg.description, nargs=arg.nargs,
+                    action=CustomAction, func=arg.func,
+                    populated=arg.populated,
+                    level=level)
         except argparse.ArgumentError:
             LOG.debug("argument already exists: %s...ignoring", arg.name)

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -30,7 +30,8 @@ class Job(Model):
         'name': {
             'attr_type': str,
             'arguments': [Argument(name='--job-name', arg_type=str,
-                                   description="Job name")]
+                                   description="Job name",
+                                   func='get_jobs')]
         },
         'url': {
             'attr_type': str,

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -42,7 +42,8 @@ class System(Model):
             'attr_type': Job,
             'attribute_value_class': AttributeListValue,
             'arguments': [Argument(name='--jobs', arg_type=str,
-                                   description="System jobs")]
+                                   description="System jobs",
+                                   func='get_jobs')]
         },
         'jobs_scope': {
             'attr_type': str,


### PR DESCRIPTION
Once an argument is associated with a function,
we can know that if user used for example the argument
'--jobs' to run the method Source.get_jobs().

In order to not run all the functions associated with
the arguments the user has used, we've also introduced
a level variable. The level variable will be used to
execute the function which is in the most advanced level.
