### PR TITLE
Implement populate method

### DIFF
--- a/cibyl/models/attribute.py
+++ b/cibyl/models/attribute.py
@@ -54,3 +54,38 @@ class AttributeListValue(AttributeValue):
         :return:
         """
         return self.value[index]
+
+
+class AttributeDictValue(AttributeValue):
+    """Represents a dict of AttributeValue objects"""
+
+    def __init__(self, name, arguments=None, attr_type=None, value=None):
+
+        super().__init__(
+            name=name, arguments=arguments, attr_type=attr_type, value=value)
+
+        if isinstance(value, dict):
+            self.value = value
+        if value is None:
+            self.value = {}
+
+    def __setitem__(self, key, item):
+        self.value[key] = item
+
+    def __getitem__(self, key):
+        return self.value[key]
+
+    def __len__(self):
+        return len(self.value)
+
+    def items(self):
+        """Return the value as key:value items"""
+        return self.value.items()
+
+    def values(self):
+        """Return dictionary values"""
+        return self.value.values()
+
+    def keys(self):
+        """Return dictionary values"""
+        return self.value.keys()

--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -21,29 +21,29 @@ from cibyl.models.model import Model
 class Build(Model):
     """General model for a job build """
     API = {
-        'build_id': {
+        'number': {
             'attr_type': str,
-            'arguments': [Argument(name='--build-id', arg_type=str,
+            'arguments': [Argument(name='--build-number', arg_type=str,
                                    description="Build ID")]
         },
-        'status': {
+        'result': {
             'attr_type': str,
-            'arguments': [Argument(name='--build-status', arg_type=str,
-                                   description="Build status")]
+            'arguments': [Argument(name='--build-result', arg_type=str,
+                                   description="Build result")]
         },
     }
 
-    def __init__(self, build_id: str, status: str = None):
-        super().__init__({'build_id': build_id, 'status': status})
+    def __init__(self, number: str, result: str = None):
+        super().__init__({'number': number, 'result': result})
 
     def __str__(self, indent=0):
         indent_space = indent*' '
-        build_str = f"{indent_space}Build: {self.build_id.value}"
-        if self.status.value:
-            build_str += f"\n{indent_space}  Status: {self.status.value}"
+        build_str = f"{indent_space}Build: {self.number.value}"
+        if self.result.value:
+            build_str += f"\n{indent_space}  result: {self.result.value}"
         return build_str
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        return self.build_id.value == other.build_id.value
+        return self.number.value == other.number.value

--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -36,10 +36,11 @@ class Build(Model):
     def __init__(self, build_id: str, status: str = None):
         super().__init__({'build_id': build_id, 'status': status})
 
-    def __str__(self):
-        build_str = f"Build: {self.build_id.value}"
+    def __str__(self, indent=0):
+        indent_space = indent*' '
+        build_str = f"{indent_space}Build: {self.build_id.value}"
         if self.status.value:
-            build_str += f"\n  Status: {self.status.value}"
+            build_str += f"\n{indent_space}  Status: {self.status.value}"
         return build_str
 
     def __eq__(self, other):

--- a/cibyl/models/ci/environment.py
+++ b/cibyl/models/ci/environment.py
@@ -48,7 +48,7 @@ class Environment(Model):
 
     def __str__(self, indent=0):
         string = ""
-        string += f"Environment: {self.name.value}\n"
+        string += f"Environment: {self.name.value}"
         for system in self.systems:
-            string += system.__str__(indent + 2)
+            string += f"\n{system.__str__(indent + 2)}"
         return string

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -58,8 +58,7 @@ class Job(Model):
             job_str += f"\n{indent_space}  URL: {self.url.value}"
         if self.builds.value:
             for build in self.builds:
-                job_str += f"\n{indent_space}  build {build.build_id.value}"
-                job_str += f" status {build.status.value}"
+                job_str += f"\n{build.__str__(indent=indent+2)}"
         return job_str
 
     def __eq__(self, other):

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -52,9 +52,14 @@ class Job(Model):
                           'builds': builds})
 
     def __str__(self, indent=0):
-        job_str = indent*' ' + f"Job: {self.name.value}"
+        indent_space = indent*' '
+        job_str = f"{indent_space}Job: {self.name.value}"
         if self.url.value:
-            job_str += f"\n  URL: {self.url.value}"
+            job_str += f"\n{indent_space}  URL: {self.url.value}"
+        if self.builds.value:
+            for build in self.builds:
+                job_str += f"\n{indent_space}  build {build.build_id.value}"
+                job_str += f" status {build.status.value}"
         return job_str
 
     def __eq__(self, other):

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -42,7 +42,7 @@ class Job(Model):
             'attr_type': Build,
             'attribute_value_class': AttributeListValue,
             'arguments': [Argument(name='--builds', arg_type=str,
-                                   nargs="*",
+                                   nargs="*", func='get_builds',
                                    description="Job builds")]
         }
     }

--- a/cibyl/models/ci/pipeline.py
+++ b/cibyl/models/ci/pipeline.py
@@ -41,11 +41,13 @@ class Pipeline(Model):
     def __init__(self, name: str, jobs: list[Job] = None):
         super().__init__(attributes={'name': name,
                                      'jobs': jobs})
-        self.name.value = name
-        self.jobs.value = jobs
 
-    def __str__(self):
-        return f"Pipeline {self.name.value}"
+    def __str__(self, indent=0):
+        indent_space = indent*' '
+        string = f"{indent_space}Pipeline: {self.name.value}"
+        for job in self.jobs:
+            string += f"\n{job.__str__(indent=indent+2)}"
+        return string
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -71,6 +71,8 @@ class System(Model):
 (type: {self.system_type.value})"
         for job_instance in self.jobs.values():
             string += f"\n{job_instance.__str__(indent=indent+2)}"
+        if len(self.jobs):
+            string += "\n" + indent*' ' + f"Total jobs: {len(self.jobs)}"
         return string
 
     def add_jobs(self, jobs: dict):

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -68,9 +68,9 @@ class System(Model):
 
     def __str__(self, indent=0):
         string = indent*' ' + f"System: {self.name.value} \
-(type: {self.system_type.value})\n"
+(type: {self.system_type.value})"
         for job in self.jobs:
-            string += job.__str__()
+            string += f"\n{job.__str__(indent=indent+2)}"
         return string
 
     def add_job(self, job: Job):

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -15,7 +15,7 @@
 """
 # pylint: disable=no-member
 from cibyl.cli.argument import Argument
