### PR TITLE
Add configuration options for logging

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -16,6 +16,7 @@
 import sys
 
 from cibyl.orchestrator import Orchestrator
+from cibyl.utils.logger import configure_logging
 
 
 def get_config_file_path(arguments):
@@ -32,6 +33,27 @@ def get_config_file_path(arguments):
     return config_file_path
 
 
+def get_config_log(arguments):
+    """Returns configuration related to logging
+
+    :param arguments: A list of strings representing the arguments and their
+                      values, defaults to None
+    :type arguments: str, optional
+    :returns: Dictionary with the logging-related configuration
+    :rtype: dict[str, str]
+    """
+    log_config = {"log_file": "cibyl_output.log", "log_mode": "both",
+                  "debug": False}
+    for i, item in enumerate(arguments[1:]):
+        if item == "--log-file":
+            log_config["log_file"] = arguments[i + 2]
+        elif item == "--log-mode":
+            log_config["log_mode"] = arguments[i+2]
+        elif item == "--debug":
+            log_config["debug"] = True
+    return log_config
+
+
 def main():
     """CLI main entry."""
 
@@ -39,6 +61,8 @@ def main():
     # to run the app parser only once, after we update it with the loaded
     # arguments from the CI models based on the loaded configuration file
     config_file_path = get_config_file_path(sys.argv)
+    log_config = get_config_log(sys.argv)
+    configure_logging(log_config)
 
     orchestrator = Orchestrator(config_file_path)
     orchestrator.load_configuration()

--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -69,6 +69,13 @@ class Parser:
         self.argument_parser.add_argument(
             '--config', '-c', dest="config_file_path")
         self.argument_parser.add_argument(
+            '--log-file', dest="log_file",
+            help='Path to store the output, default is cibyl_output.log')
+        self.argument_parser.add_argument(
+            '--log-mode', dest="log_mode",
+            choices=("terminal", "file", "both"),
+            help='Where to write the output, default is both')
+        self.argument_parser.add_argument(
             '--plugin', '-p', dest="plugin", default="openstack")
 
     def parse(self, arguments=None):

--- a/cibyl/utils/logger.py
+++ b/cibyl/utils/logger.py
@@ -1,0 +1,83 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+import logging
+import sys
+
+import colorlog
+
+FORMAT_STR = '{}%(levelname)-8s %(name)-20s %(message)s'
+FILE_LOGGER_FORMATER = logging.Formatter(fmt=FORMAT_STR.format(""))
+TERMINAL_LOGGER_FORMATTER = colorlog.ColoredFormatter(
+                                FORMAT_STR.format("%(log_color)s"),
+                                log_colors=dict(
+                                    DEBUG='blue',
+                                    INFO='green',
+                                    WARNING='yellow',
+                                    ERROR='red',
+                                    CRITICAL='bold_red,bg_white',))
+
+
+def configure_terminal_logging(level):
+    """Configure logger to print to terminal.
+
+    :param level: Logging level, default DEBUG
+    :type level: int
+    """
+    logger = logging.getLogger()
+    logger.setLevel(level)
+    stream_handler = logging.StreamHandler(sys.stderr)
+    stream_handler.setLevel(level)
+    stream_handler.setFormatter(TERMINAL_LOGGER_FORMATTER)
+    logger.addHandler(stream_handler)
+
+
+def configure_file_logging(log_file, level):
+    """Configure logger to print to file.
+
+    :param log_file: Path to log file
+    :param log_file: str
+    :param level: Logging level, default DEBUG
+    :type level: int
+    """
+    logger = logging.getLogger()
+    logger.setLevel(level)
+    file_handler = logging.FileHandler(log_file, mode="w")
+    file_handler.setLevel(level)
+    file_handler.setFormatter(FILE_LOGGER_FORMATER)
+    logger.addHandler(file_handler)
+
+
+def configure_logging(log_config, level=logging.INFO):
+    """Configure logging format and level.
+
+    :param log_config: Configuration for the logger
+    :type log_config: dict
+    :param level: Logging level, default DEBUG
+    :type level: int
+    """
+    if log_config.get("debug", False):
+        level = logging.DEBUG
+    log_mode = log_config["log_mode"]
+    log_file = log_config["log_file"]
+    if log_mode == "terminal":
+        print(log_mode, log_file)
+        configure_terminal_logging(level)
+    elif log_mode == "file":
+        configure_file_logging(log_file, level)
+    else:
+        configure_terminal_logging(level)
+        configure_file_logging(log_file, level)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyyaml~=6.0
 zuul-client~=0.0.4
 elasticsearch~=7.17.1
 python-jenkins
+colorlog


### PR DESCRIPTION
Adds two cli arguments to configure logging. log_mode configures where
to write the logs (terminal, file or both) and log_file configures the
name of the file to write them. This arguments are read from sys.argv
before the parser is extended in order to configure the loggers and have
them use the same configuration.

Defaults are currently to write both to the terminal and file, with the
filename cibyl_output.log. But these options and the logging format are open to
discussion.
