### PR TITLE
Get builds by status

### DIFF
--- a/cibyl/models/attribute.py
+++ b/cibyl/models/attribute.py
@@ -88,6 +88,9 @@ class AttributeDictValue(AttributeValue):
     def __iter__(self):
         yield from self.value
 
+    def __delitem__(self, key):
+        del self.value[key]
+
     def items(self):
         """Return the value as key:value items"""
         return self.value.items()

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -48,10 +48,7 @@ class Job(Model):
                                    description="Job builds"),
                           Argument(name='--last-build', arg_type=str,
                                    func='get_last_build', nargs=0,
-                                   description="Last build for job"),
-                          Argument(name='--build-status', arg_type=str,
-                                   func='get_builds_by_status', nargs="*",
-                                   description="Job builds by status")]
+                                   description="Last build for job")]
         }
     }
 

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -48,7 +48,10 @@ class Job(Model):
                                    description="Job builds"),
                           Argument(name='--last-build', arg_type=str,
                                    func='get_last_build', nargs=0,
-                                   description="Last build for job")]
+                                   description="Last build for job"),
+                          Argument(name='--build-status', arg_type=str,
+                                   func='get_builds_by_status', nargs="*",
+                                   description="Job builds by status")]
         }
     }
 

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -47,7 +47,7 @@ class ElasticSearchOSP(Source):  # pylint: disable=too-few-public-methods
                       from exception
             self.es_client = ElasticSearchClient(host, port).connect()
 
-    def get_jobs(self: object, **kwargs) -> list:
+    def get_jobs(self: object, **kwargs: str) -> list:
         """Get jobs from elasticsearch
 
             :returns: Job objects queried from elasticserach
@@ -90,7 +90,7 @@ class ElasticSearchOSP(Source):  # pylint: disable=too-few-public-methods
                   from exception
         return response['hits']['hits']
 
-    def get_builds(self, **kwargs):
+    def get_builds(self: object, **kwargs: str):
         """
             Get builds from elasticsearch server.
 
@@ -120,7 +120,7 @@ class ElasticSearchOSP(Source):  # pylint: disable=too-few-public-methods
 
         return jobs_found
 
-    def get_last_build(self, **kwargs):
+    def get_last_build(self: object, **kwargs: str):
         """
             Get last build for jobs from elasticsearch server.
             It uses the `method:get_builds` implemented in this class
@@ -143,6 +143,27 @@ class ElasticSearchOSP(Source):  # pylint: disable=too-few-public-methods
             job_object[job_name].add_build(build_object)
 
         return AttributeDictValue("jobs", attr_type=Job, value=job_object)
+
+    def get_builds_by_status(self: object, **kwargs: str):
+        """
+            Get builds by status for jobs from elasticsearch server.
+            It uses the `method:get_builds` implemented in this class
+
+            :returns: container of jobs with all builds by specific status
+            :rtype: :class:`AttributeDictValue`
+        """
+        build_statuses = [status.upper()
+                          for status in kwargs.get('build_status').value]
+
+        builds_jobs = self.get_builds(**kwargs)
+        for _, build_info in builds_jobs.items():
+
+            builds = build_info.builds
+            for build_number, build_object in list(builds.items()):
+                if build_object.status.value not in build_statuses:
+                    del builds[build_number]
+
+        return builds_jobs
 
 
 class QueryTemplate():  # pylint: disable=too-few-public-methods

--- a/tests/sources/elasticsearch/test_api.py
+++ b/tests/sources/elasticsearch/test_api.py
@@ -14,7 +14,7 @@
 #    under the License.
 """
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 from cibyl.sources.elasticsearch.api import ElasticSearchOSP, QueryTemplate
 
@@ -38,16 +38,19 @@ class TestElasticsearchOSP(TestCase):
                 }
             }
         ]
