### PR TITLE
Fix system __str__ method

### DIFF
--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -60,7 +60,7 @@ class Job(Model):
         if verbosity > 0 and self.url.value:
             job_str += f"\n{indent_space}  URL: {self.url.value}"
         if self.builds.value:
-            for build in self.builds:
+            for build in self.builds.values():
                 job_str += f"\n{build.__str__(indent+2, verbosity)}"
         return job_str
 

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -72,7 +72,7 @@ class System(Model):
         string = indent*' ' + f"System: {self.name.value}"
         if verbosity > 0:
             string += f" (type: {self.system_type.value})"
-        for job in self.jobs:
+        for job in self.jobs.values():
             string += f"\n{job.__str__(indent+2, verbosity)}"
         return string
 

--- a/tests/models/test_system.py
+++ b/tests/models/test_system.py
@@ -80,7 +80,7 @@ class TestSystem(unittest.TestCase):
         job.add_build(build)
         self.system.add_job(job)
         output = str(self.system)
-        expected = """System: test (type: test_type)
+        expected = """System: test
   Job: test_job
     Build: 1
       Status: SUCCESS"""


### PR DESCRIPTION
when iterating over jobs, it will iterate
over the names since those are keys.

In order for __str__ to work, it should iterate over
jobs instances.

This fixes a bug which was previously fixed but due
to not properly resolving the conflicts during a rebase,
has returned.
