### PR TITLE
Fix CLI help message

### DIFF
--- a/cibyl/exceptions/model.py
+++ b/cibyl/exceptions/model.py
@@ -29,9 +29,8 @@ class NoValidEnvironment(Exception):
     """Exception for a case when no valid environment is found."""
 
     def __init__(self):
-        self.message = """No valid environment defined.
- Please ensure the specified environments with --env-name argument
-are present in the configuration.
+        self.message = """No valid environments are defined.
+Please set at least one environment in the configuration file.
 """
         super().__init__(self.message)
 

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -61,7 +61,10 @@ class Orchestrator:
     def create_ci_environments(self) -> None:
         """Creates CI environment entities based on loaded configuration."""
         try:
-            env_data = self.config.data.get('environments', {}).items()
+            if self.config.data:
+                env_data = self.config.data.get('environments', {}).items()
+            else:
+                env_data = {}
 
             for env_name, systems_dict in env_data:
                 environment = Environment(name=env_name)


### PR DESCRIPTION
Before this change, if user tried to run "cibyl -h"
he would get an exception if his configuration file was
empty.

By default, 'cibyl -h' should never raise an exception
since users can specify a different configuration file path.
