### PR TITLE
Add plugin mechanism

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,13 @@
 CIbyl
 =====
 
-Command line interface for querying CI environments
+Command line and API interface for querying CI environments
 
 
 Installation
 ************
 
-`pip install cibyl`
+``pip install cibyl``
 
 Next, set up `configuration <http://cibyl.readthedocs.org/>`_
 
@@ -17,11 +17,11 @@ You can now run Cibyl commands :)
 Usage
 *****
 
-``cibyl`` for listing environments and systems
+``cibyl`` for listing environments and systems.
 
-``cibyl --jobs`` will print all the jobs available in your CI system
+``cibyl --jobs`` will print all the jobs available in your CI system.
 
-``cibyl --jobs --builds`` will print the jobs as well as the status of all the builds of that job
+``cibyl --jobs --last-build`` will print the jobs as well as the status of the last build of each job.
 
 
 Official Documentation

--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -16,6 +16,7 @@
 import sys
 
 from cibyl.orchestrator import Orchestrator
+from cibyl.plugins.constants import PLUGIN_NAME
 from cibyl.utils.logger import configure_logging
 
 
@@ -28,7 +29,7 @@ def raw_parsing(arguments):
     """
     args = {'config_file_path': None, 'help': False,
             "log_file": "cibyl_output.log", "log_mode": "both",
-            "debug": False}
+            "debug": False, "plugin": PLUGIN_NAME}
     for i, item in enumerate(arguments[1:]):
         if item == "--config":
             args['config_file_path'] = arguments[i + 2]
@@ -37,9 +38,11 @@ def raw_parsing(arguments):
         if item == "--log-file":
             args["log_file"] = arguments[i + 2]
         elif item == "--log-mode":
-            args["log_mode"] = arguments[i+2]
+            args["log_mode"] = arguments[i + 2]
         elif item == "--debug":
             args["debug"] = True
+        elif item == "--plugin" or item == "-p":
+            args["plugin"] = arguments[i + 2]
     return args
 
 
@@ -56,6 +59,8 @@ def main():
     orchestrator = Orchestrator(arguments.get('config_file_path'))
     orchestrator.load_configuration(
         skip_on_missing=arguments.get('help', False))
+    if arguments.get('plugin'):
+        orchestrator.extend_models(arguments.get('plugin'))
     orchestrator.create_ci_environments()
     # Add arguments from CI & product models to the parser of the app
     for env in orchestrator.environments:

--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -17,6 +17,7 @@ import argparse
 import logging
 
 from cibyl.cli.argument import Argument
+from cibyl.plugins.constants import PLUGIN_NAME
 
 LOG = logging.getLogger(__name__)
 
@@ -78,7 +79,7 @@ class Parser:
             choices=("terminal", "file", "both"),
             help='Where to write the output, default is both')
         self.argument_parser.add_argument(
-            '--plugin', '-p', dest="plugin", default="openstack")
+            '--plugin', '-p', dest="plugin", default=PLUGIN_NAME)
         self.argument_parser.add_argument(
             '-v', '--verbose', dest="verbosity", default=0, action="count",
             help="Causes Cibyl to print more debug messages. "

--- a/cibyl/exceptions/plugin.py
+++ b/cibyl/exceptions/plugin.py
@@ -1,0 +1,26 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+
+class MissingPlugin(Exception):
+    """Missing plugin exception"""
+
+    def __init__(self, plugin_name):
+        self.plugin_name = plugin_name
+        self.message = f"""Unable to locate the plugin {plugin_name}.
+Make sure the plugin is defined in cibyl.plugins directory
+"""
+        super().__init__(self.message)

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -55,8 +55,10 @@ class Job(Model):
 
     def __init__(self, name: str, url: str = None,
                  builds: Dict[str, Build] = None):
-        super().__init__({'name': name, 'url': url,
-                          'builds': builds})
+        self_init_dict = {}
+        for key in self.API.keys():
+            self_init_dict[key] = vars().get(key)
+        super().__init__(self_init_dict)
 
     def __str__(self, indent=0, verbosity=0):
         indent_space = indent*' '

--- a/cibyl/plugins/__init__.py
+++ b/cibyl/plugins/__init__.py
@@ -1,0 +1,13 @@
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.

--- a/cibyl/plugins/constants.py
+++ b/cibyl/plugins/constants.py
@@ -1,0 +1,14 @@
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+PLUGIN_NAME = "openstack"

--- a/cibyl/plugins/openstack/__init__.py
+++ b/cibyl/plugins/openstack/__init__.py
@@ -1,0 +1,13 @@
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.

--- a/cibyl/plugins/openstack/plugin.py
+++ b/cibyl/plugins/openstack/plugin.py
@@ -1,0 +1,28 @@
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from cibyl.models.openstack.deployment import Deployment
+
+
+class OpenstackPlugin:
+
+    def extend(self, model_api):
+        for attr_name, attr_value in model_api.items():
+            if 'attr_type' in attr_value and \
+               attr_value['attr_type'].__name__ == 'Job':
+                attr_value['attr_type'].API['deployment'] = {
+                    'attr_type': Deployment,
+                    'arguments': []
+                }
+            if hasattr(attr_value['attr_type'], 'API'):
+                self.extend(attr_value['attr_type'].API)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,8 +13,10 @@ Welcome to Cibyl documentation
    contribute.rst
 
 .. toctree::
-   :caption: Development
-   :maxdepth: 1
+   :caption: Core
+   :maxdepth: 2
+
+   plugins
 
 .. toctree::
    :maxdepth: 1
@@ -23,7 +25,7 @@ Welcome to Cibyl documentation
    core_ci_models/core_models.rst
 
 .. toctree::
-   :maxdepth: 1
-   :caption: Plugins Models
+   :caption: Plugins
+   :maxdepth: 2
 
-   plugins/OpenStack_models/OpenStack_models.rst
+   openstack

--- a/docs/source/openstack.rst
+++ b/docs/source/openstack.rst
@@ -1,0 +1,12 @@
+OpenStack Plugin
+================
+
+OpenStack plugin associates Job and Build models with OpenStack cloud models::
+
+    Deployment             # OpenStack Cluster
+    ├── Node               # OpenStack Cluster Node (Controller, Compute)
+
+Usage
+^^^^^
+
+In order to use OpenStack plugin, add ``--plugin openstack`` to Cibyl command

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -1,0 +1,25 @@
+Plugins
+=======
+
+Plugins allow you to extend supported models, either with your own CI models
+or models that go behind CI like product related models.
+A supported plugin in Cibyl has to adhere following
+structure:: 
+
+    cibyl 
+    ├── plugins
+    │   └── example        # Arbitrary plugin name
+    │       └── plugin.py
+
+Plugin Class
+^^^^^^^^^^^^
+
+.. code-block:: python
+
+class ExamplePlugin:
+
+    def extend(self, model_api: dict):
+        model_api['new_attribute'] = {
+            'attr_type': str,
+            arguments: []
+        }

--- a/docs/source/plugins/OpenStack_models/OpenStack_models.rst
+++ b/docs/source/plugins/OpenStack_models/OpenStack_models.rst
@@ -1,2 +1,0 @@
-OpenStack models
-================

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -19,6 +19,7 @@ from unittest.mock import Mock, patch
 from cibyl.config import Config
 from cibyl.exceptions.config import InvalidConfiguration
 from cibyl.exceptions.model import NoValidEnvironment
+from cibyl.exceptions.plugin import MissingPlugin
 from cibyl.exceptions.source import NoValidSources
 from cibyl.orchestrator import Orchestrator
 
@@ -160,3 +161,23 @@ class TestOrchestrator(TestCase):
         self.assertRaises(NoValidSources,
                           self.orchestrator.select_source_method,
                           system, argument)
+
+    def test_orchestrator_extend_models(self):
+        """Testing Orchestrator extend models method."""
+        self.assertRaises(MissingPlugin,
+                          self.orchestrator.extend_models,
+                          "nonExistingPlugin")
+
+        # Test no deployment attribute in Job
+        self.orchestrator.config.data = self.valid_env_sources
+        self.orchestrator.create_ci_environments()
+        self.assertNotIn(
+            'deployment',
+            self.orchestrator.environments[0].systems[0].jobs.attr_type.API)
+
+        # Test deployment attribute in Job after plugin extension
+        self.orchestrator.extend_models("openstack")
+        self.orchestrator.create_ci_environments()
+        self.assertIn(
+            'deployment',
+            self.orchestrator.environments[0].systems[0].jobs.attr_type.API)


### PR DESCRIPTION
By default, Cibyl makse use only of CI models
but in most cases, builds are associated with project/product
information which isn't reflected in CI models by default.

This change adds the plugin mechanism in order for users
to be able to associate CI models with Product models.

The mechanism loads dynamically the plugin from plugins
folder based on the plugin name, in order to avoid
maintaining registry in Cibyl of plugins and allow anyone
to write its own custom plugin.

The interface of a plugin is a simple one - it should
implement one method called "extend" which extends the
CI models with product-based models.
