### PR TITLE
Fix systems argument duplication

### DIFF
--- a/cibyl/cli/validator.py
+++ b/cibyl/cli/validator.py
@@ -58,10 +58,6 @@ class Validator:
         if user_system_type and system_type not in user_system_type.value:
             is_valid_system = False
 
-        user_system_name = self.ci_args.get("system_name")
-        if user_system_name and name not in user_system_name.value:
-            is_valid_system = False
-
         user_systems = self.ci_args.get("systems")
         if user_systems and name not in user_systems.value:
             is_valid_system = False

--- a/cibyl/exceptions/model.py
+++ b/cibyl/exceptions/model.py
@@ -40,7 +40,7 @@ class NoValidSystem(Exception):
 
     def __init__(self):
         self.message = """No valid system defined.
- Please ensure the specified environments with --systems, --system-name or
+ Please ensure the specified environments with --systems or
  --system-type arguments are present in the configuration.
 """
         super().__init__(self.message)

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -34,8 +34,7 @@ class System(Model):
     API = {
         'name': {
             'attr_type': str,
-            'arguments': [Argument(name='--system-name', arg_type=str,
-                                   description="System name")]
+            'arguments': []
         },
         'system_type': {
             'attr_type': str,

--- a/tests/cli/test_validator.py
+++ b/tests/cli/test_validator.py
@@ -79,24 +79,6 @@ class TestValidator(TestCase):
         self.assertEqual("system3", systems[0].name.value)
         self.assertEqual("jenkins", systems[0].system_type.value)
 
-    def tests_validator_validate_environments_system_name(self):
-        """Testing Validator validate_environment method."""
-        self.orchestrator.config.data = self.config
-        self.orchestrator.create_ci_environments()
-        self.ci_args["env_name"] = Mock()
-        self.ci_args["env_name"].value = ["env"]
-        self.ci_args["system_name"] = Mock()
-        self.ci_args["system_name"].value = ["system3"]
-
-        validator = Validator(self.ci_args)
-        original_envs = self.orchestrator.environments
-
-        envs, systems = validator.validate_environments(original_envs)
-        self.assertEqual(1, len(envs))
-        self.assertEqual(1, len(systems))
-        self.assertEqual("system3", systems[0].name.value)
-        self.assertEqual("jenkins", systems[0].system_type.value)
-
     def tests_validator_validate_environments_system_type(self):
         """Testing Validator validate_environment method."""
         self.orchestrator.config.data = self.config
@@ -135,8 +117,8 @@ class TestValidator(TestCase):
         """Testing Validator validate_environment method."""
         self.orchestrator.config.data = self.config
         self.orchestrator.create_ci_environments()
-        self.ci_args["system_name"] = Mock()
-        self.ci_args["system_name"].value = ["unknown"]
+        self.ci_args["systems"] = Mock()
+        self.ci_args["systems"].value = ["unknown"]
 
         validator = Validator(self.ci_args)
         original_envs = self.orchestrator.environments


### PR DESCRIPTION
There is no really reason to support both
--systems and --system-name if both provide
the same functionality.

Actually systems is much better since it's plural
and should allow user to specify more than one system
