### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name='Cibyl',
@@ -21,9 +21,9 @@ setup(
     license='Apache',
     description='Cibyl is tool that models ci system by'
     'command-line interface for querying CI environments',
-    version='0.0.1',
+    version='0.0.2',
     url='https://github.com/rhos-infra/cibyl',
-    packages=['cibyl'],
+    packages=find_packages(),
     entry_points={
         'console_scripts': ['cibyl = cibyl.cli.main:main',
                             'ci = cibyl.cli.main:main']


### PR DESCRIPTION
packages=['cibyl'] only takes top level directory.

Modified it to use find_packages to include all the nested levels
as well.
