### PR TITLE
Use nargs='*' for AttributeListValue arguments

### DIFF
--- a/cibyl/cli/argument.py
+++ b/cibyl/cli/argument.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 from dataclasses import dataclass
+from typing import Union
 
 
 # pylint: disable=too-many-instance-attributes
@@ -24,7 +25,7 @@ class Argument():
     name: str
     arg_type: object
     description: str
-    nargs: int = 1
+    nargs: Union[str, int] = 1
     func: str = None
     populated: bool = False
     level: int = 0

--- a/cibyl/models/ci/environment.py
+++ b/cibyl/models/ci/environment.py
@@ -32,7 +32,7 @@ class Environment(Model):
         'systems': {
             'attr_type': System,
             'attribute_value_class': AttributeListValue,
-            'arguments': [Argument(name='--systems', arg_type=str,
+            'arguments': [Argument(name='--systems', arg_type=str, nargs='*',
                                    description="Systems of the environment")]
         }
     }

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -42,6 +42,7 @@ class Job(Model):
             'attr_type': Build,
             'attribute_value_class': AttributeListValue,
             'arguments': [Argument(name='--builds', arg_type=str,
+                                   nargs="*",
                                    description="Job builds")]
         }
     }

--- a/cibyl/models/ci/pipeline.py
+++ b/cibyl/models/ci/pipeline.py
@@ -33,6 +33,7 @@ class Pipeline(Model):
             'attr_type': Job,
             'attribute_value_class': AttributeListValue,
             'arguments': [Argument(name='--jobs', arg_type=str,
+                                   nargs='*',
                                    description="Pipeline jobs")]
         }
     }

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -54,6 +54,7 @@ class System(Model):
             'attr_type': Source,
             'attribute_value_class': AttributeListValue,
             'arguments': [Argument(name='--sources', arg_type=str,
+                                   nargs="*",
                                    description="Source name")]
         }
     }

--- a/cibyl/models/openstack/deployment.py
+++ b/cibyl/models/openstack/deployment.py
@@ -42,12 +42,14 @@ class Deployment(Model):
             'attr_type': Node,
             'attribute_value_class': AttributeListValue,
             'arguments': [Argument(name='--nodes', arg_type=str,
+                          nargs='*',
                           description="Nodes on the deployment")]
         },
         'services': {
             'attr_type': Service,
             'attribute_value_class': AttributeListValue,
             'arguments': [Argument(name='--services', arg_type=str,
+                          nargs='*',
                           description="Services in the deployment")]
         }
     }

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -75,8 +75,11 @@ class Jenkins(Source):
             return self.client.get_info(query=self.jobs_builds_query)["jobs"]
         jobs_arg = kwargs.get('jobs')
         if jobs_arg:
+            jobs_found = []
             for job in jobs_arg.value:
-                return self.client.get_job_info_regex(pattern=job)
+                LOG.debug("querying %s for job %s", self.name, job)
+                jobs_found.extend(self.client.get_job_info_regex(pattern=job))
+            return jobs_found
 
         return self.client.get_info(query=self.jobs_query)["jobs"]
 


### PR DESCRIPTION
With this change, cli arguments can accept more than one input. For
example to select multiple job names, or multiple systems.
