### PR TITLE
Introduce verbosity

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -75,7 +75,9 @@ def main():
     # from the CI models
     orchestrator.parser.parse()
     orchestrator.run_query()
-    orchestrator.publisher.publish(orchestrator.environments)
+    orchestrator.publisher.publish(
+        orchestrator.environments,
+        verbosity=orchestrator.parser.app_args.get('verbosity'))
 
 
 if __name__ == "__main__":

--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -80,6 +80,10 @@ class Parser:
             help='Where to write the output, default is both')
         self.argument_parser.add_argument(
             '--plugin', '-p', dest="plugin", default="openstack")
+        self.argument_parser.add_argument(
+            '-v', '--verbose', dest="verbosity", default=0, action="count",
+            help="Causes Cibyl to print more debug messages. "
+                 "Adding multiple -v will increase the verbosity.")
 
     def parse(self, arguments=None):
         """Parse application and CI models arguments.
@@ -97,8 +101,8 @@ class Parser:
         self.ci_args = {arg_name: arg_value for arg_name, arg_value in vars(
             known_arguments).items() if isinstance(arg_value, Argument)}
         self.app_args = {arg_name: arg_value for arg_name, arg_value in vars(
-            known_arguments).items() if arg_value and not isinstance(
-                arg_value, Argument)}
+            known_arguments).items() if arg_value is not None and not
+            isinstance(arg_value, Argument)}
 
     def get_group(self, group_name: str):
         """Returns the argument parser group based on a given group_name

--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -36,7 +36,7 @@ class Build(Model):
     def __init__(self, build_id: str, status: str = None):
         super().__init__({'build_id': build_id, 'status': status})
 
-    def __str__(self, indent=0):
+    def __str__(self, indent=0, verbosity=0):
         indent_space = indent*' '
         build_str = f"{indent_space}Build: {self.build_id.value}"
         if self.status.value:

--- a/cibyl/models/ci/environment.py
+++ b/cibyl/models/ci/environment.py
@@ -46,9 +46,9 @@ class Environment(Model):
         self.systems.append(System(name=name, system_type=system_type,
                                    jobs_scope=jobs_scope, sources=sources))
 
-    def __str__(self, indent=0):
+    def __str__(self, indent=0, verbosity=0):
         string = ""
         string += f"Environment: {self.name.value}"
         for system in self.systems:
-            string += f"\n{system.__str__(indent + 2)}"
+            string += f"\n{system.__str__(indent + 2, verbosity)}"
         return string

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -54,14 +54,14 @@ class Job(Model):
         super().__init__({'name': name, 'url': url,
                           'builds': builds})
 
-    def __str__(self, indent=0):
+    def __str__(self, indent=0, verbosity=0):
         indent_space = indent*' '
         job_str = f"{indent_space}Job: {self.name.value}"
-        if self.url.value:
+        if verbosity > 0 and self.url.value:
             job_str += f"\n{indent_space}  URL: {self.url.value}"
         if self.builds.value:
             for build in self.builds:
-                job_str += f"\n{build.__str__(indent=indent+2)}"
+                job_str += f"\n{build.__str__(indent+2, verbosity)}"
         return job_str
 
     def __eq__(self, other):

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -68,11 +68,12 @@ class System(Model):
                           'jobs': jobs, 'jobs_scope': jobs_scope,
                           'sources': sources})
 
-    def __str__(self, indent=0):
-        string = indent*' ' + f"System: {self.name.value} \
-(type: {self.system_type.value})"
+    def __str__(self, indent=0, verbosity=0):
+        string = indent*' ' + f"System: {self.name.value}"
+        if verbosity > 0:
+            string += f" (type: {self.system_type.value})"
         for job in self.jobs:
-            string += f"\n{job.__str__(indent=indent+2)}"
+            string += f"\n{job.__str__(indent+2, verbosity)}"
         return string
 
     def populate(self, instances_dict):

--- a/cibyl/publisher.py
+++ b/cibyl/publisher.py
@@ -25,10 +25,10 @@ class Publisher:
     """
 
     @staticmethod
-    def publish(environments, dest="terminal"):
+    def publish(environments, dest="terminal", verbosity=0):
         """Publishes the data of the given environments to the
         chosen destination.
         """
         if dest == "terminal":
             for env in environments:
-                print(env)
+                print(env.__str__(verbosity=verbosity))

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -61,12 +61,16 @@ class TestParser(TestCase):
     def test_parser_parse_args(self):
         """Testing parser extend method"""
         self.parser.parse()
-        self.assertEqual(self.parser.app_args, {'plugin': 'openstack'})
+        self.assertEqual(self.parser.app_args, {'debug': False,
+                                                'plugin': 'openstack',
+                                                'verbosity': 0})
         self.assertEqual(self.parser.ci_args, {})
 
         self.parser.extend(self.environment.arguments, 'Environment')
         self.parser.parse(['--env-name', 'env1', '--plugin', 'openshift'])
-        self.assertEqual(self.parser.app_args, {'plugin': 'openshift'})
+        self.assertEqual(self.parser.app_args, {'plugin': 'openshift',
+                                                'verbosity': 0,
+                                                'debug': False})
         self.assertEqual(self.parser.ci_args,
                          {'env_name': Argument(
                              name='env_name', arg_type=str,

--- a/tests/models/test_job.py
+++ b/tests/models/test_job.py
@@ -102,9 +102,7 @@ Should be {self.job_url}")
 
         self.second_job.url.value = self.job_url
 
-        self.assertEqual(str(self.second_job),
-                         f'Job: {self.job_name}\n  \
-URL: {self.job_url}')
+        self.assertEqual(str(self.second_job), f'Job: {self.job_name}')
 
     def test_jobs_add_build(self):
         """Testing Job add_build method."""

--- a/tests/models/test_system.py
+++ b/tests/models/test_system.py
@@ -116,10 +116,10 @@ class TestZuulSystem(unittest.TestCase):
     def test_system_str(self):
         """Testing ZuulSystem __str__ method"""
         self.assertEqual(str(self.system),
-                         f"System: {self.name} (type: zuul)")
+                         f"System: {self.name}")
 
         self.assertEqual(str(self.other_system),
-                         f"System: {self.name} (type: zuul)")
+                         f"System: {self.name}")
 
     def test_add_pipeline(self):
         """Testing ZuulSystem add pipeline method"""
@@ -202,10 +202,10 @@ class TestJenkinsSystem(unittest.TestCase):
     def test_system_str(self):
         """Testing JenkinsSystem __str__ method"""
         self.assertEqual(str(self.system),
-                         f"System: {self.name} (type: jenkins)")
+                         f"System: {self.name}")
 
         self.assertEqual(str(self.other_system),
-                         f"System: {self.name} (type: jenkins)")
+                         f"System: {self.name}")
 
     def test_add_job(self):
         """Testing adding a new job to a system"""

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -33,4 +33,4 @@ class TestOrchestrator(TestCase):
         """Testing Publisher publish method"""
         self.publisher.publish(environments=[self.environment],
                                dest="terminal")
-        mock_print.assert_called_with(self.environment)
+        mock_print.assert_called_with(self.environment.__str__())


### PR DESCRIPTION
Allow the user to control the level of details he can
get while running the application.

'cibyl --jobs' for example, prints only jobs names, while
'cibyl --jobs -v' will also print the URL for each job.
