### PR TITLE
Adapt get builds to new sources changes

### DIFF
--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -129,18 +129,19 @@ class ElasticSearchOSP(Source):
                 job.add_build(Build(str(build['_source']['build_id']),
                                     build["_source"]['build_result']))
 
+        if 'last_build' in kwargs:
+            return self.get_last_build(jobs_found)
+
         return jobs_found
 
-    def get_last_build(self: object, **kwargs: Argument):
+    def get_last_build(self: object, builds_jobs: AttributeDictValue):
         """
-            Get last build for jobs from elasticsearch server.
-            It uses the `method:get_builds` implemented in this class
+            Get last build from builds. It's determinated
+            by the build_id
 
             :returns: container of jobs with last build information
             :rtype: :class:`AttributeDictValue`
         """
-        builds_jobs = self.get_builds(**kwargs)
-
         job_object = {}
         for job_name, build_info in builds_jobs.items():
             builds = build_info.builds


### PR DESCRIPTION
**Change**: use the same get_last_build method to pass filter and get the last build.

In this case we can not just filter by status but the last build at the same time too.

So we can:

1. Get the last build from all builds of the job
2. Get the builds by status
3. Get all builds filtered by status and at the same time get the last build of this case