### PR TITLE
Use AttributeDictValue for populated models

### DIFF
--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -47,3 +47,13 @@ class Build(Model):
         if not isinstance(other, self.__class__):
             return False
         return self.build_id.value == other.build_id.value
+
+    def merge(self, other):
+        """Merge the information of two build objects representing the same
+        build.
+
+        :param other: The Build object to merge
+        :type other: :class:`.Build`
+        """
+        if not self.status.value:
+            self.status.value = other.status.value

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -14,10 +14,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from typing import List
+from typing import Dict
 
 from cibyl.cli.argument import Argument
-from cibyl.models.attribute import AttributeListValue
+from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.build import Build
 from cibyl.models.model import Model
 
@@ -42,14 +42,15 @@ class Job(Model):
         },
         'builds': {
             'attr_type': Build,
-            'attribute_value_class': AttributeListValue,
+            'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--builds', arg_type=str,
                                    nargs="*", func="get_builds",
                                    description="Job builds")]
         }
     }
 
-    def __init__(self, name: str, url: str = None, builds: List[Build] = None):
+    def __init__(self, name: str, url: str = None,
+                 builds: Dict[str, Build] = None):
         super().__init__({'name': name, 'url': url,
                           'builds': builds})
 
@@ -74,4 +75,20 @@ class Job(Model):
         :param build: Build to add to the job
         :type build: Build
         """
-        self.builds.append(build)
+        build_id = build.build_id.value
+        if build_id in self.builds:
+            self.builds[build_id].merge(build)
+        else:
+            self.builds[build_id] = build
+
+    def merge(self, other):
+        """Merge the information of two job objects representing the same
+        job.
+
+        :param other: The Job object to merge
+        :type other: :class:`.Job`
+        """
+        if not self.url.value:
+            self.url.value = other.url.value
+        for build in other.builds.values():
+            self.add_build(build)

--- a/cibyl/models/ci/pipeline.py
+++ b/cibyl/models/ci/pipeline.py
@@ -14,10 +14,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from typing import List
+from typing import Dict
 
 from cibyl.cli.argument import Argument
-from cibyl.models.attribute import AttributeListValue
+from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.job import Job
 from cibyl.models.model import Model
 
@@ -33,14 +33,14 @@ class Pipeline(Model):
         },
         'jobs': {
             'attr_type': Job,
-            'attribute_value_class': AttributeListValue,
+            'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--jobs', arg_type=str,
                                    nargs='*',
                                    description="Pipeline jobs")]
         }
     }
 
-    def __init__(self, name: str, jobs: List[Job] = None):
+    def __init__(self, name: str, jobs: Dict[str, Job] = None):
         super().__init__(attributes={'name': name,
                                      'jobs': jobs})
 
@@ -55,3 +55,24 @@ class Pipeline(Model):
         if not isinstance(other, self.__class__):
             return False
         return self.name.value == other.name.value
+
+    def add_job(self, job: Job):
+        """Add a job to the CI pipeline
+
+        :param job: Job to add to the pipeline
+        :type job: Job
+        """
+        name = job.name.value
+        if name in self.jobs:
+            self.jobs[name].merge(job)
+        else:
+            self.jobs[name] = job
+
+    def merge(self, other):
+        """Merge the information of two pipelines.
+
+        :param other: The Pipeline object to merge
+        :type other: :class:`.Pipeline`
+        """
+        for job in other.jobs.values():
+            self.add_job(job)

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -14,11 +14,11 @@
 #    under the License.
 """
 # pylint: disable=no-member
-from typing import List
+from typing import Dict, List
 
 from cibyl.cli.argument import Argument
 from cibyl.exceptions.model import NonSupportedModelType
-from cibyl.models.attribute import AttributeListValue
+from cibyl.models.attribute import AttributeDictValue, AttributeListValue
 from cibyl.models.ci.job import Job
 from cibyl.models.ci.pipeline import Pipeline
 from cibyl.models.model import Model
@@ -43,7 +43,7 @@ class System(Model):
         },
         'jobs': {
             'attr_type': Job,
-            'attribute_value_class': AttributeListValue,
+            'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--jobs', arg_type=str, nargs='*',
                                    description="System jobs",
                                    func='get_jobs')]
