### PR TITLE
Rework system and environment validation from user input

### DIFF
--- a/cibyl/cli/validator.py
+++ b/cibyl/cli/validator.py
@@ -69,48 +69,69 @@ class Validator:
         :returns: Whether the system is consistent with user input
         :rtype: bool
         """
-        is_valid_system = True
         name = system.name.value
         system_type = system.system_type.value
+        system_sources = set(source.name for source in system.sources)
 
         user_system_type = self.ci_args.get("system_type")
         if user_system_type and system_type not in user_system_type.value:
-            is_valid_system = False
+            return False
 
         user_systems = self.ci_args.get("systems")
         if user_systems and name not in user_systems.value:
-            is_valid_system = False
+            return False
 
-        return is_valid_system
+        user_sources = self.ci_args.get("sources")
+        if user_sources:
+            user_sources_names = set(user_sources.value)
+            if not user_sources_names & system_sources:
+                return False
+
+        return True
 
     def validate_environments(self, environments):
         """Filter environments and systems according to user input.
 
-        :returns: Systems that can be used according to user input
-        :rtype: dict
+        :returns: Environments and systems that can be used according to user
+        input
+        :rtype: list, list
         """
-        user_systems = []
-        user_envs = []
         all_envs = []
         all_systems = []
+        # first get all environments and systems so we can ensure that the user
+        # input is found within the configuration
         for env in environments:
             all_envs.append(env.name.value)
+            for system in env.systems:
+                all_systems.append(system.name.value)
+        self._check_input_environments(all_envs, "env_name",
+                                       InvalidEnvironment)
+        self._check_input_environments(all_systems, "systems", InvalidSystem)
+
+        # if the user input is good, then filter the environments and systems
+        # so we only keep the ones consistent with user input
+        user_systems = []
+        user_envs = []
+        for env in environments:
+            env_systems = []
             if not self._consistent_environment(env):
                 LOG.debug("Environment %s is not consistent with user input",
                           env.name.value)
                 continue
-            user_envs.append(env)
             for system in env.systems:
-                all_systems.append(system.name.value)
                 if not self._consistent_system(system):
                     LOG.debug("System %s is not consistent with user input",
                               system.name.value)
-                    continue
-                user_systems.append(system)
 
-        self._check_input_environments(all_envs, "env_name",
-                                       InvalidEnvironment)
-        self._check_input_environments(all_systems, "systems", InvalidSystem)
+                    continue
+                env_systems.append(system)
+            if env_systems:
+                # if the environment has no valid systems, we will not pass it
+                # back, so for the rest of the execution we will only consider
+                # valid environments and systems
+                env.systems.value = env_systems
+                user_envs.append(env)
+                user_systems.extend(env_systems)
 
         if not user_systems:
             raise NoValidSystem(all_systems)

--- a/cibyl/exceptions/model.py
+++ b/cibyl/exceptions/model.py
@@ -26,22 +26,50 @@ Unable to populate system with pulled data"""
         super().__init__(self.message)
 
 
-class NoValidEnvironment(CibylException):
-    """Exception for a case when no valid environment is found."""
-
-    def __init__(self):
-        self.message = """No valid environments are defined.
-Please set at least one environment in the configuration file.
-"""
-        super().__init__(self.message)
-
-
 class NoValidSystem(CibylException):
     """Exception for a case when no valid system is found."""
 
-    def __init__(self):
-        self.message = """
-No valid system defined.
-Please ensure the specified systems are present in the configuration.
-"""
+    def __init__(self, valid_systems=None):
+        self.message = """No valid system defined."""
+        if valid_systems:
+            self.message += "\nPlease use one of the following available"
+            self.message += " systems:\n"
+            for system_name in valid_systems:
+                self.message += f"{system_name}\n"
+        else:
+            self.message += "\nPlease ensure the specified systems are present"
+            self.message += " in the configuration."
+        super().__init__(self.message)
+
+
+class InvalidEnvironment(CibylException):
+    """Exception for a case when no valid environment is found."""
+
+    def __init__(self, environment, valid_environments=None):
+        self.message = f"No such environment: {environment}"
+        if valid_environments:
+            self.message += "\nPlease use one of the following available"
+            self.message += " environments:\n"
+            for env_name in valid_environments:
+                self.message += f"{env_name}\n"
+        else:
+            self.message += "\nPlease set at least one environment in the "
+            self.message += "configuration file."
+
+        super().__init__(self.message)
+
+
+class InvalidSystem(CibylException):
+    """Exception for a case when non existing system is passed by the user."""
+
+    def __init__(self, system, valid_systems=None):
+        self.message = f"No such system: {system}"
+        if valid_systems:
+            self.message += "\nPlease use one of the following available"
+            self.message += " systems:\n"
+            for system_name in valid_systems:
+                self.message += f"{system_name}\n"
+        else:
+            self.message += "\nPlease ensure the specified systems are present"
+            self.message += " in the configuration."
         super().__init__(self.message)

