### PR TITLE
Remove get_last_build func from --last-build

### DIFF
--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -24,11 +24,13 @@ class Build(Model):
         'build_id': {
             'attr_type': str,
             'arguments': [Argument(name='--build-id', arg_type=str,
+                                   func='get_builds',
                                    description="Build ID")]
         },
         'status': {
             'attr_type': str,
             'arguments': [Argument(name='--build-status', arg_type=str,
+                                   func='get_builds',
                                    description="Build status")]
         },
         'duration': {

--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -48,7 +48,7 @@ class Job(Model):
                                    nargs="*", func="get_builds",
                                    description="Job builds"),
                           Argument(name='--last-build', arg_type=str,
-                                   func='get_last_build', nargs=0,
+                                   func='get_builds', nargs=0,
                                    description="Last build for job")]
         }
     }

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -290,6 +290,8 @@ class Jenkins(Source):
             :rtype: :class:`AttributeDictValue`
         """
 
+        if kwargs.get('last_build'):
+            return self.get_last_build(**kwargs)
         jobs_found = self.get_jobs(**kwargs)
         if kwargs.get('verbosity', 0) > 0 and len(jobs_found) > 80:
             LOG.warning("This might take a couple of minutes...\


### PR DESCRIPTION
This change modifies the source interfaces and moves all arguments
regarding builds to get_builds func. The proposal is to have only a few methods
as the public source interface: get_jobs and get_builds. Later more methods
will be needed, but these two methdod should handle all arguments related to
jobs (--job-name, --job-url) and builds (--build-id, --build-status).