-from cibyl.models.attribute import AttributeListValue
+from cibyl.models.attribute import AttributeDictValue, AttributeListValue
 from cibyl.models.ci.job import Job
 from cibyl.models.ci.pipeline import Pipeline
 from cibyl.models.model import Model
@@ -40,9 +40,9 @@ class System(Model):
         },
         'jobs': {
             'attr_type': Job,
-            'attribute_value_class': AttributeListValue,
+            'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--jobs', arg_type=str,
-                                   default=['*'], nargs='*',
+                                   nargs='*',
                                    description="System jobs",
                                    func='get_jobs')]
         },
@@ -69,17 +69,18 @@ class System(Model):
     def __str__(self, indent=0):
         string = indent*' ' + f"System: {self.name.value} \
 (type: {self.system_type.value})"
-        for job in self.jobs:
-            string += f"\n{job.__str__(indent=indent+2)}"
+        for job_instance in self.jobs.values():
+            string += f"\n{job_instance.__str__(indent=indent+2)}"
         return string
 
-    def add_job(self, job: Job):
+    def add_jobs(self, jobs: dict):
         """Add a job to the CI system
 
         :param job: Job to add to the system
         :type job: Job
         """
-        self.jobs.append(job)
+        for job_name, job_instnace in jobs.items():
+            self.jobs[job_name] = job_instnace
 
     def add_source(self, source: Source):
         """Add a source to the CI system

--- a/tests/models/test_build.py
+++ b/tests/models/test_build.py
@@ -23,68 +23,68 @@ class TestBuild(unittest.TestCase):
     """Testing Build CI model"""
 
     def setUp(self):
-        self.build_id = 'test-build'
-        self.build_status = 'FAILURE'
-        self.build = Build(build_id=self.build_id)
-        self.second_build = Build(build_id=self.build_id)
+        self.build_number = 'test-build'
+        self.build_result = 'FAILURE'
+        self.build = Build(number=self.build_number)
+        self.second_build = Build(number=self.build_number)
 
-    def test_build_id(self):
+    def test_build_number(self):
         """Testing new Build id attribute"""
         self.assertTrue(
-            hasattr(self.build, 'build_id'),
-            msg="Build lacks build_id attribute")
+            hasattr(self.build, 'number'),
+            msg="Build lacks number attribute")
 
         self.assertEqual(
-            self.build.build_id.value, self.build_id,
-            msg=f"Build id is {self.build.build_id.value}. \
-Should be {self.build_id}")
+            self.build.number.value, self.build_number,
+            msg=f"Build id is {self.build.number.value}. \
+Should be {self.build_number}")
 
-    def test_build_status(self):
-        """Testing new Build status attribute"""
+    def test_build_result(self):
+        """Testing new Build result attribute"""
         self.assertTrue(
-            hasattr(self.build, 'status'), msg="Build lacks status attribute")
+            hasattr(self.build, 'result'), msg="Build lacks result attribute")
 
         self.assertEqual(
-            self.build.status.value, None,
-            msg=f"Build default status is {self.build.status.value}. \
+            self.build.result.value, None,
+            msg=f"Build default result is {self.build.result.value}. \
 Should be None")
 
         self.assertEqual(
-            self.second_build.status.value, None,
-            msg=f"Build default status is {self.second_build.status.value}.\
+            self.second_build.result.value, None,
+            msg=f"Build default result is {self.second_build.result.value}.\
  Should be None")
 
-        self.build.status.value = self.build_status
+        self.build.result.value = self.build_result
 
         self.assertEqual(
-            self.build.status.value, self.build_status,
-            msg="New build status is {self.build.status.value}. \
-Should be {self.build_status}")
+            self.build.result.value, self.build_result,
+            msg="New build result is {self.build.result.value}. \
+Should be {self.build_result}")
 
     def test_builds_comparison(self):
         """Testing new Build instances comparison."""
         self.assertEqual(
             self.build, self.second_build,
-            msg=f"Builds {self.build.build_id.value} and \
-{self.second_build.build_id.value} are not equal")
+            msg=f"Builds {self.build.number.value} and \
+{self.second_build.number.value} are not equal")
 
     def test_builds_comparison_other_types(self):
         """Testing new Build instances comparison."""
         self.assertNotEqual(
             self.build, "test",
-            msg=f"Build {self.build.build_id.value} should be different from \
+            msg=f"Build {self.build.number.value} should be different from \
 str")
 
     def test_build_str(self):
         """Testing Build __str__ method"""
-        self.assertEqual(str(self.build), f'Build: {self.build_id}')
+        self.assertEqual(str(self.build), f'Build: {self.build_number}')
 
         self.assertEqual(
             str(self.second_build),
-            f'Build: {self.build_id}')
+            f'Build: {self.build_number}')
 
-        self.second_build.status.value = self.build_status
+        self.second_build.result.value = self.build_result
 
         self.assertEqual(
                 str(self.second_build),
-                f'Build: {self.build_id}\n  Status: {self.build_status}')
+                f'Build: {self.build_number}\n  result: {self.build_result}')

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -57,7 +57,7 @@ instead of {self.name}")
 
     def test_str_environment(self):
         """Testing environment str method"""
-        self.assertEqual(f"Environment: {self.name}\n",
+        self.assertEqual(f"Environment: {self.name}",
                          str(self.env))
 
     def test_add_systems_constructor(self):

--- a/tests/models/test_pipeline.py
+++ b/tests/models/test_pipeline.py
@@ -54,7 +54,7 @@ from str")
     def test_pipeline_str(self):
         """Testing Pipeline __str__ method"""
         self.assertEqual(str(self.pipeline),
-                         f'Pipeline {self.pipeline.name.value}')
+                         f'Pipeline: {self.pipeline.name.value}')
 
         self.assertEqual(str(self.second_pipeline),
-                         f'Pipeline {self.second_pipeline.name.value}')
+                         f'Pipeline: {self.second_pipeline.name.value}')

--- a/tests/models/test_system.py
+++ b/tests/models/test_system.py
@@ -55,12 +55,12 @@ class TestSystem(unittest.TestCase):
         msg_str = f"System type should be test_type, not {type_name}"
         self.assertEqual(type_name, "test_type", msg=msg_str)
 
-    def test_add_job(self):
+    def test_add_jobs(self):
         """Testing adding a new job to a system"""
-        job = Job("test_job")
-        self.system.add_job(job)
+        jobs = {'test_job': Job("test_job")}
+        self.system.add_jobs(jobs)
         self.assertEqual(len(self.system.jobs.value), 1)
-        self.assertEqual(job, self.system.jobs.value[0])
+        self.assertEqual(jobs['test_job'], self.system.jobs.value['test_job'])
 
 
 class TestZuulSystem(unittest.TestCase):
@@ -118,12 +118,12 @@ class TestZuulSystem(unittest.TestCase):
         self.assertEqual(len(self.system.pipelines.value), 1)
         self.assertEqual(pipeline, self.system.pipelines[0])
 
-    def test_add_job(self):
+    def test_add_jobs(self):
         """Testing adding a new job to a system"""
         job = Job("test_job")
-        self.system.add_job(job)
+        self.system.add_jobs({'jobs': {'test_job': job}})
         self.assertEqual(len(self.system.jobs.value), 1)
-        self.assertEqual(job, self.system.jobs.value[0])
+        self.assertEqual(job, self.system.jobs['test_job'])
 
     def test_add_source(self):
         """Testing adding a new source to a system"""
@@ -181,9 +181,9 @@ class TestJenkinsSystem(unittest.TestCase):
         self.assertEqual(str(self.other_system),
                          f"System: {self.name} (type: jenkins)")
 
-    def test_add_job(self):
+    def test_add_jobs(self):
         """Testing adding a new job to a system"""
-        job = Job("test_job")
-        self.system.add_job(job)
+        jobs = {'test_job': Job("test_job")}
+        self.system.add_jobs(jobs)
         self.assertEqual(len(self.system.jobs.value), 1)
-        self.assertEqual(job, self.system.jobs.value[0])
+        self.assertEqual(jobs['test_job'], self.system.jobs.value['test_job'])

--- a/tests/models/test_system.py
+++ b/tests/models/test_system.py
@@ -121,7 +121,7 @@ class TestZuulSystem(unittest.TestCase):
     def test_add_jobs(self):
         """Testing adding a new job to a system"""
         job = Job("test_job")
-        self.system.add_jobs({'jobs': {'test_job': job}})
+        self.system.add_jobs({'test_job': job})
         self.assertEqual(len(self.system.jobs.value), 1)
         self.assertEqual(job, self.system.jobs['test_job'])
 

--- a/tests/models/test_system.py
+++ b/tests/models/test_system.py
@@ -106,10 +106,10 @@ class TestZuulSystem(unittest.TestCase):
     def test_system_str(self):
         """Testing ZuulSystem __str__ method"""
         self.assertEqual(str(self.system),
-                         f"System: {self.name} (type: zuul)\n")
+                         f"System: {self.name} (type: zuul)")
 
         self.assertEqual(str(self.other_system),
-                         f"System: {self.name} (type: zuul)\n")
+                         f"System: {self.name} (type: zuul)")
 
     def test_add_pipeline(self):
         """Testing ZuulSystem add pipeline method"""
@@ -176,10 +176,10 @@ class TestJenkinsSystem(unittest.TestCase):
     def test_system_str(self):
         """Testing JenkinsSystem __str__ method"""
         self.assertEqual(str(self.system),
-                         f"System: {self.name} (type: jenkins)\n")
+                         f"System: {self.name} (type: jenkins)")
 
         self.assertEqual(str(self.other_system),
-                         f"System: {self.name} (type: jenkins)\n")
+                         f"System: {self.name} (type: jenkins)")
 
     def test_add_job(self):
         """Testing adding a new job to a system"""

--- a/tests/sources/test_jenkins.py
+++ b/tests/sources/test_jenkins.py
@@ -113,23 +113,18 @@ class TestJenkinsSource(TestCase):
             Tests that the internal logic from :meth:`Jenkins.get_builds` is
             correct.
         """
