### PR TITLE
Revisiting conditions for linting error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Jetbrains IDEA
 .idea/
+
+# Pylint
+pylint.report.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,13 @@ repos:
         language: system
         types: [python]
         require_serial: true
+        args: [
+          "-j 4",
+          "--reports=n", # Simple report -> Just the problems
+          "--fail-under=9",
+          "--output=pylint.report.txt", # Does not get printed on console anymore
+          "--output-format=text"
+        ]
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.24.2
     hooks:

--- a/.pylintrc
+++ b/.pylintrc
@@ -2,3 +2,6 @@
 
 # Increasing the inheritance depth so that standard classes can be extended (See R0901)
 max-parents=15
+
+# A class can have a single function if it needs to, but avoid classes that do nothing (See R0903)
+min-public-methods=1

--- a/cibyl/cli/validator.py
+++ b/cibyl/cli/validator.py
@@ -21,7 +21,6 @@ from cibyl.exceptions.model import NoValidEnvironment, NoValidSystem
 LOG = logging.getLogger(__name__)
 
 
-# pylint: disable=too-few-public-methods
 class Validator:
     """This is a helper class that will filter the configuration according to
     the user input.

--- a/cibyl/publisher.py
+++ b/cibyl/publisher.py
@@ -18,7 +18,6 @@ import logging
 LOG = logging.getLogger(__name__)
 
 
-# pylint: disable=too-few-public-methods
 class Publisher:
     """Represents a publisher which is responsible for publishing the data
     collected by the application in the chosen format and to the chosen

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -21,7 +21,7 @@ from cibyl.exceptions.elasticsearch import ElasticSearchError
 LOG = logging.getLogger(__name__)
 
 
-class ElasticSearchOSP:  # pylint: disable=too-few-public-methods
+class ElasticSearchOSP:
     """Used to perform queries in elasticsearch"""
 
     ALLOWED_QUERIES = [

--- a/cibyl/sources/elasticsearch/client.py
+++ b/cibyl/sources/elasticsearch/client.py
@@ -23,7 +23,7 @@ from cibyl.exceptions.elasticsearch import ElasticSearchError
 LOG = logging.getLogger(__name__)
 
 
-class ElasticSearchClient:  # pylint: disable=too-few-public-methods
+class ElasticSearchClient:
     """Elasticsearch client to connect to the instance
     and retrieve the data from this one"""
 


### PR DESCRIPTION
I have changed pylint's behavior so that it is more relaxed and does not get so much in our way, here are the changes:
- Will only fail when we have accumulated enough conditions to be below a 9 rating.
- Minimum number of methods per class is 1. The warning will just indicate when a class has no purpose. This still affects data classes, but it is a matter for another time.
- Warnings do no longer get printed on console, instead, they are exported to a file called 'pylint.report.txt'. This is because pylint will only print on console when an error occurred.
- Made pylint use 4 threads, should speed things up a bit.