-        self.build_hit = [
-            {
-                '_index': 'test',
-                '_id': 'random',
-                '_score': 1.0,
-                '_source': {
-                    'build_result': 'SUCCESS',
-                    'build_id': '1',
-                }
-            }
+        self.build_hits = [
+                    {
+                        '_source': {
+                            'build_result': 'SUCCESS',
+                            'build_id': '1',
+                        }
+                    },
+                    {
+                        '_source': {
+                            'build_result': 'FAIL',
+                            'build_id': '2',
+                        }
+                    }
         ]
 
     @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
@@ -80,14 +83,44 @@ class TestElasticsearchOSP(TestCase):
 
         self.es_api.get_jobs = Mock()
         self.es_api.get_jobs.return_value = jobs
-        mock_query_hits.return_value = self.build_hit
+        mock_query_hits.return_value = self.build_hits
 
         builds = self.es_api.get_builds()['test'].builds
-        self.assertEqual(len(builds), 1)
+        self.assertEqual(len(builds), 2)
 
         build = builds['1']
         self.assertEqual(build.build_id.value, '1')
         self.assertEqual(build.status.value, "SUCCESS")
+
+    @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
+    def test_get_builds_by_status(self: object,
+                                  mock_query_hits: object) -> None:
+        """Tests internal logic from :meth:`ElasticSearchOSP.get_builds_by_status`
+            is correct.
+        """
+        mock_query_hits.return_value = self.job_hit
+
+        jobs_argument = Mock()
+        jobs_argument.value = ['test']
+        jobs = self.es_api.get_jobs(jobs=jobs_argument)
+        self.assertEqual(len(jobs), 1)
+
+        self.es_api.get_jobs = Mock()
+        self.es_api.get_jobs.return_value = jobs
+        mock_query_hits.return_value = self.build_hits
+
+        # We need to mock the Argument kwargs passed. In this case
+        # build_status
+        status_argument = MagicMock()
+        build_status = PropertyMock(return_value=['fAiL'])
+        type(status_argument).value = build_status
+
+        # We have one FAIL and one SUCCESS job. If we filter by one of
+        # them then we should have just 1 job.
+        builds = self.es_api.get_builds_by_status(build_status=status_argument)
+        self.assertEqual(len(builds['test'].builds), 1)
+        status = builds['test'].builds['2'].status.value
+        self.assertEqual(status, 'FAIL')
 
 
 class TestQueryTemplate(TestCase):

--- a/tests/sources/elasticsearch/test_api.py
+++ b/tests/sources/elasticsearch/test_api.py
@@ -95,7 +95,7 @@ class TestElasticsearchOSP(TestCase):
     @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
     def test_get_builds_by_status(self: object,
                                   mock_query_hits: object) -> None:
-        """Tests internal logic from :meth:`ElasticSearchOSP.get_builds_by_status`
+        """Tests filtering by status in :meth:`ElasticSearchOSP.get_builds`
             is correct.
         """
         mock_query_hits.return_value = self.job_hit
@@ -103,8 +103,6 @@ class TestElasticsearchOSP(TestCase):
         jobs_argument = Mock()
         jobs_argument.value = ['test']
         jobs = self.es_api.get_jobs(jobs=jobs_argument)
-        self.assertEqual(len(jobs), 1)
-
         self.es_api.get_jobs = Mock()
         self.es_api.get_jobs.return_value = jobs
         mock_query_hits.return_value = self.build_hits
@@ -115,12 +113,11 @@ class TestElasticsearchOSP(TestCase):
         build_status = PropertyMock(return_value=['fAiL'])
         type(status_argument).value = build_status
 
-        # We have one FAIL and one SUCCESS job. If we filter by one of
-        # them then we should have just 1 job.
-        builds = self.es_api.get_builds_by_status(build_status=status_argument)
-        self.assertEqual(len(builds['test'].builds), 1)
-        status = builds['test'].builds['2'].status.value
-        self.assertEqual(status, 'FAIL')
+        builds = self.es_api.get_builds(build_status=status_argument)
+        builds_values = builds['test'].builds
+        build = builds_values['2']
+        self.assertEqual(build.build_id.value, '2')
+        self.assertEqual(build.status.value, "FAIL")
 
 
 class TestQueryTemplate(TestCase):


### PR DESCRIPTION
- Added in Job class the --build-status argument. We can use it to filter the jobs builds by status.
- Added in the AttributeDictValue class the __delitem__ method. In this case we can delete the elements by key in the same dictionary without creating a new one.
- Added the method get_builds_by_status in the Elasticsearch class. We will use it to filter the jobs builds by status.
- Added method to test get_builds_by_status.