### PR TITLE
Moving the config file's default path to be under ~/.config

### DIFF
--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -35,7 +35,7 @@ class Config(UserDict):
     """
 
     DEFAULT_FILE_PATHS = (
-        os.path.join(os.path.expanduser('~'), '.cibyl/cibyl.yaml'),
+        os.path.join(os.path.expanduser('~'), '.config/cibyl.yaml'),
         '/etc/cibyl/cibyl.yaml'
     )
     """Collection of paths where the configuration file for the app is


### PR DESCRIPTION
When I first created the 'Config' class I made a mistake and set its default folder to be '~/.cibyl'. I always really meant it to be '~/.config' as that is the standard location. Here I am correcting the mistake.