-        response = '{"jobs": [{"name": "ansible", "url": "url1"}]}'
-        builds = {'_class': '_empty',
-                  'allBuilds': [{'number': 1, 'result': "SUCCESS"},
-                                {'number': 2, 'result': "FAILURE"}]}
-        self.jenkins.client.run_script = Mock(side_effect=[response, builds])
+        response = '{"data": [{"job_name": "ansible",\
+                               "number": "4", "result": "SUCCESS"}]}'
+        self.jenkins.client.run_script = Mock(return_value=response)
 
-        jobs = self.jenkins.get_builds()
+        jobs = self.jenkins.get_builds()['jobs']
         self.assertEqual(len(jobs), 1)
-        job = jobs[0]
+        job = jobs['ansible']
         self.assertEqual(job.name.value, "ansible")
-        self.assertEqual(job.url.value, "url1")
         builds_found = job.builds.value
-        self.assertEqual(len(builds_found), 2)
-        self.assertEqual(builds_found[0].build_id.value, "1")
-        self.assertEqual(builds_found[0].status.value, "SUCCESS")
-        self.assertEqual(builds_found[1].build_id.value, "2")
-        self.assertEqual(builds_found[1].status.value, "FAILURE")
+        self.assertEqual(len(builds_found), 1)
+        self.assertEqual(builds_found[0].number.value, "4")
+        self.assertEqual(builds_found[0].result.value, "SUCCESS")
 
 
 class TestJenkinsOSPSource(TestCase):

