### PR TITLE
Redesigning how builds are retrieved on the Zuul source.

### DIFF
--- a/cibyl/sources/zuul/api.py
+++ b/cibyl/sources/zuul/api.py
@@ -22,20 +22,46 @@ class ZuulAPIError(Exception):
 
 
 class ZuulJobAPI(ABC):
+    """Interface which defines the information that can be retrieved from
+    Zuul regarding a particular job.
+    """
+
     def __init__(self, tenant, job):
+        """Constructor.
+
+        :param tenant: Tenant this job belongs to.
+        :type tenant: :class:`ZuulTenantAPI`
+        :param job: Description of the job being consulted by this
+            API. At least a field called 'name' providing the name
+            of the job is required here.
+        :type job: dict
+        """
         self._tenant = tenant
         self._job = job
 
     @property
     def tenant(self):
+        """
+        :return: The tenant this job belongs to.
+        :rtype: :class:`ZuulTenantAPI`
+        """
         return self._tenant
 
     @property
     def name(self):
+        """
+        :return: Name of the job being consulted.
+        :rtype: str
+        """
         return self._job['name']
 
     @abstractmethod
     def builds(self):
+        """
+        :return: The builds of this job.
+        :rtype: list[dict]
+        :raises ZuulAPIError: If the request failed.
+        """
         raise NotImplementedError
 
 
@@ -58,6 +84,7 @@ class ZuulTenantAPI(ABC):
     def name(self):
         """
         :return: Name of the tenant being consulted.
+        :rtype: str
         """
         return self._tenant['name']
 

--- a/cibyl/sources/zuul/api.py
+++ b/cibyl/sources/zuul/api.py
@@ -21,6 +21,24 @@ class ZuulAPIError(Exception):
     """
 
 
+class ZuulJobAPI(ABC):
+    def __init__(self, tenant, job):
+        self._tenant = tenant
+        self._job = job
+
+    @property
+    def tenant(self):
+        return self._tenant
+
+    @property
+    def name(self):
+        return self._job['name']
+
+    @abstractmethod
+    def builds(self):
+        raise NotImplementedError
+
+
 class ZuulTenantAPI(ABC):
     """Interface which defines the information that can be retrieved from
     Zuul regarding a particular tenant.
@@ -69,7 +87,7 @@ class ZuulTenantAPI(ABC):
         a project.
 
         :return: Information about all jobs under this tenant.
-        :rtype: list[dict]
+        :rtype: list[:class:`ZuulJobAPI`]
         :raises ZuulAPIError: If the request failed.
         """
         raise NotImplementedError

--- a/cibyl/sources/zuul/apis/rest.py
+++ b/cibyl/sources/zuul/apis/rest.py
@@ -17,10 +17,8 @@ from urllib.parse import urljoin
 
 from requests import HTTPError, Session
 
-from cibyl.sources.zuul.api import (ZuulAPI,
-                                    ZuulAPIError,
-                                    ZuulTenantAPI,
-                                    ZuulJobAPI)
+from cibyl.sources.zuul.api import (ZuulAPI, ZuulAPIError, ZuulJobAPI,
+                                    ZuulTenantAPI)
 
 
 class ZuulSession:
@@ -94,7 +92,15 @@ class ZuulSession:
 
 
 class ZuulJobRESTClient(ZuulJobAPI):
+    """Implementation of a Zuul client through the use of Zuul's REST-API.
+    """
+
     def __init__(self, session, tenant, job):
+        """Constructor. See parent class for more information.
+
+        :param session: The link through which the REST-API will be contacted.
+        :type session: :class:`ZuulSession`
+        """
         super().__init__(tenant, job)
 
         self._session = session
@@ -119,7 +125,7 @@ class ZuulTenantRESTClient(ZuulTenantAPI):
     """
 
     def __init__(self, session, tenant):
-        """ Constructor. See parent class for more information.
+        """Constructor. See parent class for more information.
 
         :param session: The link through which the REST-API will be contacted.
         :type session: :class:`ZuulSession`

--- a/cibyl/sources/zuul/apis/rest.py
+++ b/cibyl/sources/zuul/apis/rest.py
@@ -17,7 +17,10 @@ from urllib.parse import urljoin
 
 from requests import HTTPError, Session
 
-from cibyl.sources.zuul.api import ZuulAPI, ZuulAPIError, ZuulTenantAPI
+from cibyl.sources.zuul.api import (ZuulAPI,
+                                    ZuulAPIError,
+                                    ZuulTenantAPI,
+                                    ZuulJobAPI)
 
 
 class ZuulSession:
@@ -90,6 +93,27 @@ class ZuulSession:
             raise ZuulAPIError(f'Unknown error code {code}') from ex
 
 
