### PR TITLE
Add support for --job-name, --job-url in jenkins

### DIFF
--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -38,6 +38,7 @@ class Job(Model):
         'url': {
             'attr_type': str,
             'arguments': [Argument(name='--job-url', arg_type=str,
+                                   func='get_jobs',
                                    description="Job URL")]
         },
         'builds': {

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -18,11 +18,12 @@ import json
 import logging
 import re
 from functools import partial
-from typing import Dict, List
+from typing import Dict, List, Pattern
 
 import requests
 import urllib3
 
+from cibyl.cli.argument import Argument
 from cibyl.exceptions.jenkins import JenkinsError
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.build import Build
@@ -36,18 +37,75 @@ safe_request = partial(safe_request_generic, custom_error=JenkinsError)
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
+def satisfy_regex_match(job: Dict[str, str], pattern: Pattern,
+                        field_to_check: str):
+    """Check whether job should be included according to the user input.
+    The job should be added if the information provided field_to_check
+    (the job name or url for example) is matches the regex pattern.
+
+    :param job: job information obtained from jenkins
+    :type job: str
+    :param pattern: regex patter that the job name should match
+    :type pattern: :class:`re.Pattern`
+    :param field_to_check: Job field to perform the check
+    :param field_to_check: str
+    :returns: Whether the job satisfies user input
+    :rtype: bool
+    """
+    return re.search(pattern, job[field_to_check]) is not None
+
+
+def satisfy_exact_match(job: Dict[str, str], user_input: Argument,
+                        field_to_check: str):
+    """Check whether job should be included according to the user input. The
+    job should be added if the information provided field_to_check
+    (the job name or url for example) is present in the user_input values.
+
+    :param job: job information obtained from jenkins
+    :type job: str
+    :param user_input: input argument specified by the user
+    :type job_urls: :class:`.Argument`
+    :param field_to_check: Job field to perform the check
+    :param field_to_check: str
+    :returns: Whether the job satisfies user input
+    :rtype: bool
+    """
+    return job[field_to_check] in user_input.value
+
+
 def filter_jobs(jobs_found: List[Dict], **kwargs):
     """Filter the result from the Jenkins API according to user input"""
+    checks_to_apply = []
+
     pattern = None
     jobs_arg = kwargs.get('jobs')
     if jobs_arg:
         pattern = re.compile("|".join(jobs_arg.value))
+        checks_to_apply.append(partial(satisfy_regex_match, pattern=pattern,
+                                       field_to_check="name"))
 
-    jobs_filtered = jobs_found
-    if pattern:
-        jobs_filtered = [job for job in jobs_found if re.search(pattern,
-                                                                job['name']
-                                                                )]
+    job_names = kwargs.get('job_name')
+    if job_names:
+        checks_to_apply.append(partial(satisfy_exact_match,
+                                       user_input=job_names,
+                                       field_to_check="name"))
+
+    job_urls = kwargs.get('job_url')
+    if job_urls:
+        checks_to_apply.append(partial(satisfy_exact_match,
+                                       user_input=job_urls,
+                                       field_to_check="url"))
+
+    jobs_filtered = []
+    for job in jobs_found:
+        is_valid_job = True
+        # we build the list of checks to apply dynamically depending on the
+        # user input, to avoid repeating the same checks for every job
+        for check in checks_to_apply:
+            is_valid_job &= check(job=job)
+        if is_valid_job:
+            jobs_filtered.append(job)
+
     return jobs_filtered
 
 

--- a/tests/sources/test_jenkins.py
+++ b/tests/sources/test_jenkins.py
@@ -104,7 +104,7 @@ class TestJenkinsSource(TestCase):
                               'name': "ansible", 'url': 'url1'},
                     {'_class': 'org..job.WorkflowRun', 'name': "job2",
                      'url': 'url2'},
-                    {'_class': 'empty', 'name': 'empty'}]}
+                    {'_class': 'empty', 'name': 'ansible-empty'}]}
         self.jenkins.send_request = Mock(return_value=response)
         jobs_arg = Mock()
         jobs_arg.value = ["ansible"]
@@ -165,7 +165,8 @@ class TestJenkinsSource(TestCase):
 
         response = {'jobs': [{'_class': 'org.job.WorkflowJob',
                               'name': 'ansible-nfv-branch', 'url': 'url',
-                              'lastBuild': None}]}
+                              'lastBuild': None},
+                             {'_class': 'folder'}]}
 
         self.jenkins.send_request = Mock(side_effect=[response])
 
@@ -212,4 +213,97 @@ class TestJenkinsSource(TestCase):
                      'name': "ans2", 'url': 'url3',
                      'lastBuild': {'number': 0, 'result': "FAILURE"}},
                     ]
