### PR TITLE
Allow model attributes outside init dictionary

### DIFF
--- a/cibyl/models/model.py
+++ b/cibyl/models/model.py
@@ -28,6 +28,6 @@ class Model:
             setattr(self, attribute_name,
                     attribute_class(
                         name=attribute_name,
-                        value=attributes[attribute_name],
+                        value=attributes.get(attribute_name),
                         arguments=attribute_dict.get('arguments', []),
                         attr_type=attribute_dict.get('attr_type')))


### PR DESCRIPTION
CI models' init calls the one from Model, passing an attributes
dictionary. Until now, all attributes were defined in this dictionary
and were always passed from the models init. However, with the
introduction of plugins this is not longer true, models might have
attributes in their API that are not defined in their init. For example
with the Openstack plugin, Job has now a deployment attribute, which is
not passed in its init. With this change, a Job will be created with and
empty deployment attribute, that the plugin should later populate or
extend the funcionality as needed.
