### PR TITLE
Fix Python 3.6 tests

### DIFF
--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -21,6 +21,7 @@ from cibyl.cli.argument import Argument
 LOG = logging.getLogger(__name__)
 
 
+# pylint: disable=too-few-public-methods
 class CustomAction(argparse.Action):
     """Custom argparse.Action that allows in addition, to specify
     whether an argument data is populated, the function associated

--- a/cibyl/models/openstack/deployment.py
+++ b/cibyl/models/openstack/deployment.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from typing import List
 
 from cibyl.cli.argument import Argument
 from cibyl.models.attribute import AttributeListValue
@@ -55,7 +56,7 @@ class Deployment(Model):
     }
 
     def __init__(self, release: float, infra_type: str,
-                 nodes: list[Node], services: list[Service]):
+                 nodes: List[Node], services: List[Service]):
         super().__init__({'release': release, 'infra_type': infra_type,
                           'nodes': nodes, 'services': services})
 


### PR DESCRIPTION
Disable unsubscriptable-object and too-few-public-methods test errors.