--- a/tests/sources/test_jenkins.py
+++ b/tests/sources/test_jenkins.py
@@ -18,16 +18,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from cibyl.exceptions.jenkins import JenkinsError
-from cibyl.models.ci.system import System
 from cibyl.sources.jenkins import Jenkins, JenkinsOSP, safe_request
-
-
-def return_arg(query=None):
-    """
-        Helper function that returns its argument. It can't be a lambda because
-        it will get called inside a decorated function
-    """
-    return {"jobs": query}
 
 
 class TestSafeRequestJenkinsError(TestCase):
@@ -89,85 +80,68 @@ class TestJenkinsSource(TestCase):
 
         self.assertIsNone(jenkins.client._session.verify)
 
+    def test_get_jobs_all(self):
+        """
+            Tests that the internal logic from :meth:`Jenkins.get_jobs` is
+            correct.
+        """
+        self.jenkins.client.get_info = Mock(return_value={"jobs": []})
+        jobs_arg = Mock()
+        jobs_arg.value = ["*"]
+
+        jobs = self.jenkins.get_jobs(jobs=jobs_arg)
+        self.jenkins.client.get_info.assert_called_with(
+                                query=self.jenkins.jobs_query)
+        self.assertEqual(jobs, [])
+
     def test_get_jobs(self):
         """
             Tests that the internal logic from :meth:`Jenkins.get_jobs` is
-            correct. The jenkins API method that should do the query is mocked
-            to that it returns the query itself.
+            correct.
         """
