### PR TITLE
Adding Zuul environment for E2E testing.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyyaml~=6.0
+pyyaml>=5.0
 requests~=2.27.1
 elasticsearch~=7.17.1
 colorlog~=6.6.0

--- a/tests/e2e/configs/zuul.yaml
+++ b/tests/e2e/configs/zuul.yaml
@@ -1,0 +1,9 @@
+---
+environments:
+  env_1:
+    zuul_system:
+      system_type: zuul
+      sources:
+        osp_zuul:
+          driver: zuul
+          url: 'http://localhost:9000/'

--- a/tests/e2e/fixture/__init__.py
+++ b/tests/e2e/fixture/__init__.py
@@ -1,0 +1,84 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import os.path
+import sys
+from io import StringIO
+from tempfile import TemporaryDirectory
+from time import sleep
+from unittest import TestCase
+
+from git import Repo
+from testcontainers.compose import DockerCompose
+
+
+class EndToEndTest(TestCase):
+    def setUp(self):
+        self.buffer = StringIO()
+
+        sys.stdout = self.buffer
+
+    @property
+    def output(self):
+        return self.buffer.getvalue()
+
+
+class JenkinsTest(EndToEndTest):
+    jenkins = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.jenkins = DockerCompose(
+            filepath='tests/e2e/images/jenkins',
+            pull=True
+        )
+
+        # Launch the container
+        cls.jenkins.start()
+
+        # Wait for container to start
+        sleep(10)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.jenkins.stop()
+
+
+class ZuulTest(EndToEndTest):
+    dir = None
+    zuul = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dir = TemporaryDirectory()
+
+        Repo.clone_from('https://opendev.org/zuul/zuul', cls.dir.name)
+
+        cls.zuul = DockerCompose(
+            filepath=os.path.join(cls.dir.name, 'doc/source/examples'),
+            compose_file_name=['docker-compose.yaml'],
+            pull=True
+        )
+
+        # Launch the container
+        cls.zuul.start()
+
+        # Wait for container to start
+        sleep(10)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.zuul.stop()
+        cls.dir.cleanup()

--- a/tests/e2e/images/jenkins/docker-compose.yml
+++ b/tests/e2e/images/jenkins/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+services:
+  jenkins:
+    build: .
+    ports:
+      - "8080:8080"
+      - "50000:50000"
+    environment:
+      - JENKINS_ADMIN_ID=admin
+      - JENKINS_ADMIN_PASSWORD=passw

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,0 +1,3 @@
+testcontainers~=3.4.2
+docker-compose~=1.29.2
+GitPython~=3.1.18

--- a/tests/e2e/test_zuul.py
+++ b/tests/e2e/test_zuul.py
@@ -16,15 +16,15 @@
 import sys
 
 from cibyl.cli.main import main
-from tests.e2e.fixture import JenkinsTest
+from tests.e2e.fixture import ZuulTest
 
 
-class TestJenkins(JenkinsTest):
-    def test_get_jobs(self):
+class TestZuul(ZuulTest):
+    def test_zuul(self):
         sys.argv = [
             '',
             '--config',
-            'tests/e2e/configs/jenkins.yaml',
+            'tests/e2e/configs/zuul.yaml',
             '--jobs',
             '-vv'
         ]

--- a/tox.ini
+++ b/tox.ini
@@ -5,17 +5,7 @@ skipsdist = True
 ignore_basepython_conflict = True
 skip_missing_interpreters = False
 requires =
-    tox-docker; python_version >= '3.8'
     tox-extra; python_version >= '3.8'
-
-[docker:jenkins]
-image = cre/jenkins
-environment =
-    JENKINS_ADMIN_ID=admin
-    JENKINS_ADMIN_PASSWORD=passw
-ports =
-    8080:8080/tcp
-    50000:50000/tcp
 
 [gh-actions]
 python =
@@ -42,12 +32,9 @@ commands =
     python -m unittest discover tests/unit
 
 [testenv:e2e]
-docker =
-    jenkins
 deps =
     -r {toxinidir}/requirements.txt
-whitelist_externals = bash
-commands_pre = bash -c 'sleep 10' # Wait for containers to be ready
+    -r {toxinidir}/tests/e2e/requirements.txt
 commands = python -m unittest discover tests/e2e
 
 [testenv:coverage]


### PR DESCRIPTION
Remade how e2e testing is performed so it is possible to use Docker-Compose. The new implementation is based around the testcontainers library.

Benefits:
- Independence from Tox.
- Docker-Compose.
- All set up defined on code.
- Test fixtures to remove boilerplate.