### PR TITLE
Ignore attributes with no function associated

### DIFF
--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -86,6 +86,11 @@ class Orchestrator:
         for arg in sorted(self.parser.ci_args.values(),
                           key=operator.attrgetter('level'), reverse=True):
             if arg.level >= start_level and arg.level >= last_level:
+                if not arg.func:
+                    # if an argument does not have a function
+                    # associated, we should not consider it here, e.g.
+                    # --sources
+                    continue
                 for env in self.environments:
                     for system in env.systems:
                         source_method = Source.get_source_method(


### PR DESCRIPTION
Ignore cli arguments with no function associated. For example, in some
configurations jobs and sources will both have a level 1. If we call
cibyl with both --jobs and --sources it will try to call some method
assciated with each, but sources does not have any method associated.
With this change we detect this and ignore --sources when running
a query.