-        self.jenkins.client.get_info = Mock()
-        self.jenkins.client.get_info.side_effect = return_arg
+        response = [{'_class': 'org..job.WorkflowRun', 'name': "ansible",
+                     'url': 'url1'},
+                    {'_class': 'org..job.WorkflowRun', 'name': "job2",
+                     'url': 'url2'},
+                    {'_class': 'empty'}]
+        self.jenkins.client.get_job_info_regex = Mock(return_value=response)
+        jobs_arg = Mock()
+        jobs_arg.value = ["ansible"]
 
-        jobs_builds = self.jenkins.get_jobs(True)
-        jobs = self.jenkins.get_jobs(False)
-        self.assertEqual(jobs_builds, self.jenkins.jobs_builds_query)
-        self.assertEqual(jobs, self.jenkins.jobs_query)
+        jobs = self.jenkins.get_jobs(jobs=jobs_arg)
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual(jobs[0].name.value, "ansible")
+        self.assertEqual(jobs[0].url.value, "url1")
+        self.assertEqual(jobs[1].name.value, "job2")
+        self.assertEqual(jobs[1].url.value, "url2")
 
-    def test_populate_jobs_without_builds(self):
+    def test_get_builds(self):
         """
-            Tests that the jenkins info is correctly parsed and job models are
-            populated.
+            Tests that the internal logic from :meth:`Jenkins.get_builds` is
+            correct.
         """
