### PR TITLE
Add source registry to identify source classes

### DIFF
--- a/cibyl/sources/source.py
+++ b/cibyl/sources/source.py
@@ -18,6 +18,7 @@ import logging
 
 from cibyl.exceptions.source import (NoSupportedSourcesFound,
                                      TooManyValidSources)
+from cibyl.sources.source_registry import SourceRegistry
 
 LOG = logging.getLogger(__name__)
 
@@ -97,5 +98,9 @@ class Source:
         :param driver: the name of the driver as used by the source
         :type driver: str
         """
-        return getattr(importlib.import_module(
-            f"cibyl.sources.{driver}"), driver.capitalize())
+        module, class_name = SourceRegistry.sources.get(driver, (None, None))
+        if module is None or class_name is None:
+            # fallback in case the driver is not in the source registry
+            return getattr(importlib.import_module(
+                    f"cibyl.sources.{driver}"), driver.capitalize())
+        return getattr(importlib.import_module(module), class_name)

--- a/cibyl/sources/source_registry.py
+++ b/cibyl/sources/source_registry.py
@@ -1,0 +1,31 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+
+# pylint: disable=too-few-public-methods
+class SourceRegistry:
+    """Relates driver names to Source classes.
+
+    The format of the mapping is "driver name": ("source module", "source
+    class").
+    """
+    sources = {
+            "jenkins": ("cibyl.sources.jenkins", "Jenkins"),
+            "jenkins_job_builder": ("cibyl.sources.jenkins_job_builder",
+                                    "JenkinsJobBuilder"),
+            "zuul": ("cibyl.sources.zuul", ""),
+            "elasticsearch": ("cibyl.sources.elasticsearch", "")
+            }


### PR DESCRIPTION
This new class contains a mapping between driver names and source
classes, so the sources defined in the environment can be correctly
found and constructed.
