### PR TITLE
Add initial source for rhos-qe-jenkins

### DIFF
--- a/cibyl/exceptions/jenkins_job_builder.py
+++ b/cibyl/exceptions/jenkins_job_builder.py
@@ -1,0 +1,19 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+
+class JenkinsJobBuilderError(Exception):
+    """Represents an error occurring while querying JenkinsJobBuilder."""

--- a/cibyl/sources/jenkins_job_builder.py
+++ b/cibyl/sources/jenkins_job_builder.py
@@ -1,0 +1,124 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+import logging
+import os
+import subprocess
+import xml.etree.ElementTree as ET
+from functools import partial
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from cibyl.exceptions.jenkins_job_builder import JenkinsJobBuilderError
+from cibyl.models.ci.job import Job
+from cibyl.sources.source import Source, safe_request_generic
+
+LOG = logging.getLogger(__name__)
+
+
+safe_request = partial(safe_request_generic,
+                       custom_error=JenkinsJobBuilderError)
+
+
+# pylint: disable=no-member
+class JenkinsJobBuilder(Source):
+    """A class representation of a JenkinsJobBuilder repo."""
+
+    def __init__(self, url: str, dest: str = None, branch: str = None):
+        """Create a client to talk to a jenkins job definitions instance.
+
+        :param url: Job definitions address
+        :type url: str
+        :param dest: Path to the repository, or where to store it
+        :type dest: str
+        :param branch: Branch to checkout
+        :type branch: str
+        """
+        super().__init__("", url)
+        self.dest = dest
+        self.branch = branch
+        if dest is None:
+            # store the TemporaryDirectory directory, so that the contents live
+            # until the instance of self is destroyed
+            # pylint: disable=consider-using-with
+            self.tmp_folder = TemporaryDirectory()
+            self.dest = self.tmp_folder.name
+
+        if not os.path.exists(os.path.join(self.dest, ".git")):
+            LOG.debug("cloning repository to %s", self.dest)
+            self.get_repo()
+        else:
+            LOG.debug("repository already present in %s", self.dest)
+
+    @safe_request
+    def get_repo(self):
+        """Download git repository for job definitions."""
+        branch_options = []
+        if self.branch is not None:
+            branch_options = ["-b", self.branch]
+        subprocess.run(["git", "clone", self.url, self.dest]+branch_options,
+                       check=True)
+
+    def _generate_xml(self):
+        """Use tox to generate jenkins job xml files."""
+        subprocess.run(["tox",  "-e", "jobs"], check=True, cwd=self.dest)
+
+    def get_jobs(self):
+        """Get all jobs from jenkins server.
+
+        :returns: All jobs from jenkins server, as dictionaries of _class,
+        name, fullname, url, color
+        :rtype: list
+        """
+        self._generate_xml()
+        jobs = []
+        for path in Path(os.path.join(self.dest, "out-xml")).rglob("*.xml"):
+            file_content = ET.parse(path).getroot()
+            file_type = file_content.tag
+            if "folder" in file_type:
+                # if the xml file contains the word folder in the top-level
+                # attribute, then it's probably not a job
+                continue
+            # for now we store the job name as the only information, later we
+            # will need to see which additional information to pull from the
+            # job definition
+            jobs.append(path.parent.name)
+
+        return jobs
+
+    # pylint: disable=no-self-use
+    def populate_jobs(self, system, jobs: list[str]):
+        """Create Job models using jenkins jobs information.
+
+        :param system: System model to input the jobs to
+        :type system: :class:`cibyl.models.ci.system.System`
+        :param jobs: Jobs received from jenkins server
+        :type jobs: list
+        """
+        for job_name in jobs:
+            system.jobs.append(Job(name=job_name))
+
+    # pylint: disable=inconsistent-return-statements
+    def query(self, system, args):
+        LOG.debug("querying system %s using source: %s",
+                  system.name.value, self.__name__)
+
+        if args.get('jobs'):
+            jobs = self.get_jobs()
+            self.populate_jobs(system, jobs)
+
+        if all(argument.populated for argument in args):
+            return system

--- a/tests/sources/test_jenkins.py
+++ b/tests/sources/test_jenkins.py
@@ -31,8 +31,7 @@ def return_arg(query=None):
 
 
 class TestSafeRequestJenkinsError(TestCase):
