### PR TITLE
Fix bug in add_job and add_pipeline

### DIFF
--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -141,7 +141,7 @@ class JobsSystem(System):
         :type job: Job
         """
         job_name = job.name.value
-        if job_name in self.jobs.values():
+        if job_name in self.jobs:
             self.jobs[job_name].merge(job)
         else:
             self.jobs[job_name] = job
@@ -187,7 +187,7 @@ class PipelineSystem(System):
         :type pipeline: Pipeline
         """
         pipeline_name = pipeline.name.value
-        if pipeline_name in self.pipelines.values():
+        if pipeline_name in self.pipelines:
             self.pipelines[pipeline_name].merge(pipeline)
         else:
             self.pipelines[pipeline_name] = pipeline


### PR DESCRIPTION
The system methods add_job and add_pipeline were iterating over the
values of the AttributeValueDict, instead of the keys, which prevented
merging jobs properly.