-        jobs = [{"_class": "job", "name": "job1", "url": "url1"},
-                {"_class": "job", "name": "job2", "url": "url2"},
-                {"_class": "job", "name": "job3", "url": "url3"}]
-        system = System("test_system", "test")
-        self.jenkins.populate_jobs(system, jobs)
-        self.assertEqual(3, len(system.jobs.value))
-        self.assertEqual("job1", system.jobs.value[0].name.value)
-        self.assertEqual("job2", system.jobs.value[1].name.value)
-        self.assertEqual("job3", system.jobs.value[2].name.value)
-        self.assertEqual("url1", system.jobs.value[0].url.value)
-        self.assertEqual("url2", system.jobs.value[1].url.value)
-        self.assertEqual("url3", system.jobs.value[2].url.value)
+        response = {'jobs': [{'_class': 'org..job.WorkflowRun',
+                              'name': "ansible", 'url': 'url1'}]}
+        builds = {'_class': '_empty',
+                  'allBuilds': [{'number': 1, 'result': "SUCCESS"},
+                                {'number': 2, 'result': "FAILURE"}]}
+        self.jenkins.client.get_info = Mock(side_effect=[response, builds])
 
-    def test_populate_jobs_with_builds(self):
-        """
-            Tests that the jenkins info is correctly parsed and job and build
-            models are correctly populated.
-        """
-        jobs = [{'_class': 'org.jenkinsci.plugins.workflow.job.WorkflowJob',
-                 'name': 'job1', 'url': 'url1',
-                 'builds': [
-                     {'_class': 'org.jenkinsci.plugins.workflow.job.',
-                      'number': 13, 'result': 'FAILURE'},
-                     {'_class': 'org.jenkinsci.plugins.workflow.job',
-                      'number': 10, 'result': 'SUCCESS'}]},
-                {'_class': 'jenkins.branch.OrganizationFolder',
-                 'name': 'ccc',
-                 'url': 'url2'},
-                {'_class': 'org.jenkinsci.plugins.workflow.job.WorkflowJob',
-                 'name': 'job3', 'url': 'url3',
-                 'builds': [
-                     {'_class': 'org.jenkinsci.plugins.workflow.job',
-                      'number': 2, 'result': 'SUCCESS'}]}
-                ]
-
-        system = System("test_system", "test")
-        self.jenkins.populate_jobs(system, jobs)
-
-        self.assertEqual(2, len(system.jobs.value))
-        job1 = system.jobs.value[0]
-        job2 = system.jobs.value[1]
-        self.assertEqual("job1", job1.name.value)
-        self.assertEqual("job3", job2.name.value)
-        self.assertEqual("url1", job1.url.value)
-        self.assertEqual("url3", job2.url.value)
-
-        self.assertEqual(2, len(job1.builds.value))
-        self.assertEqual("13", job1.builds.value[0].build_id.value)
-        self.assertEqual("FAILURE", job1.builds.value[0].status.value)
-        self.assertEqual("10", job1.builds.value[1].build_id.value)
-        self.assertEqual("SUCCESS", job1.builds.value[1].status.value)
-
-        self.assertEqual(1, len(job2.builds.value))
-        self.assertEqual("2", job2.builds.value[0].build_id.value)
-        self.assertEqual("SUCCESS", job2.builds.value[0].status.value)
+        jobs = self.jenkins.get_builds()
+        self.assertEqual(len(jobs), 1)
+        job = jobs[0]
+        self.assertEqual(job.name.value, "ansible")
+        self.assertEqual(job.url.value, "url1")
+        builds_found = job.builds.value
+        self.assertEqual(len(builds_found), 2)
+        self.assertEqual(builds_found[0].build_id.value, "1")
+        self.assertEqual(builds_found[0].status.value, "SUCCESS")
+        self.assertEqual(builds_found[1].build_id.value, "2")
+        self.assertEqual(builds_found[1].status.value, "FAILURE")
 
 
 class TestJenkinsOSPSource(TestCase):
