### PR TITLE
Creating e2e testing environment and a sample of how a test would look like.

### DIFF
--- a/e2e/__init__.py
+++ b/e2e/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/e2e/configs/jenkins.yaml
+++ b/e2e/configs/jenkins.yaml
@@ -1,0 +1,11 @@
+---
+environments:
+  osp_phases:
+    osp_jenkins:
+      system_type: jenkins
+      sources:
+        jenkins:
+          driver: jenkins
+          username: 'admin'
+          token: 'passw'
+          url: 'http://localhost:8080/'

--- a/e2e/images/jenkins/Dockerfile
+++ b/e2e/images/jenkins/Dockerfile
@@ -1,0 +1,13 @@
+FROM jenkins/jenkins:lts-jdk11
+
+# Avoid GUI setup wizard
+ENV JAVA_OPTS -Djenkins.install.runSetupWizard=false
+
+# Indicate path to configuration file
+ENV CASC_JENKINS_CONFIG /var/jenkins_home/casc.yaml
+
+# Install plugins
+RUN jenkins-plugin-cli --plugins configuration-as-code
+
+# Load Jenkin's configuration
+COPY setup.yaml /var/jenkins_home/casc.yaml

--- a/e2e/images/jenkins/setup.yaml
+++ b/e2e/images/jenkins/setup.yaml
@@ -1,0 +1,10 @@
+jenkins:
+  securityRealm:
+    local:
+      allowsSignup: false
+      users:
+        - id: ${JENKINS_ADMIN_ID}
+          password: ${JENKINS_ADMIN_PASSWORD}
+unclassified:
+  location:
+    url: http://localhost:8080/

--- a/e2e/test_jenkins.py
+++ b/e2e/test_jenkins.py
@@ -1,0 +1,44 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import sys
+from io import StringIO
+from unittest import TestCase
+
+from cibyl.cli.main import main
+
+
+class TestJenkins(TestCase):
+    def setUp(self) -> None:
+        self._output = StringIO()
+
+        sys.stdout = self._output
+
+    @property
+    def output(self):
+        return self._output.getvalue()
+
+    def test_get_jobs(self):
+        sys.argv = [
+            '',
+            '--config',
+            'e2e/configs/jenkins.yaml',
+            '--jobs',
+            '-vv'
+        ]
+
+        main()
+
+        self.assertIn('Total jobs: 0', self.output)

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,21 @@ skipsdist = True
 ignore_basepython_conflict = True
 skip_missing_interpreters = False
 requires =
+    tox-docker; python_version >= '3.8'
     tox-extra; python_version >= '3.8'
+
+[docker:jenkins]
+image = cre/jenkins
+environment =
+    JENKINS_ADMIN_ID=admin
+    JENKINS_ADMIN_PASSWORD=passw
+ports =
+    8080:8080/tcp
+    50000:50000/tcp
+
+[gh-actions]
+python =
+    3.9: py39
 
 [testenv]
 usedevelop = True
@@ -25,18 +39,23 @@ deps =
     -r {toxinidir}/requirements.txt
     -r {toxinidir}/test-requirements.txt
 commands =
-    python -m unittest
+    python -m unittest discover tests
 
-[gh-actions]
-python =
-    3.9: py39
+[testenv:e2e]
+docker =
+    jenkins
+deps =
+    -r {toxinidir}/requirements.txt
+whitelist_externals = bash
+commands_pre = bash -c 'sleep 10' # Wait for containers to be ready
+commands = python -m unittest discover e2e
 
 [testenv:coverage]
 deps =
     -r {toxinidir}/requirements.txt
     -r {toxinidir}/test-requirements.txt
 commands =
-    coverage run -m unittest discover
+    coverage run -m unittest discover tests
     coverage report -m --fail-under=90
 
 [testenv:docs]


### PR DESCRIPTION
E2E testing consists on asserting the complete flow of one of the app's functionalities. In this case, I have run a Jenkins instance on a Docker container and had Cibyl perform a query over it in order to check that the Jenkins source is working right and the answer is as expected.

E2E tests do not form part of the tox pipeline yet and must be explicitly called with: `tox -e e2e`. This is due to two reasons: first, these tests usually take longer to execute and will slow down the pipeline; second, right now they require some set up that is not automated yet.

In order to run the test cases, you will need to install the Jenkins image first:
`docker build -t cre/jenkins images/jenkins`