### PR TITLE
Populate systems with output from source(s)

### DIFF
--- a/cibyl/exceptions/model.py
+++ b/cibyl/exceptions/model.py
@@ -1,0 +1,25 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+
+class NonSupportedModelType(Exception):
+    """Exception for trying to populate non-supported model"""
+
+    def __init__(self, model_type):
+        self.model_type = model_type
+        self.message = f"""Not supported type for model: {self.model_type}.
+Unable to populate system with pulled data"""
+        super().__init__(self.message)

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -15,6 +15,7 @@
 """
 # pylint: disable=no-member
 from cibyl.cli.argument import Argument
+from cibyl.exceptions.model import NonSupportedModelType
 from cibyl.models.attribute import AttributeListValue
 from cibyl.models.ci.job import Job
 from cibyl.models.ci.pipeline import Pipeline
@@ -41,8 +42,7 @@ class System(Model):
         'jobs': {
             'attr_type': Job,
             'attribute_value_class': AttributeListValue,
-            'arguments': [Argument(name='--jobs', arg_type=str,
-                                   default=['*'], nargs='*',
+            'arguments': [Argument(name='--jobs', arg_type=str, nargs='*',
                                    description="System jobs",
                                    func='get_jobs')]
         },
@@ -72,6 +72,14 @@ class System(Model):
         for job in self.jobs:
             string += f"\n{job.__str__(indent=indent+2)}"
         return string
+
+    def populate(self, instances_dict):
+        """Populate instances from a given dictionary of instances."""
+        if instances_dict.attr_type == Job:
+            for job in instances_dict.values():
+                self.add_job(job)
+        else:
+            raise NonSupportedModelType(instances_dict.attr_type)
 
     def add_job(self, job: Job):
         """Add a job to the CI system

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -116,9 +116,9 @@ class Orchestrator:
                 for env in self.environments:
                     for system in env.systems:
                         source_method = self.select_source_method(system, arg)
-                        model_instances = source_method(
+                        model_instances_dict = source_method(
                             **self.parser.ci_args)
-                        self.populate(env, model_instances)
+                        system.populate(model_instances_dict)
             last_level = arg.level
 
     def extend_parser(self, attributes, group_name='Environment',

--- a/cibyl/sources/source.py
+++ b/cibyl/sources/source.py
@@ -16,6 +16,8 @@
 import importlib
 import logging
 
+import requests
+
 from cibyl.exceptions.source import (NoSupportedSourcesFound,
                                      TooManyValidSources)
 from cibyl.sources.source_registry import SourceRegistry
@@ -40,6 +42,9 @@ def safe_request_generic(request, custom_error):
         """
         try:
             return request(*args, **kwargs)
+        except requests.exceptions.SSLError as ex:
+            raise custom_error("Please set certificates in order to \
+                               connect to the system") from ex
         except Exception as ex:
             raise custom_error('Failure on request to target host.') from ex
 

--- a/tests/models/test_system.py
+++ b/tests/models/test_system.py
@@ -16,6 +16,7 @@
 # pylint: disable=no-member
 import unittest
 
+from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.job import Job
 from cibyl.models.ci.pipeline import Pipeline
 from cibyl.models.ci.system import JenkinsSystem, System, ZuulSystem
@@ -59,6 +60,15 @@ class TestSystem(unittest.TestCase):
         """Testing adding a new job to a system"""
         job = Job("test_job")
         self.system.add_job(job)
+        self.assertEqual(len(self.system.jobs.value), 1)
+        self.assertEqual(job, self.system.jobs.value[0])
+
+    def test_system_populate(self):
+        """Testing adding a new job to a system"""
+        job = Job("test_job")
+        jobs = AttributeDictValue(name='jobs', value={'test_job': job},
+                                  attr_type=Job)
+        self.system.populate(jobs)
         self.assertEqual(len(self.system.jobs.value), 1)
         self.assertEqual(job, self.system.jobs.value[0])
 


### PR DESCRIPTION
Before the change, we didn't do anything with the instances
returned from the source.

This change makes sure the system on which the query was performed,
also updates its models with the instances returned from the source