-    """Tests for :class:`Jenkins`.
-    """
+    """Tests for :class:`Jenkins`."""
 
     # pylint: disable=protected-access
     def test_with_all_args(self):

--- a/tests/sources/test_jenkins_job_builder.py
+++ b/tests/sources/test_jenkins_job_builder.py
@@ -19,7 +19,7 @@ import shutil
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from cibyl.models.ci.system import System
+from cibyl.models.ci.job import Job
 from cibyl.sources.jenkins_job_builder import JenkinsJobBuilder
 
 
@@ -114,19 +114,6 @@ class TestJenkinsJobBuilderSource(TestCase):
         jenkins = JenkinsJobBuilder("url", dest="out_jjb_test")
         jenkins._generate_xml = Mock()
 
-        jobs = jenkins.get_jobs()
-        self.assertEqual(jobs, ["fake_job2"])
-
-    def test_populate_jobs(self, _):
-        """
-            Tests that the jenkins info is correctly parsed and job models are
-            populated.
-        """
-        jenkins = JenkinsJobBuilder("url", dest="out_jjb_test")
-        jenkins._generate_xml = Mock()
-
-        jobs = jenkins.get_jobs()
-        system = System("test_system", "test")
-        jenkins.populate_jobs(system, jobs)
-        self.assertEqual(1, len(system.jobs.value))
-        self.assertEqual("fake_job2", system.jobs.value[0].name.value)
+        jobs = jenkins.get_jobs(jobs=["*"])
+        job = Job(name="fake_job2")
+        self.assertEqual(jobs, [job])


### PR DESCRIPTION
This PR implements a simple version of populate method in the Orchestrator. It
assumes that the sources will provide a fully constructed hierarchy of models
starting from a Job. I propose to use this simpler version and relying on the
sources for several reasons:

- The sources will have all the context to generate the full model structure.
If for example we want to query all jenkins builds but do no generate Job
objects inside the source, the job information will be lost, as the Build 
model does not have it.

- Traversing down the model hierarchy is easy to do with the API and model
classes, but more difficult with model instances. But we need the instances to
call the appropiate add_\* and actually populate the environments.

I'm marking this as a draft so that we have a chance to discuss what's the best
course of action in the next project sync.