-    """Tests for :func:`safe_request`.
-    """
+    """Tests for :func:`safe_request`."""
 
     def test_wraps_errors_jenkins_error(self):
         """Tests that errors coming out of the Jenkins API call are wrapped around the
@@ -58,8 +57,7 @@ class TestSafeRequestJenkinsError(TestCase):
 
 
 class TestJenkinsSource(TestCase):
-    """Tests for :class:`Jenkins`.
-    """
+    """Tests for :class:`Jenkins`."""
 
     def setUp(self):
         self.jenkins = Jenkins("url", "user", "token")

--- a/tests/sources/test_jenkins_job_builder.py
+++ b/tests/sources/test_jenkins_job_builder.py
@@ -1,0 +1,132 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+# pylint: disable=no-member, protected-access
+import os
+import shutil
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from cibyl.models.ci.system import System
+from cibyl.sources.jenkins_job_builder import JenkinsJobBuilder
+
+
+def remove_fake_files():
+    """Remove the fake xml files."""
+    shutil.rmtree("out_jjb_test")
+
+
+def fake_xml_files():
+    """Create two fake xml files to test the get_jobs method."""
+    path1 = "out_jjb_test/out-xml/fake_job1"
+    path2 = "out_jjb_test/out-xml/fake_job2"
+    os.makedirs(path1, exist_ok=True)
+    os.makedirs(path2, exist_ok=True)
+    file_name = os.path.join(path1, "config.xml")
+    with open(file_name, "w", encoding="utf-8") as fake1:
+        fake1.write('<?xml version="1.0" encoding="utf-8"?>\n')
+        fake1.write('<com.folder.Folder plugin="cloudbees-folder">\n')
+        fake1.write('  <icon class="com.folder.icons.StockFolderIcon"/>\n')
+        fake1.write('  <views/>\n')
+        fake1.write('  <scm class="hudson.scm.NullSCM"/>\n')
+        fake1.write('  <publishers/>\n')
+        fake1.write('  <buildWrappers/>\n')
+        fake1.write('</com.folder.Folder>\n')
+
+    file_name = os.path.join(path2, "config.xml")
+    with open(file_name, "w", encoding="utf-8") as fake2:
+        fake2.write('<?xml version="1.0" encoding="utf-8"?>\n')
+        fake2.write('<flow-definition plugin="workflow-job">\n')
+        fake2.write('  <definition plugin="workflow-cps" class="org.j">\n')
+        fake2.write('  </definition>\n')
+        fake2.write('</flow-definition> \n')
+
+
+@patch('cibyl.sources.jenkins_job_builder.JenkinsJobBuilder.get_repo')
+class TestJenkinsJobBuilderSource(TestCase):
+    """Tests for :class:`JenkinsJobBuilder`."""
+    def setUp(self):
+        fake_xml_files()
+
+    def tearDown(self):
+        remove_fake_files()
+
+    # second argument is necessary to support patching of mock get_repo method
+    def test_with_all_args(self, _):
+        """Checks that the object is built correctly when all arguments are
+        provided.
+        """
+        url = 'url/to/repo'
+        dest = 'dest_folder'
+        branch = 'master'
+
+        jenkins = JenkinsJobBuilder(url, dest=dest, branch=branch)
+
+        self.assertEqual(dest, jenkins.dest)
+        self.assertEqual(url, jenkins.url)
+        self.assertEqual(branch, jenkins.branch)
+
+    def test_with_no_dest(self, _):
+        """Checks that object is built correctly when the dest is not
+        provided.
+        """
+        url = 'url/to/repo/'
+        branch = 'master'
+
+        jenkins = JenkinsJobBuilder(url, branch=branch)
+
+        self.assertEqual(url, jenkins.url)
+        self.assertEqual(branch, jenkins.branch)
+        self.assertIsNotNone(jenkins.dest)
+        self.assertTrue(os.path.isdir(jenkins.dest))
+
+    def test_with_no_branch(self, _):
+        """Checks that object is built correctly when the branch is not
+        provided.
+        """
+        url = 'url/to/repo/'
+        dest = 'dest'
+
+        jenkins = JenkinsJobBuilder(url, dest=dest)
+
+        self.assertEqual(url, jenkins.url)
+        self.assertIsNone(jenkins.branch)
+        self.assertEqual(dest, jenkins.dest)
+
+    def test_get_jobs(self, _):
+        """
+            Tests that the internal logic of :meth:`JenkinsJobBuilder.get_jobs`
+            is correct. The jenkins API method that should do the query is
+            mocked so that it returns the query itself.
+        """
+        jenkins = JenkinsJobBuilder("url", dest="out_jjb_test")
+        jenkins._generate_xml = Mock()
+
+        jobs = jenkins.get_jobs()
+        self.assertEqual(jobs, ["fake_job2"])
+
+    def test_populate_jobs(self, _):
+        """
+            Tests that the jenkins info is correctly parsed and job models are
+            populated.
+        """
+        jenkins = JenkinsJobBuilder("url", dest="out_jjb_test")
+        jenkins._generate_xml = Mock()
+
+        jobs = jenkins.get_jobs()
+        system = System("test_system", "test")
+        jenkins.populate_jobs(system, jobs)
+        self.assertEqual(1, len(system.jobs.value))
+        self.assertEqual("fake_job2", system.jobs.value[0].name.value)


### PR DESCRIPTION
Create source with basic functionality to pull information from
a repository with jenkins job builder definition. Clones the repository,
runs tox to generate xml files for the jobs and reads them. In the
future we might need to revisit how to filter the xml files.
