### PR TITLE
ElasticsearchOSP tests

### DIFF
--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -24,6 +24,11 @@ LOG = logging.getLogger(__name__)
 class ElasticSearchOSP:  # pylint: disable=too-few-public-methods
     """Used to perform queries in elasticsearch"""
 
+    ALLOWED_QUERIES = [
+        'regexp',
+        'term'
+    ]
+
     def __init__(self: object, elastic_client: object) -> None:
         self.es_client = elastic_client
 
@@ -41,6 +46,11 @@ class ElasticSearchOSP:  # pylint: disable=too-few-public-methods
         :return: hits
         :rtype: list
         """
+
+        if query_type not in self.ALLOWED_QUERIES:
+            raise ElasticSearchError(f"Query '{query_type}' not allowed. \
+                  Allowed queries: {' '.join(self.ALLOWED_QUERIES)}")
+
         if query_type == 'term':
             key = 'jobName.keyword'
         else:

--- a/tests/sources/elasticsearch/test_api.py
+++ b/tests/sources/elasticsearch/test_api.py
@@ -16,8 +16,9 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from cibyl.sources.elasticsearch.api import ElasticSearchOSP
 from cibyl.exceptions.elasticsearch import ElasticSearchError
+from cibyl.sources.elasticsearch.api import ElasticSearchOSP
+
 
 class TestElasticsearchOSP(TestCase):
     """Test cases for :class:`ElasticSearchOSP`.

--- a/tests/sources/elasticsearch/test_api.py
+++ b/tests/sources/elasticsearch/test_api.py
@@ -39,13 +39,17 @@ class TestElasticsearchOSP(TestCase):
             'not_valid': 'example'
         }
 
-    @patch("cibyl.sources.elasticsearch.api.ElasticSearchOSP.get_jobs_by_name")
+    # @patch("cibyl.sources.elasticsearch.api.ElasticSearchOSP.__query_get_hits")
+    @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
     def test_method_return_list(self: object, mock_query_hits: object) -> None:
         """Tests if :meth:`ElasticSearchOSP.get_jobs_by_name`
         return a list.
         """
         mock_query_hits.return_value = self.hits
-        self.assertIsInstance(ElasticSearchOSP.get_jobs_by_name(), list)
+        self.assertIsInstance(
+            self.es_api.get_jobs_by_name(self.job_name),
+            list
+        )
 
     def test_type_query(self: object) -> None:
         """Tests if :meth:`ElasticSearchOSP.get_jobs_by_name`

--- a/tests/sources/elasticsearch/test_api.py
+++ b/tests/sources/elasticsearch/test_api.py
@@ -39,7 +39,6 @@ class TestElasticsearchOSP(TestCase):
             'not_valid': 'example'
         }
 
-    # @patch("cibyl.sources.elasticsearch.api.ElasticSearchOSP.__query_get_hits")
     @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
     def test_method_return_list(self: object, mock_query_hits: object) -> None:
         """Tests if :meth:`ElasticSearchOSP.get_jobs_by_name`

--- a/tests/sources/elasticsearch/test_api.py
+++ b/tests/sources/elasticsearch/test_api.py
@@ -1,0 +1,48 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.sources.elasticsearch.api import ElasticSearchOSP
+
+
+def return_hits():
+    """It will return fake hits from elasticsearch
+    to use it in a Mock
+    """
+    return [
+        {
+            '_index': 'test',
+            '_id': 'random',
+            '_score': 1.0
+        }
+    ]
+
+
+class TestElasticsearchOSP(TestCase):
+    """Test cases for :class:`ElasticSearchOSP`.
+    """
+
+    def setUp(self) -> None:
+        self.es_api = ElasticSearchOSP(Mock())
+
+    def test_return_list(self):
+        """Tests if :meth:`ElasticSearchOSP.get_jobs_by_name`
+        return a list.
+        """
+        self.es_api.get_jobs_by_name = Mock()
+        self.es_api.get_jobs_by_name.side_effect = return_hits
+        self.assertIsInstance(self.es_api.get_jobs_by_name(), list)


### PR DESCRIPTION
- Add list of allowed queries to ElasticSearchOSP.
- Add test for `ElasticSearchOSP.get_jobs_by_name` method.