### PR TITLE
Associate model arguments with functions

### DIFF
--- a/cibyl/cli/argument.py
+++ b/cibyl/cli/argument.py
@@ -16,6 +16,7 @@
 from dataclasses import dataclass
 
 
+# pylint: disable=too-many-instance-attributes
 @dataclass
 class Argument():
     """Represents Parser's argument"""
@@ -24,3 +25,7 @@ class Argument():
     arg_type: object
     description: str
     nargs: int = 1
+    func: str = None
+    populated: bool = False
+    level: int = 0
+    value: object = None

--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -43,6 +43,7 @@ def main():
     orchestrator = Orchestrator(config_file_path)
     orchestrator.load_configuration()
     orchestrator.create_ci_environments()
+    # Add arguments from CI & product models to the parser of the app
     for env in orchestrator.environments:
         orchestrator.extend_parser(attributes=env.API)
     # We can parse user's arguments only after we have loaded the

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -30,7 +30,8 @@ class Job(Model):
         'name': {
             'attr_type': str,
             'arguments': [Argument(name='--job-name', arg_type=str,
-                                   description="Job name")]
+                                   description="Job name",
+                                   func='get_jobs')]
         },
         'url': {
             'attr_type': str,

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -42,7 +42,8 @@ class System(Model):
             'attr_type': Job,
             'attribute_value_class': AttributeListValue,
             'arguments': [Argument(name='--jobs', arg_type=str,
-                                   description="System jobs")]
+                                   description="System jobs",
+                                   func='get_jobs')]
         },
         'jobs_scope': {
             'attr_type': str,


### PR DESCRIPTION
This change expands the attributes of "Argument" class in order to:

1. Associate arguments with functions. This will allow us
to invoke a function when an argument is used. So --jobs
argument will invoke Source.get_jobs()

2. In order to not run every function associated with
the different arguments the user has used, this change also
introduces a "level" attribute to determine the level
of the model.

Environment
   System
      Jobs
        Job -> Run this function and not any of the previous
               levels, even if user has used them.

The reason level is part of Argument and not the Model itself
is because models relationship differs based on the system
(Zuul -> Pipline -> Job vs. Jenkins -> Job for example. Job level
is different for job in every system).

3. Finally, also introduced a 'populated' variable to
mark whether information in regards to certain used argument
was pulled from the source to give the user an indication
as to what the source has pulled. This can be also used in the future
to mark failure/success for a source and move to the next one in the
list.