--- a/tests/cli/test_validator.py
+++ b/tests/cli/test_validator.py
@@ -40,7 +40,13 @@ class TestValidator(TestCase):
                 },
                 'env1': {
                     'system1': {
-                        'system_type': 'zuul'}
+                        'system_type': 'zuul',
+                        'sources': {
+                            'zuul': {
+                                'driver': 'zuul',
+                                'url': ''
+                                }
+                            }}
                 }
             }
         }
@@ -143,3 +149,19 @@ class TestValidator(TestCase):
         self.assertRaises(InvalidSystem,
                           validator.validate_environments,
                           original_envs)
+
+    def test_validtor_validate_sources(self):
+        """Test Validator validate_environments with sources."""
+        self.orchestrator.config.data = self.config
+        self.orchestrator.create_ci_environments()
+        self.ci_args["sources"] = Mock()
+        self.ci_args["sources"].value = ["zuul"]
+
+        validator = Validator(self.ci_args)
+        original_envs = self.orchestrator.environments
+        envs, systems = validator.validate_environments(original_envs)
+        self.assertEqual(1, len(envs))
+        self.assertEqual(1, len(systems))
+        self.assertEqual("system1", systems[0].name.value)
+        self.assertEqual("zuul", systems[0].system_type.value)
+        self.assertEqual("env1", envs[0].name.value)

--- a/tests/cli/test_validator.py
+++ b/tests/cli/test_validator.py
@@ -17,7 +17,8 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from cibyl.cli.validator import Validator
-from cibyl.exceptions.model import NoValidEnvironment, NoValidSystem
+from cibyl.exceptions.model import (InvalidEnvironment, InvalidSystem,
+                                    NoValidSystem)
 from cibyl.orchestrator import Orchestrator
 
 
@@ -97,6 +98,22 @@ class TestValidator(TestCase):
         self.assertEqual("system3", systems[0].name.value)
         self.assertEqual("jenkins", systems[0].system_type.value)
 
+    def tests_validator_validate_environments_system_type_no_systems(self):
+        """Testing Validator validate_environment method."""
+        self.orchestrator.config.data = self.config
+        self.orchestrator.create_ci_environments()
+        self.ci_args["env_name"] = Mock()
+        self.ci_args["env_name"].value = ["env"]
+        self.ci_args["system_type"] = Mock()
+        self.ci_args["system_type"].value = ["unk"]
+
+        validator = Validator(self.ci_args)
+        original_envs = self.orchestrator.environments
+
+        self.assertRaises(NoValidSystem,
+                          validator.validate_environments,
+                          original_envs)
+
     def tests_validator_validate_environments_no_envs(self):
         """Testing Validator validate_environment method."""
         self.orchestrator.config.data = self.config
@@ -109,7 +126,7 @@ class TestValidator(TestCase):
         validator = Validator(self.ci_args)
         original_envs = self.orchestrator.environments
 
-        self.assertRaises(NoValidEnvironment,
+        self.assertRaises(InvalidEnvironment,
                           validator.validate_environments,
                           original_envs)
 
@@ -123,6 +140,6 @@ class TestValidator(TestCase):
         validator = Validator(self.ci_args)
         original_envs = self.orchestrator.environments
 
-        self.assertRaises(NoValidSystem,
+        self.assertRaises(InvalidSystem,
                           validator.validate_environments,
                           original_envs)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -18,7 +18,6 @@ from unittest.mock import Mock, patch
 
 from cibyl.config import Config
 from cibyl.exceptions.config import InvalidConfiguration
-from cibyl.exceptions.model import NoValidEnvironment
 from cibyl.exceptions.source import NoValidSources
 from cibyl.orchestrator import Orchestrator
 
@@ -79,10 +78,6 @@ class TestOrchestrator(TestCase):
         self.orchestrator.load_configuration()
 
         self.orchestrator.config.load.assert_called()
-
-    def test_orchestrator_query_empty(self):
-        """Testing Orchestrator query method"""
-        self.assertRaises(NoValidEnvironment, self.orchestrator.run_query)
 
     def test_orchestrator_create_ci_environments(self):
         """Testing Orchestartor query method"""


### PR DESCRIPTION
This change modifies the behaviour of the validation of environments and systems from user input:

1. After the validation, only environments and systems consistent with user input will be kept to avoid printing any information about systems that are not used.
2. If the user asks for a non-existing system or environment, the exception will print all the available systems or environments. This removes the NoValidEnvironment exception, that will no longer be needed, but keeps the NoValidSystem one, that might be necessary if user queries by system type and no system is found.
3. Adds a check for --sources in the validation. If --sources is provided, only those systems with sources consistent with user input will be kept.
