### PR TITLE
simplify jenkins source

### DIFF
--- a/cibyl/models/attribute.py
+++ b/cibyl/models/attribute.py
@@ -54,3 +54,41 @@ class AttributeListValue(AttributeValue):
         :return:
         """
         return self.value[index]
+
+
+class AttributeDictValue(AttributeValue):
+    """Represents a dict of AttributeValue objects"""
+
+    def __init__(self, name, arguments=None, attr_type=None, value=None):
+
+        super().__init__(
+            name=name, arguments=arguments, attr_type=attr_type, value=value)
+
+        if isinstance(value, dict):
+            self.value = value
+        if value is None:
+            self.value = {}
+
+    def __setitem__(self, key, item):
+        self.value[key] = item
+
+    def __getitem__(self, key):
+        return self.value[key]
+
+    def __len__(self):
+        return len(self.value)
+
+    def __iter__(self):
+        yield from self.value
+
+    def items(self):
+        """Return the value as key:value items"""
+        return self.value.items()
+
+    def values(self):
+        """Return dictionary values"""
+        return self.value.values()
+
+    def keys(self):
+        """Return dictionary values"""
+        return self.value.keys()

--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -36,10 +36,11 @@ class Build(Model):
     def __init__(self, build_id: str, status: str = None):
         super().__init__({'build_id': build_id, 'status': status})
 
-    def __str__(self):
-        build_str = f"Build: {self.build_id.value}"
+    def __str__(self, indent=0):
+        indent_space = indent*' '
+        build_str = f"{indent_space}Build: {self.build_id.value}"
         if self.status.value:
-            build_str += f"\n  Status: {self.status.value}"
+            build_str += f"\n{indent_space}  Status: {self.status.value}"
         return build_str
 
     def __eq__(self, other):

--- a/cibyl/models/ci/environment.py
+++ b/cibyl/models/ci/environment.py
@@ -48,7 +48,7 @@ class Environment(Model):
 
     def __str__(self, indent=0):
         string = ""
-        string += f"Environment: {self.name.value}\n"
+        string += f"Environment: {self.name.value}"
         for system in self.systems:
-            string += system.__str__(indent + 2)
+            string += f"\n{system.__str__(indent + 2)}"
         return string

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -42,7 +42,7 @@ class Job(Model):
             'attr_type': Build,
             'attribute_value_class': AttributeListValue,
             'arguments': [Argument(name='--builds', arg_type=str,
-                                   nargs="*",
+                                   nargs="*", func="get_builds",
                                    description="Job builds")]
         }
     }
@@ -52,7 +52,8 @@ class Job(Model):
                           'builds': builds})
 
     def __str__(self, indent=0):
-        job_str = indent*' ' + f"Job: {self.name.value}"
+        indent_space = indent*' '
+        job_str = f"{indent_space}Job: {self.name.value}"
         if self.url.value:
             job_str += f"\n{indent_space}  URL: {self.url.value}"
         if self.builds.value:

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -54,7 +54,10 @@ class Job(Model):
     def __str__(self, indent=0):
         job_str = indent*' ' + f"Job: {self.name.value}"
         if self.url.value:
-            job_str += f"\n  URL: {self.url.value}"
+            job_str += f"\n{indent_space}  URL: {self.url.value}"
+        if self.builds.value:
+            for build in self.builds:
+                job_str += f"\n{build.__str__(indent=indent+2)}"
         return job_str
 
     def __eq__(self, other):

--- a/cibyl/models/ci/pipeline.py
+++ b/cibyl/models/ci/pipeline.py
@@ -41,11 +41,13 @@ class Pipeline(Model):
     def __init__(self, name: str, jobs: list[Job] = None):
         super().__init__(attributes={'name': name,
                                      'jobs': jobs})
-        self.name.value = name
-        self.jobs.value = jobs
 
-    def __str__(self):
-        return f"Pipeline {self.name.value}"
+    def __str__(self, indent=0):
+        indent_space = indent*' '
+        string = f"{indent_space}Pipeline: {self.name.value}"
+        for job in self.jobs:
+            string += f"\n{job.__str__(indent=indent+2)}"
+        return string
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -68,9 +68,9 @@ class System(Model):
 
     def __str__(self, indent=0):
         string = indent*' ' + f"System: {self.name.value} \
-(type: {self.system_type.value})\n"
+(type: {self.system_type.value})"
         for job in self.jobs:
-            string += job.__str__()
+            string += f"\n{job.__str__(indent=indent+2)}"
         return string
 
     def add_job(self, job: Job):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyyaml~=6.0
 requests~=2.27.1
 elasticsearch~=7.17.1
-python-jenkins
 colorlog

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -57,7 +57,7 @@ instead of {self.name}")
 
     def test_str_environment(self):
         """Testing environment str method"""
-        self.assertEqual(f"Environment: {self.name}\n",
+        self.assertEqual(f"Environment: {self.name}",
                          str(self.env))
 
     def test_add_systems_constructor(self):

--- a/tests/models/test_pipeline.py
+++ b/tests/models/test_pipeline.py
@@ -54,7 +54,7 @@ from str")
     def test_pipeline_str(self):
         """Testing Pipeline __str__ method"""
         self.assertEqual(str(self.pipeline),
-                         f'Pipeline {self.pipeline.name.value}')
+                         f'Pipeline: {self.pipeline.name.value}')
 
         self.assertEqual(str(self.second_pipeline),
-                         f'Pipeline {self.second_pipeline.name.value}')
+                         f'Pipeline: {self.second_pipeline.name.value}')

--- a/tests/models/test_system.py
+++ b/tests/models/test_system.py
@@ -106,10 +106,10 @@ class TestZuulSystem(unittest.TestCase):
     def test_system_str(self):
         """Testing ZuulSystem __str__ method"""
         self.assertEqual(str(self.system),
-                         f"System: {self.name} (type: zuul)\n")
+                         f"System: {self.name} (type: zuul)")
 
         self.assertEqual(str(self.other_system),
-                         f"System: {self.name} (type: zuul)\n")
+                         f"System: {self.name} (type: zuul)")
 
     def test_add_pipeline(self):
         """Testing ZuulSystem add pipeline method"""
@@ -176,10 +176,10 @@ class TestJenkinsSystem(unittest.TestCase):
     def test_system_str(self):
         """Testing JenkinsSystem __str__ method"""
         self.assertEqual(str(self.system),
-                         f"System: {self.name} (type: jenkins)\n")
+                         f"System: {self.name} (type: jenkins)")
 
         self.assertEqual(str(self.other_system),
-                         f"System: {self.name} (type: jenkins)\n")
+                         f"System: {self.name} (type: jenkins)")
 
     def test_add_job(self):
         """Testing adding a new job to a system"""

--- a/tests/sources/test_jenkins_job_builder.py
+++ b/tests/sources/test_jenkins_job_builder.py
@@ -19,7 +19,8 @@ import shutil
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from cibyl.models.ci.system import System
+from cibyl.models.attribute import AttributeDictValue
+from cibyl.models.ci.job import Job
 from cibyl.sources.jenkins_job_builder import JenkinsJobBuilder
 
 
@@ -114,19 +115,9 @@ class TestJenkinsJobBuilderSource(TestCase):
         jenkins = JenkinsJobBuilder("url", dest="out_jjb_test")
         jenkins._generate_xml = Mock()
 
-        jobs = jenkins.get_jobs()
-        self.assertEqual(jobs, ["fake_job2"])
+        jobs = jenkins.get_jobs(jobs=["*"])
+        job = Job(name="fake_job2")
+        result = AttributeDictValue("jobs", attr_type=Job,
+                                    value={"fake_job2": job})
 
-    def test_populate_jobs(self, _):
-        """
-            Tests that the jenkins info is correctly parsed and job models are
-            populated.
-        """
-        jenkins = JenkinsJobBuilder("url", dest="out_jjb_test")
-        jenkins._generate_xml = Mock()
-
-        jobs = jenkins.get_jobs()
-        system = System("test_system", "test")
-        jenkins.populate_jobs(system, jobs)
-        self.assertEqual(1, len(system.jobs.value))
-        self.assertEqual("fake_job2", system.jobs.value[0].name.value)
+        self.assertEqual(jobs, result)


### PR DESCRIPTION
Simplify jenkins source to use requests and make custom API calls, which is
faster. It also introduces AttributeDictValue and uses it to return Job objects
from the get_jobs and get_builds methods.