+class ZuulJobRESTClient(ZuulJobAPI):
+    def __init__(self, session, tenant, job):
+        super().__init__(tenant, job)
+
+        self._session = session
+
+    def __eq__(self, other):
+        if not issubclass(type(other), ZuulJobAPI):
+            return False
+
+        if self is other:
+            return True
+
+        return self.tenant == other.tenant and self.name == other.name
+
+    def builds(self):
+        return self._session.get(
+            f'tenant/{self.tenant.name}/builds?job_name={self.name}'
+        )
+
+
 class ZuulTenantRESTClient(ZuulTenantAPI):
     """Implementation of a Zuul client through the use of Zuul's REST-API.
     """
@@ -111,7 +135,12 @@ class ZuulTenantRESTClient(ZuulTenantAPI):
         return self._session.get(f'tenant/{self.name}/buildsets')
 
     def jobs(self):
-        return self._session.get(f'tenant/{self.name}/jobs')
+        result = []
+
+        for job in self._session.get(f'tenant/{self.name}/jobs'):
+            result.append(ZuulJobRESTClient(self._session, self, job))
+
+        return result
 
 
 class ZuulRESTClient(ZuulAPI):

--- a/cibyl/sources/zuul/source.py
+++ b/cibyl/sources/zuul/source.py
@@ -27,16 +27,23 @@ class Zuul(Source):
     """
 
     class Jobs:
-        def __init__(self, parent):
-            """
+        """Extends actions that the source can do with regard to jobs.
+        """
 
-            :param parent:
+        def __init__(self, parent):
+            """Constructor.
+
+            :param parent: Source this extends.
             :type parent: :class:`Zuul`
             """
             self._parent = parent
 
         @property
         def api(self):
+            """
+            :return: Link this uses to perform queries with.
+            :rtype: :class:`cibyl.sources.zuul.api.ZuulAPI`
+            """
             return self._parent.api
 
         @staticmethod
@@ -73,6 +80,14 @@ class Zuul(Source):
             return f"{self._parent.url}/t/{tenant.name}/job/{job.name}"
 
         def get_jobs_in_zuul(self, **kwargs):
+            """Provides a link to the jobs present on the host that meet
+            the filters described on the keyed arguments.
+
+            :key jobs: Name of the desired jobs. Type: list[str].
+                Default: None.
+            :return: The jobs.
+            :rtype: list[:class:`sources.zuul.api.ZuulJobAPI`]
+            """
             result = []
 
             for tenant in self.api.tenants():
@@ -107,6 +122,10 @@ class Zuul(Source):
 
     @property
     def api(self):
+        """
+        :return: Link this uses to perform queries with.
+        :rtype: :class:`cibyl.sources.zuul.api.ZuulAPI`
+        """
         return self._api
 
     @staticmethod
@@ -117,8 +136,11 @@ class Zuul(Source):
         :type url: str
         :param cert: See :meth:`ZuulRESTClient.from_url`
         :type cert: str or None
