### PR TITLE
Deleted 'too-few-public-methods' comments and fix elastic query type

### DIFF
--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -21,7 +21,6 @@ from cibyl.cli.argument import Argument
 LOG = logging.getLogger(__name__)
 
 
-# pylint: disable=too-few-public-methods
 class CustomAction(argparse.Action):
     """Custom argparse.Action that allows in addition, to specify
     whether an argument data is populated, the function associated

--- a/cibyl/models/model.py
+++ b/cibyl/models/model.py
@@ -16,7 +16,6 @@
 from cibyl.models.attribute import AttributeValue
 
 
-# pylint: disable=too-few-public-methods
 class Model:
     """Represents a base class inherited by CI and product models."""
 

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -27,7 +27,7 @@ from cibyl.sources.source import Source
 LOG = logging.getLogger(__name__)
 
 
-class ElasticSearchOSP(Source):  # pylint: disable=too-few-public-methods
+class ElasticSearchOSP(Source):
     """Used to perform queries in elasticsearch"""
 
     def __init__(self: object, driver: str = 'elasticsearch',
@@ -145,7 +145,7 @@ class ElasticSearchOSP(Source):  # pylint: disable=too-few-public-methods
         return AttributeDictValue("jobs", attr_type=Job, value=job_object)
 
 
-class QueryTemplate():  # pylint: disable=too-few-public-methods
+class QueryTemplate():
     """Used for template and substitutions according to the
        elements received and return a dictionary equivalent to
        a DSL query
@@ -166,7 +166,7 @@ class QueryTemplate():  # pylint: disable=too-few-public-methods
             query_type = 'match_phrase_prefix'
 
             if 'query_type' in kwargs:
-                query_type = 'match'
+                query_type = kwargs.get('query_type')
 
             self.query_body = {
                 'query': {

--- a/cibyl/sources/zuul/source.py
+++ b/cibyl/sources/zuul/source.py
@@ -22,7 +22,7 @@ from cibyl.sources.source import Source
 from cibyl.sources.zuul.apis.rest import ZuulRESTClient
 
 
-class ZuulData:  # pylint: disable=too-few-public-methods
+class ZuulData:
     """Data class representing the source side of Zuul.
     """
 


### PR DESCRIPTION
- Deleted 'too-few-public-methods' comments. Exception added in `.pylintrc` (https://github.com/rhos-infra/cibyl/pull/56#discussion_r830567565)
- Fixed type of query elastic