### PR TITLE
Print only two decimals for build duration

### DIFF
--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -51,7 +51,7 @@ class Build(Model):
             build_str += f"\n{indent_space}  Status: {self.status.value}"
         if verbosity > 0 and self.duration.value:
             duration_in_min = self.duration.value / 60000
-            build_str += f"\n{indent_space}  Duration: {duration_in_min}m"
+            build_str += f"\n{indent_space}  Duration: {duration_in_min:.2f}m"
         return build_str
 
     def __eq__(self, other):


### PR DESCRIPTION
This simple change prints only two decimals for the build duration. Before it
would print often many more decimals than I think are required to show the
duration of a build.
