### PR TITLE
Fix missing configuration file bug

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -19,39 +19,28 @@ from cibyl.orchestrator import Orchestrator
 from cibyl.utils.logger import configure_logging
 
 
-def get_config_file_path(arguments):
+def raw_parsing(arguments):
     """Returns config file path if one was passed with --config argument
 
     :param arguments: A list of strings representing the arguments and their
                       values, defaults to None
     :type arguments: str, optional
     """
-    config_file_path = None
+    args = {'config_file_path': None, 'help': False,
+            "log_file": "cibyl_output.log", "log_mode": "both",
+            "debug": False}
     for i, item in enumerate(arguments[1:]):
         if item == "--config":
-            config_file_path = arguments[i + 2]
-    return config_file_path
-
-
-def get_config_log(arguments):
-    """Returns configuration related to logging
-
-    :param arguments: A list of strings representing the arguments and their
-                      values, defaults to None
-    :type arguments: str, optional
-    :returns: Dictionary with the logging-related configuration
-    :rtype: dict[str, str]
-    """
-    log_config = {"log_file": "cibyl_output.log", "log_mode": "both",
-                  "debug": False}
-    for i, item in enumerate(arguments[1:]):
+            args['config_file_path'] = arguments[i + 2]
+        if item == "-h" or item == "--help":
+            args['help'] = True
         if item == "--log-file":
-            log_config["log_file"] = arguments[i + 2]
+            args["log_file"] = arguments[i + 2]
         elif item == "--log-mode":
-            log_config["log_mode"] = arguments[i+2]
+            args["log_mode"] = arguments[i+2]
         elif item == "--debug":
-            log_config["debug"] = True
-    return log_config
+            args["debug"] = True
+    return args
 
 
 def main():
@@ -60,12 +49,13 @@ def main():
     # We parse it from sys.argv instead of argparse parser because we want
     # to run the app parser only once, after we update it with the loaded
     # arguments from the CI models based on the loaded configuration file
-    config_file_path = get_config_file_path(sys.argv)
-    log_config = get_config_log(sys.argv)
-    configure_logging(log_config)
 
-    orchestrator = Orchestrator(config_file_path)
-    orchestrator.load_configuration()
+    arguments = raw_parsing(sys.argv)
+    configure_logging(arguments)
+
+    orchestrator = Orchestrator(arguments.get('config_file_path'))
+    orchestrator.load_configuration(
+        skip_on_missing=arguments.get('help', False))
     orchestrator.create_ci_environments()
     # Add arguments from CI & product models to the parser of the app
     for env in orchestrator.environments:

--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -71,7 +71,7 @@ class Config(UserDict):
 
         return self._path
 
-    def load(self):
+    def load(self, skip_on_missing=False):
         """Loads the contents of the configuration file into this object.
         This will look for the first file available from the list of paths
         provided by :attr:`~path`.
@@ -82,6 +82,6 @@ class Config(UserDict):
         file = get_first_available_file(self.path)
         if file:
             self.data = yaml.parse(file)
-        else:
+        elif not skip_on_missing:
             raise FileNotFoundError(f"Could not find configuration file: \
 '{self.path}'")

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -54,9 +54,9 @@ class Orchestrator:
         if not environments:
             self.environments = []
 
-    def load_configuration(self):
+    def load_configuration(self, skip_on_missing=False):
         """Loads the configuration of the application."""
-        self.config.load()
+        self.config.load(skip_on_missing)
 
     def create_ci_environments(self) -> None:
         """Creates CI environment entities based on loaded configuration."""


### PR DESCRIPTION
Before this change, if user tries to run application
executable with -h or --help and the configuration file
doesn't exists, it will fail.

Normally, this shouldn't happen as the user can provide a
different path for the configuration file with one of the
arguments. But, in order to know that, user should be able
to run -h or --help without failing. This is what this change
does. It checks if user has specified -h or --help and
instead of trying to load the configuration and create
environment instances, it prints the help message

In addition merged the methods that iterate over sys.argv as
they are essentially the same and this allows us to avoid iterating
sys.argv twice.