-        :param kwargs:
-        :type kwargs: Any
+        :key name: Name of the source. Type: str. Default: 'zuul-ci'.
+        :key driver: Driver for this source. Type: str. Default: 'zuul'.
+        :key priority: Priority of the source. Type: int. Default: 0.
+        :key enabled: Whether this source is to be used.
+            Type: bool. Default: True.
         :return: The instance.
         """
         kwargs.setdefault('name', 'zuul-ci')

--- a/tests/sources/zuul/apis/test_rest.py
+++ b/tests/sources/zuul/apis/test_rest.py
@@ -16,10 +16,8 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from cibyl.sources.zuul.apis.rest import (ZuulRESTClient,
-                                          ZuulSession,
-                                          ZuulTenantRESTClient,
-                                          ZuulJobRESTClient)
+from cibyl.sources.zuul.apis.rest import (ZuulJobRESTClient, ZuulRESTClient,
+                                          ZuulSession, ZuulTenantRESTClient)
 
 
 class TestZuulSession(TestCase):
@@ -68,7 +66,12 @@ class TestZuulSession(TestCase):
 
 
 class TestZuulJobRESTClient(TestCase):
+    """Tests for :class:`ZuulJobRESTClient`.
+    """
+
     def test_equality(self):
+        """Checks '__eq__'.
+        """
         job = {
             'name': 'job'
         }
@@ -88,6 +91,9 @@ class TestZuulJobRESTClient(TestCase):
         self.assertEqual(ZuulJobRESTClient(session, tenant, job), client)
 
     def test_builds(self):
+        """Checks that the current steps are taken to get the builds
+        of this job.
+        """
         job = {
             'name': 'job'
         }

--- a/tests/sources/zuul/test_source.py
+++ b/tests/sources/zuul/test_source.py
@@ -69,6 +69,10 @@ class TestZuulGetJobs(TestCase):
         """Checks that the source is capable of retrieving all jobs on the
         remote alongside their appropriate data.
         """
+
+        def build_url(tenant, job):
+            return f"{url}/t/{tenant.name}/job/{job}"
+
         job1 = 'job_1'
         job2 = 'job_2'
 
@@ -77,9 +81,6 @@ class TestZuulGetJobs(TestCase):
         kwargs = {
             'jobs': Argument('name', list, '', value=[])
         }
-
-        def build_url(tenant, job):
-            return f"{url}/t/{tenant.name}/job/{job}"
 
         expected_jobs = {
             job1: Job(
@@ -92,11 +93,17 @@ class TestZuulGetJobs(TestCase):
             )
         }
 
+        client1 = Mock()
+        client2 = Mock()
+
+        client1.name = job1
+        client2.name = job2
+
         self.tenants[0].name = 'tenant1'
         self.tenants[1].name = 'tenant2'
 
-        self.tenants[0].jobs.return_value = [{'name': job1}]
-        self.tenants[1].jobs.return_value = [{'name': job2}]
+        self.tenants[0].jobs.return_value = [client1]
+        self.tenants[1].jobs.return_value = [client2]
 
         zuul = Zuul(self.api, 'zuul-ci', 'zuul', url)
 
@@ -118,11 +125,19 @@ class TestZuulGetJobs(TestCase):
             'jobs': Argument('name', list, '', value=[job1, job2])
         }
 
+        client1 = Mock()
+        client2 = Mock()
+        client3 = Mock()
+
+        client1.name = job1
+        client2.name = job2
+        client3.name = job3
+
         self.tenants[0].name.value = 'tenant1'
         self.tenants[1].name.value = 'tenant2'
 
-        self.tenants[0].jobs.return_value = [{'name': job1}]
-        self.tenants[1].jobs.return_value = [{'name': job2}, {'name': job3}]
+        self.tenants[0].jobs.return_value = [client1]
+        self.tenants[1].jobs.return_value = [client2, client3]
 
         zuul = Zuul(self.api, 'zuul-ci', 'zuul', 'http://localhost:8080')
 
@@ -180,15 +195,33 @@ class TestZuulGetBuilds(TestCase):
             'jobs': Argument('name', list, '', value=[])
         }
 
-        self.tenants[0].jobs.return_value = [{'name': job1}]
-        self.tenants[1].jobs.return_value = [{'name': job2}]
+        client1 = Mock()
+        client2 = Mock()
 
-        self.tenants[0].builds.return_value = [
-            {'uuid': build1, 'job_name': job1, 'result': 'success'}
+        client1.name = job1
+        client2.name = job2
+
+        client1.builds = Mock()
+        client2.builds = Mock()
+
+        client1.builds.return_value = [
+            {
+                'uuid': build1,
+                'job_name': job1,
+                'result': 'success'
+            }
         ]
-        self.tenants[1].builds.return_value = [
-            {'uuid': build2, 'job_name': job2, 'result': 'success'}
+
+        client2.builds.return_value = [
+            {
+                'uuid': build2,
+                'job_name': job2,
+                'result': 'success'
+            }
         ]
+
+        self.tenants[0].jobs.return_value = [client1]
+        self.tenants[1].jobs.return_value = [client2]
 
         zuul = Zuul(self.api, 'zuul-ci', 'zuul', 'http://localhost:8080')
 
@@ -216,15 +249,33 @@ class TestZuulGetBuilds(TestCase):
             'jobs': Argument('name', list, '', value=[job1])
         }
 
-        self.tenants[0].jobs.return_value = [{'name': job1}]
-        self.tenants[1].jobs.return_value = [{'name': job2}]
+        client1 = Mock()
+        client2 = Mock()
 
-        self.tenants[0].builds.return_value = [
-            {'uuid': build1, 'job_name': job1, 'result': 'success'}
+        client1.name = job1
+        client2.name = job2
+
+        client1.builds = Mock()
+        client2.builds = Mock()
+
+        client1.builds.return_value = [
+            {
+                'uuid': build1,
+                'job_name': job1,
+                'result': 'success'
+            }
         ]
-        self.tenants[1].builds.return_value = [
-            {'uuid': build2, 'job_name': job2, 'result': 'success'}
+
+        client2.builds.return_value = [
+            {
+                'uuid': build2,
+                'job_name': job2,
+                'result': 'success'
+            }
         ]
+
+        self.tenants[0].jobs.return_value = [client1]
+        self.tenants[1].jobs.return_value = [client2]
 
         zuul = Zuul(self.api, 'zuul-ci', 'zuul', 'http://localhost:8080')
 


### PR DESCRIPTION
Adding a new API to perform queries related to jobs. This allows for easier filtering of desired builds. This redesign was meant to implement the '--last-build- query, but I will wait for how https://github.com/rhos-infra/cibyl/pull/101 resolves first.