### PR TITLE
Updated config template

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ Set up configuration in one of the following paths:
   * ~/.cibyl/cibyl.yaml
   * /etc/cibyl/cibyl.yaml
 
+A valid configuration should specify an environment, its system(s) and the
+system(s) details.
+Use the configuration below as placeholder.
+
 ```
 environments:
-  env1:
-    system1:
-      sources:
-        source1:
-          url: ...
-          type: jenkins
+    env_1:
+        jenkins_system:
+            system_type: ""
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ For query purposes, add sources in the following format:
 
 ```
 environments:
-  osp_phases:
-    osp_jenkins:
+  phases:
+    phase1:
       system_type: 'SYSTEM_TYPE'                                                                                                                                                   
       sources:
-        osp_jenkins1:
+        source1:
           driver: 'DRIVER'
           username: 'USERNAME' 
           token: 'PERSONAL_TOKEN'
-          url: 'https://SOME_JENKINS.com'
+          url: 'https://URL.com'
 ```
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Set up configuration in one of the following paths:
 
 A valid configuration should specify an environment, its system(s) and the
 system(s) details.
-Use the configuration below as placeholder.
-
+Use the configuration below as a minimal configuration file.
 ```
 environments:
     env_1:
@@ -23,6 +22,20 @@ environments:
             system_type: ""
 ```
 
+For query purposes, add sources in the following format:
+
+```
+environments:
+  osp_phases:
+    osp_jenkins:
+      system_type: 'SYSTEM_TYPE'                                                                                                                                                   
+      sources:
+        osp_jenkins1:
+          driver: 'DRIVER'
+          username: 'USERNAME' 
+          token: 'PERSONAL_TOKEN'
+          url: 'https://SOME_JENKINS.com'
+```
 ## Usage
 
 To list existing environments and their systems, run `cibyl`

--- a/README.md
+++ b/README.md
@@ -21,18 +21,17 @@ environments:
         jenkins_system:
             system_type: ""
 ```
-
 For query purposes, add sources in the following format:
 
 ```
 environments:
-  phases:
-    phase1:
-      system_type: 'SYSTEM_TYPE'                                                                                                                                                   
+  staging:
+    environment1:
+      system_type: 'SYSTEM_TYPE'
       sources:
         source1:
           driver: 'DRIVER'
-          username: 'USERNAME' 
+          username: 'USERNAME'
           token: 'PERSONAL_TOKEN'
           url: 'https://URL.com'
 ```


### PR DESCRIPTION
This is just an update to the configuration template displayed on the README.
The previous template would give an error when running `cibyl` or `cibyl --help`.
Ideally, those commands should run without going through the configuration file.