### PR TITLE
Hide exception traceback if no configuration found

### DIFF
--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -17,6 +17,7 @@ import logging
 import os
 from collections import UserDict
 
+from cibyl.exceptions.config import ConfigurationNotFound
 from cibyl.utils import yaml
 from cibyl.utils.files import get_first_available_file
 
@@ -76,12 +77,12 @@ class Config(UserDict):
         This will look for the first file available from the list of paths
         provided by :attr:`~path`.
 
-        :raises FileNotFoundError: If no configuration file could be found.
+        :raises ConfigurationNotFound: If no configuration file could be found.
         :raises YAMLError: If the configuration file could not be parsed.
         """
         file = get_first_available_file(self.path)
         if file:
             self.data = yaml.parse(file)
         elif not skip_on_missing:
-            raise FileNotFoundError(f"Could not find configuration file: \
+            raise ConfigurationNotFound(f"Could not find configuration file: \
 '{self.path}'")

--- a/cibyl/exceptions/config.py
+++ b/cibyl/exceptions/config.py
@@ -30,3 +30,11 @@ environments:
             system_type: jenkins"""):
         self.message = message
         super().__init__(self.message)
+
+
+class ConfigurationNotFound(CibylException):
+    """Configuration file not found exception"""
+    def __init__(self, message="Could not find configuration file:"
+                 "('~/.config/cibyl.yaml', '/etc/cibyl/cibyl.yaml')"):
+        self.message = message
+        super().__init__(self.message)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock
 
 import cibyl.config
 from cibyl.config import Config
+from cibyl.exceptions.config import ConfigurationNotFound
 
 
 class TestConfig(TestCase):
@@ -25,15 +26,15 @@ class TestConfig(TestCase):
     """
 
     def test_error_when_file_not_found(self):
-        """Checks that 'load' raises a FileNotFoundError when the config file
-        does not exist.
+        """Checks that 'load' raises a ConfigurationNotFound when the config
+        file does not exist.
         """
         cibyl.config.get_first_available_file = Mock()
         cibyl.config.get_first_available_file.return_value = None
 
         config = Config()
 
-        self.assertRaises(FileNotFoundError, config.load)
+        self.assertRaises(ConfigurationNotFound, config.load)
 
     def test_contents_are_loaded(self):
         """Checks that the contents of the loaded file are made available by


### PR DESCRIPTION
If a configuration was not found it was raising FileNotFoundError, which
is not handled by the setup_quiet_exceptions function.
