### PR TITLE
Introduce quiet exceptions

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -15,6 +15,7 @@
 """
 import sys
 
+from cibyl.exceptions import CibylException
 from cibyl.orchestrator import Orchestrator
 from cibyl.utils.logger import configure_logging
 
@@ -51,6 +52,7 @@ def main():
     # arguments from the CI models based on the loaded configuration file
 
     arguments = raw_parsing(sys.argv)
+    CibylException.setup_quiet_exceptions()
     configure_logging(arguments)
 
     orchestrator = Orchestrator(arguments.get('config_file_path'))

--- a/cibyl/exceptions/__init__.py
+++ b/cibyl/exceptions/__init__.py
@@ -11,3 +11,19 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import sys
+
+
+class CibylException(Exception):
+
+    @staticmethod
+    def setup_quiet_exceptions():
+        """Sets up quiet exceptions, without tracebacks, if they are
+        of the type CibylException
+        """
+        def quiet_hook(kind, message, traceback):
+            if CibylException in kind.__bases__:
+                print(f'{message}')
+            else:
+                sys.__excepthook__(kind, message, traceback)
+        sys.excepthook = quiet_hook

--- a/cibyl/exceptions/config.py
+++ b/cibyl/exceptions/config.py
@@ -13,9 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.exceptions import CibylException
 
 
-class InvalidConfiguration(Exception):
+class InvalidConfiguration(CibylException):
     """Invalid configuration exception"""
 
     def __init__(self, message="""

--- a/cibyl/exceptions/elasticsearch.py
+++ b/cibyl/exceptions/elasticsearch.py
@@ -13,9 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.exceptions import CibylException
 
 
-class ElasticSearchError(Exception):
+class ElasticSearchError(CibylException):
     """Elasticsearch error.
     Used for personalized elasticsearch exceptions
     """

--- a/cibyl/exceptions/jenkins.py
+++ b/cibyl/exceptions/jenkins.py
@@ -13,7 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.exceptions import CibylException
 
 
-class JenkinsError(Exception):
+class JenkinsError(CibylException):
     """Represents an error occurring while querying Jenkins."""

--- a/cibyl/exceptions/jenkins_job_builder.py
+++ b/cibyl/exceptions/jenkins_job_builder.py
@@ -13,7 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.exceptions import CibylException
 
 
-class JenkinsJobBuilderError(Exception):
+class JenkinsJobBuilderError(CibylException):
     """Represents an error occurring while querying JenkinsJobBuilder."""

--- a/cibyl/exceptions/model.py
+++ b/cibyl/exceptions/model.py
@@ -13,9 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.exceptions import CibylException
 
 
-class NonSupportedModelType(Exception):
+class NonSupportedModelType(CibylException):
     """Exception for trying to populate non-supported model"""
 
     def __init__(self, model_type):
@@ -25,7 +26,7 @@ Unable to populate system with pulled data"""
         super().__init__(self.message)
 
 
-class NoValidEnvironment(Exception):
+class NoValidEnvironment(CibylException):
     """Exception for a case when no valid environment is found."""
 
     def __init__(self):
@@ -35,12 +36,13 @@ Please set at least one environment in the configuration file.
         super().__init__(self.message)
 
 
-class NoValidSystem(Exception):
+class NoValidSystem(CibylException):
     """Exception for a case when no valid system is found."""
 
     def __init__(self):
-        self.message = """No valid system defined.
- Please ensure the specified environments with --systems, --system-name or
- --system-type arguments are present in the configuration.
+        self.message = """
+No valid system defined.
+Please ensure the specified environments arguments are present in the
+configuration.
 """
         super().__init__(self.message)

--- a/cibyl/exceptions/source.py
+++ b/cibyl/exceptions/source.py
@@ -13,9 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.exceptions import CibylException
 
 
-class TooManyValidSources(Exception):
+class TooManyValidSources(CibylException):
     """Exception for trying to use multiple supported sources."""
 
     def __init__(self, system):
@@ -37,7 +38,7 @@ environments:
         super().__init__(self.message)
 
 
-class NoSupportedSourcesFound(Exception):
+class NoSupportedSourcesFound(CibylException):
     """Exception for a case where non of the sources of a single system is
        implementing the function of the argument the user is interested in
     """
@@ -49,7 +50,7 @@ class NoSupportedSourcesFound(Exception):
         super().__init__(self.message)
 
 
-class NoValidSources(Exception):
+class NoValidSources(CibylException):
     """Exception for a case when no valid source is found."""
 
     def __init__(self, system):


### PR DESCRIPTION
Printing the whole traceback creates the impression
of internal error in Cibyl.

Instead, this change introduces quiet exceptions where
if the exception inherits from CibylException class, it
will only print the message itself instead of the whole
traceback.

Tracebacks will still be displayed when an internal error
occurs that isn't planned and isn't part of Cibyl known
workflow.