+        self.assertEqual(jobs_filtered, expected)
+
+    def test_filter_job_name_job_url(self):
+        """
+            Test that filter_jobs filters the jobs given the user input.
+        """
+        response = [{'_class': 'org..job.WorkflowRun',
+                     'name': "ansible", 'url': 'url1',
+                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
+                    {'_class': 'org..job.WorkflowRun',
+                     'name': "test_jobs", 'url': 'url2',
+                     'lastBuild': {'number': 2, 'result': "FAILURE"}},
+                    {'_class': 'org..job.WorkflowRun',
+                     'name': "ans2", 'url': 'url3',
+                     'lastBuild': {'number': 0, 'result': "FAILURE"}}]
+        job_name = Mock()
+        job_name.value = ["ans2"]
+        job_url = Mock()
+        job_url.value = ["url3"]
+        jobs_filtered = filter_jobs(response, job_name=job_name,
+                                    job_url=job_url)
+        expected = [{'_class': 'org..job.WorkflowRun',
+                     'name': "ans2", 'url': 'url3',
+                     'lastBuild': {'number': 0, 'result': "FAILURE"}}]
+        self.assertEqual(jobs_filtered, expected)
+
+    def test_filter_job_name(self):
+        """
+            Test that filter_jobs filters the jobs given the user input.
+        """
+        response = [{'_class': 'org..job.WorkflowRun',
+                     'name': "ansible", 'url': 'url1',
+                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
+                    {'_class': 'org..job.WorkflowRun',
+                     'name': "test_jobs", 'url': 'url2',
+                     'lastBuild': {'number': 2, 'result': "FAILURE"}},
+                    {'_class': 'org..job.WorkflowRun',
+                     'name': "ans2", 'url': 'url3',
+                     'lastBuild': {'number': 0, 'result': "FAILURE"}}]
+        job_name = Mock()
+        job_name.value = ["ansible"]
+        jobs_filtered = filter_jobs(response, job_name=job_name)
+        expected = [{'_class': 'org..job.WorkflowRun',
+                     'name': "ansible", 'url': 'url1',
+                     'lastBuild': {'number': 1, 'result': "SUCCESS"}}]
+        self.assertEqual(jobs_filtered, expected)
+
+    def test_filter_job_url(self):
+        """
+            Test that filter_jobs filters the jobs given the user input.
+        """
+        response = [{'_class': 'org..job.WorkflowRun',
+                     'name': "ansible", 'url': 'url1',
+                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
+                    {'_class': 'org..job.WorkflowRun',
+                     'name': "test_jobs", 'url': 'url2',
+                     'lastBuild': {'number': 2, 'result': "FAILURE"}},
+                    {'_class': 'org..job.WorkflowRun',
+                     'name': "ans2", 'url': 'url3',
+                     'lastBuild': {'number': 0, 'result': "FAILURE"}}
+                    ]
+        job_url = Mock()
+        job_url.value = ["url2"]
+        jobs_filtered = filter_jobs(response, job_url=job_url)
+        expected = [{'_class': 'org..job.WorkflowRun',
+                     'name': "test_jobs", 'url': 'url2',
+                     'lastBuild': {'number': 2, 'result': "FAILURE"}}]
+        self.assertEqual(jobs_filtered, expected)
+
+    def test_filter_job_name_job_url_jobs(self):
+        """
+            Test that filter_jobs filters the jobs given the user input.
+        """
+        response = [{'_class': 'org..job.WorkflowRun',
+                     'name': "ansible", 'url': 'url1',
+                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
+                    {'_class': 'org..job.WorkflowRun',
+                     'name': "test_jobs", 'url': 'url2',
+                     'lastBuild': {'number': 2, 'result': "FAILURE"}},
+                    {'_class': 'org..job.WorkflowRun',
+                     'name': "ans2", 'url': 'url3',
+                     'lastBuild': {'number': 0, 'result': "FAILURE"}}]
+        args = Mock()
+        args.value = ["ans"]
+        job_name = Mock()
+        job_name.value = ["ansible"]
+        job_url = Mock()
+        job_url.value = ["url1"]
+        jobs_filtered = filter_jobs(response, jobs=args, job_url=job_url,
+                                    job_name=job_name)
+        expected = [{'_class': 'org..job.WorkflowRun',
+                     'name': "ansible", 'url': 'url1',
+                     'lastBuild': {'number': 1, 'result': "SUCCESS"}}]
         self.assertEqual(jobs_filtered, expected)


### PR DESCRIPTION
If the user specifies a --job-name or --job-url the jobs will be
filtered by those values. This filters are applied in addition to the
--jobs argument so the jobs selected will conform to all of the
arguments specified.