@@ -62,7 +62,7 @@ class System(Model):
     }
 
     def __init__(self, name: str,  # pylint: disable=too-many-arguments
-                 system_type: str, jobs: List[Job] = None,
+                 system_type: str, jobs: Dict[str, Job] = None,
                  jobs_scope: str = "*", sources: List = None):
         super().__init__({'name': name, 'system_type': system_type,
                           'jobs': jobs, 'jobs_scope': jobs_scope,
@@ -89,7 +89,11 @@ class System(Model):
         :param job: Job to add to the system
         :type job: Job
         """
-        self.jobs.append(job)
+        job_name = job.name.value
+        if job_name in self.jobs.values():
+            self.jobs[job_name].merge(job)
+        else:
+            self.jobs[job_name] = job
 
     def add_source(self, source: Source):
         """Add a source to the CI system
@@ -111,7 +115,7 @@ class ZuulSystem(System):
         super().__init__(name, "zuul")
         pipeline_argument = Argument(name='--pipelines', arg_type=str,
                                      description="System pipelines")
-        self.pipelines = AttributeListValue(name="pipelines",
+        self.pipelines = AttributeDictValue(name="pipelines",
                                             attr_type=Pipeline,
                                             arguments=[pipeline_argument])
 
@@ -121,7 +125,11 @@ class ZuulSystem(System):
         :param pipeline: Pipeline to add to the system
         :type pipeline: Pipeline
         """
-        self.pipelines.append(pipeline)
+        pipeline_name = pipeline.name.value
+        if pipeline_name in self.pipelines.values():
+            self.pipelines[pipeline_name].merge(pipeline)
+        else:
+            self.pipelines[pipeline_name] = pipeline
 
 
 class JenkinsSystem(System):

--- a/tests/models/test_build.py
+++ b/tests/models/test_build.py
@@ -20,7 +20,7 @@ from cibyl.models.ci.build import Build
 
 
 class TestBuild(unittest.TestCase):
-    """Testing Build CI model"""
+    """Test Build CI model."""
 
     def setUp(self):
         self.build_id = 'test-build'
@@ -29,7 +29,7 @@ class TestBuild(unittest.TestCase):
         self.second_build = Build(build_id=self.build_id)
 
     def test_build_id(self):
-        """Testing new Build id attribute"""
+        """Test new Build id attribute"""
         self.assertTrue(
             hasattr(self.build, 'build_id'),
             msg="Build lacks build_id attribute")
@@ -40,7 +40,7 @@ class TestBuild(unittest.TestCase):
 Should be {self.build_id}")
 
     def test_build_status(self):
-        """Testing new Build status attribute"""
+        """Test new Build status attribute."""
         self.assertTrue(
             hasattr(self.build, 'status'), msg="Build lacks status attribute")
 
@@ -62,21 +62,21 @@ Should be None")
 Should be {self.build_status}")
 
     def test_builds_comparison(self):
-        """Testing new Build instances comparison."""
+        """Test new Build instances comparison."""
         self.assertEqual(
             self.build, self.second_build,
             msg=f"Builds {self.build.build_id.value} and \
 {self.second_build.build_id.value} are not equal")
 
     def test_builds_comparison_other_types(self):
-        """Testing new Build instances comparison."""
+        """Test new Build instances comparison."""
         self.assertNotEqual(
             self.build, "test",
             msg=f"Build {self.build.build_id.value} should be different from \
 str")
 
     def test_build_str(self):
-        """Testing Build __str__ method"""
+        """Test Build __str__ method."""
         self.assertEqual(str(self.build), f'Build: {self.build_id}')
 
         self.assertEqual(
@@ -88,3 +88,9 @@ str")
         self.assertEqual(
                 str(self.second_build),
                 f'Build: {self.build_id}\n  Status: {self.build_status}')
+
+    def test_build_merge(self):
+        """Test Build merge method."""
+        self.build.status.value = "SUCCESS"
+        self.second_build.merge(self.build)
+        self.assertEqual(self.second_build.status.value, "SUCCESS")

--- a/tests/models/test_job.py
+++ b/tests/models/test_job.py
@@ -47,12 +47,12 @@ Should be {self.job_name}")
             hasattr(self.job, 'builds'), msg="Job lacks builds attribute")
 
         self.assertEqual(
-            self.job.builds.value, [],
+            self.job.builds.value, {},
             msg=f"Job default builds is {self.job.builds.value}. \
 Should be []")
 
         self.assertEqual(
-            self.second_job.builds.value, [],
+            self.second_job.builds.value, {},
             msg="Job default builds are {self.second_job.builds.value}.\
  Should be []")
 
@@ -111,4 +111,20 @@ URL: {self.job_url}')
         build2 = Build("2", "SUCCESS")
         self.job.add_build(build2)
         self.assertEqual(1, len(self.job.builds.value))
-        self.assertEqual(build2, self.job.builds.value[0])
+        self.assertEqual(build2, self.job.builds.value["2"])
+
+    def test_jobs_add_build_with_merge(self):
+        """Testing Job add_build method."""
+        build2 = Build("2")
+        build3 = Build("2", "SUCCESS")
+        self.job.add_build(build2)
+        self.job.add_build(build3)
+        self.assertEqual(1, len(self.job.builds.value))
+        build = self.job.builds.value["2"]
+        self.assertEqual(build.status.value, build3.status.value)
+
+    def test_jobs_merge(self):
+        """Testing Job merge method."""
+        self.second_job.url.value = self.job_url
+        self.job.merge(self.second_job)
+        self.assertEqual(self.job.url.value, self.job_url)

--- a/tests/models/test_pipeline.py
+++ b/tests/models/test_pipeline.py
@@ -15,12 +15,13 @@
 """
 import unittest
 
+from cibyl.models.ci.job import Job
 from cibyl.models.ci.pipeline import Pipeline
 
 
 # pylint: disable=no-member
 class TestPipeline(unittest.TestCase):
-    """Testing Pipeline CI model"""
+    """Test Pipeline CI model."""
 
     def setUp(self):
         self.pipeline_name = 'test-pipeline'
@@ -28,7 +29,7 @@ class TestPipeline(unittest.TestCase):
         self.second_pipeline = Pipeline(name=self.pipeline_name)
 
     def test_pipeline_name(self):
-        """Testing new Pipeline name attribute"""
+        """Test new Pipeline name attribute."""
         self.assertTrue(
             hasattr(self.pipeline, 'name'), msg="Pipeline lacks name")
 
@@ -38,23 +39,40 @@ class TestPipeline(unittest.TestCase):
 Should be {self.pipeline_name}")
 
     def test_pipelines_comparison(self):
-        """Testing new Pipeline instances comparison."""
+        """Test new Pipeline instances comparison."""
         self.assertEqual(
             self.pipeline, self.second_pipeline,
             msg=f"Pipelines {self.pipeline.name.value} and \
 {self.second_pipeline.name.value} are not equal")
 
     def test_pipelines_comparison_other_types(self):
-        """Testing new Pipeline instances comparison."""
+        """Test new Pipeline instances comparison."""
         self.assertNotEqual(
             self.pipeline, "test",
             msg=f"Pipeline {self.pipeline.name.value} should be different \
 from str")
 
     def test_pipeline_str(self):
-        """Testing Pipeline __str__ method"""
+        """Test Pipeline __str__ method."""
         self.assertEqual(str(self.pipeline),
                          f'Pipeline: {self.pipeline.name.value}')
 
         self.assertEqual(str(self.second_pipeline),
                          f'Pipeline: {self.second_pipeline.name.value}')
+
+    def test_pipeline_add_job(self):
+        """Test Pipeline add_jobs method."""
+        job1 = Job("name")
+        self.pipeline.add_job(job1)
+        job2 = Job("name")
+        self.pipeline.add_job(job2)
+        self.assertEqual(len(self.pipeline.jobs), 1)
+
+    def test_pipeline_merge(self):
+        """Test Pipeline merge method."""
+        job1 = Job("name")
+        self.pipeline.add_job(job1)
+        job2 = Job("name")
+        self.second_pipeline.add_job(job2)
+        self.pipeline.merge(self.second_pipeline)
+        self.assertEqual(len(self.pipeline.jobs), 1)

--- a/tests/models/test_system.py
+++ b/tests/models/test_system.py
@@ -61,7 +61,7 @@ class TestSystem(unittest.TestCase):
         job = Job("test_job")
         self.system.add_job(job)
         self.assertEqual(len(self.system.jobs.value), 1)
-        self.assertEqual(job, self.system.jobs.value[0])
+        self.assertEqual(job, self.system.jobs.value["test_job"])
 
     def test_system_populate(self):
         """Testing adding a new job to a system"""
@@ -70,7 +70,7 @@ class TestSystem(unittest.TestCase):
                                   attr_type=Job)
         self.system.populate(jobs)
         self.assertEqual(len(self.system.jobs.value), 1)
-        self.assertEqual(job, self.system.jobs.value[0])
+        self.assertEqual(job, self.system.jobs.value["test_job"])
 
 
 class TestZuulSystem(unittest.TestCase):
@@ -126,14 +126,30 @@ class TestZuulSystem(unittest.TestCase):
         pipeline = Pipeline("check")
         self.system.add_pipeline(pipeline)
         self.assertEqual(len(self.system.pipelines.value), 1)
-        self.assertEqual(pipeline, self.system.pipelines[0])
+        self.assertEqual(pipeline, self.system.pipelines["check"])
+
+    def test_add_pipeline_with_merge(self):
+        """Testing ZuulSystem add pipeline method"""
+        pipeline = Pipeline("check")
+        self.system.add_pipeline(pipeline)
+        self.system.add_pipeline(pipeline)
+        self.assertEqual(len(self.system.pipelines.value), 1)
+        self.assertEqual(pipeline, self.system.pipelines["check"])
 
     def test_add_job(self):
         """Testing adding a new job to a system"""
         job = Job("test_job")
         self.system.add_job(job)
         self.assertEqual(len(self.system.jobs.value), 1)
-        self.assertEqual(job, self.system.jobs.value[0])
+        self.assertEqual(job, self.system.jobs.value["test_job"])
+
+    def test_add_job_with_merge(self):
+        """Testing adding a new job to a system"""
+        job = Job("test_job")
+        self.system.add_job(job)
+        self.system.add_job(job)
+        self.assertEqual(len(self.system.jobs.value), 1)
+        self.assertEqual(job, self.system.jobs.value["test_job"])
 
     def test_add_source(self):
         """Testing adding a new source to a system"""
@@ -196,4 +212,4 @@ class TestJenkinsSystem(unittest.TestCase):
         job = Job("test_job")
         self.system.add_job(job)
         self.assertEqual(len(self.system.jobs.value), 1)
-        self.assertEqual(job, self.system.jobs.value[0])
+        self.assertEqual(job, self.system.jobs.value["test_job"])

--- a/tests/sources/test_jenkins.py
+++ b/tests/sources/test_jenkins.py
@@ -133,7 +133,7 @@ class TestJenkinsSource(TestCase):
         self.assertEqual(job.url.value, "url1")
         builds_found = job.builds.value
         self.assertEqual(len(builds_found), 2)
-        self.assertEqual(builds_found[0].build_id.value, "1")
-        self.assertEqual(builds_found[0].status.value, "SUCCESS")
-        self.assertEqual(builds_found[1].build_id.value, "2")
-        self.assertEqual(builds_found[1].status.value, "FAILURE")
+        self.assertEqual(builds_found["1"].build_id.value, "1")
+        self.assertEqual(builds_found["1"].status.value, "SUCCESS")
+        self.assertEqual(builds_found["2"].build_id.value, "2")
+        self.assertEqual(builds_found["2"].status.value, "FAILURE")


### PR DESCRIPTION
With this change, when populating models (adding jobs, builds,
pipelines,..) they will be added to a dict instead of a list. This makes
it easier to avoid duplication and integrate information coming from
different sources.
