### PR TITLE
Introducing user and token to urls generated by the Jenkins source.

### DIFF
--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -256,8 +256,12 @@ class Jenkins(Source):
 
             return url
 
-        response = requests.get(generate_query_url(), verify=self.cert, timeout=timeout)
+        response = requests.get(
+            generate_query_url(), verify=self.cert, timeout=timeout
+        )
+
         response.raise_for_status()
+
         return json.loads(response.text)
 
     def get_jobs(self, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pyyaml~=6.0
 requests~=2.27.1
 elasticsearch~=7.17.1
-colorlog
+colorlog~=6.6.0
+urllib3~=1.26.9

--- a/tests/sources/test_jenkins.py
+++ b/tests/sources/test_jenkins.py
@@ -187,9 +187,10 @@ class TestJenkinsSource(TestCase):
                               'name': "ansible", 'url': 'url1'}]}
         patched_get.return_value = Mock(text=json.dumps(response))
         self.assertEqual(response, self.jenkins.send_request("test"))
-        patched_get.assert_called_with("url//api/jsontest",
-                                       verify=self.jenkins.cert,
-                                       timeout=None)
+        patched_get.assert_called_with(
+            f'://{self.jenkins.username}:{self.jenkins.token}@/api/jsontest',
+            verify=self.jenkins.cert, timeout=None
+        )
 
 
 class TestFilters(TestCase):


### PR DESCRIPTION
I have modified how queries are generated by the Jenkins source so that it includes the provided username and token. This will allow us to communicate with hosts running on the 'http' scheme.

I am not very proud of the way the URL is generated, but have not found a library to make it easier. I am open to suggestions because I feel that URLs is something we will usually have to work with.

I also took the chance and solved a couple of warnings I got on the requirements file.