### PR TITLE
Introduce speed index mechanism

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -34,7 +34,8 @@ def raw_parsing(arguments):
     """
     args = {'config_file_path': None, 'help': False,
             "log_file": "cibyl_output.log", "log_mode": "both",
-            "logging": logging.INFO, "plugins": [DEFAULT_PLUGIN]}
+            "logging": logging.INFO, "plugins": [DEFAULT_PLUGIN],
+            "debug": False}
     for i, item in enumerate(arguments[1:]):
         if item == "--config":
             args['config_file_path'] = arguments[i + 2]
@@ -46,6 +47,9 @@ def raw_parsing(arguments):
             args["log_mode"] = arguments[i + 2]
         elif item in ('-d', '--debug'):
             args["logging"] = logging.DEBUG
+            # add both arguments so that the checking code to enable the
+            # exception traceback is clearer
+            args["debug"] = True
         elif item in ('-p', '--plugin'):
             plugins = []
             for argument in arguments[(i + 2):]:

--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -34,7 +34,7 @@ def raw_parsing(arguments):
     """
     args = {'config_file_path': None, 'help': False,
             "log_file": "cibyl_output.log", "log_mode": "both",
-            "debug": False, "plugins": [DEFAULT_PLUGIN]}
+            "logging": logging.INFO, "plugins": [DEFAULT_PLUGIN]}
     for i, item in enumerate(arguments[1:]):
         if item == "--config":
             args['config_file_path'] = arguments[i + 2]
@@ -44,8 +44,8 @@ def raw_parsing(arguments):
             args["log_file"] = arguments[i + 2]
         elif item == "--log-mode":
             args["log_mode"] = arguments[i + 2]
-        elif item == "--debug":
-            args["debug"] = True
+        elif item in ('-d', '--debug'):
+            args["logging"] = logging.DEBUG
         elif item in ('-p', '--plugin'):
             plugins = []
             for argument in arguments[(i + 2):]:
@@ -65,7 +65,9 @@ def main():
     arguments = raw_parsing(sys.argv)
     if not arguments['debug']:
         CibylException.setup_quiet_exceptions()
-    configure_logging(arguments)
+    configure_logging(arguments.get('log_mode'),
+                      arguments.get('log_file'),
+                      arguments.get('logging'))
 
     plugins = arguments.get('plugins')
     if plugins:

--- a/cibyl/exceptions/source.py
+++ b/cibyl/exceptions/source.py
@@ -16,28 +16,6 @@
 from cibyl.exceptions import CibylException
 
 
-class TooManyValidSources(CibylException):
-    """Exception for trying to use multiple supported sources."""
-
-    def __init__(self, system):
-        self.system = system
-        self.message = f"""You have more than one source defined for the system
- {self.system}.
-Please either specify one source with --source argument or set higher
-priority for the source
-in the configuration, this way:
-
-environments:
-    env_1:
-        jenkins_system:
-            system_type: jenkins
-                 sources:
-                   jenkins:
-                     priority: 1
-"""
-        super().__init__(self.message)
-
-
 class NoSupportedSourcesFound(CibylException):
     """Exception for a case where non of the sources of a single system is
        implementing the function of the argument the user is interested in

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -126,7 +126,7 @@ class Orchestrator:
         if not system_sources:
             raise NoValidSources(system)
         return get_source_method(system.name.value, system_sources,
-                                 argument.func)
+                                 argument.func, args=self.parser.ci_args)
 
     def run_query(self, start_level=1):
         """Execute query based on provided arguments."""
@@ -158,6 +158,8 @@ class Orchestrator:
                         continue
                     source_methods_store.add_call(source_method)
                     start_time = time.time()
+                    LOG.debug(f"Running {source_method.__name__} method \
+from {source_method.__self__.get('driver')}")
                     model_instances_dict = source_method(
                         **self.parser.ci_args, **self.parser.app_args)
                     end_time = time.time()

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -51,7 +51,7 @@ class ElasticSearchOSP(Source):
                       from exception
             self.es_client = ElasticSearchClient(host, port)
 
-    @speed_index({'jobs': 3})
+    @speed_index({'base': 1})
     def get_jobs(self: object, **kwargs: Argument) -> list:
         """Get jobs from elasticsearch
 
@@ -99,6 +99,7 @@ class ElasticSearchOSP(Source):
                   from exception
         return response['hits']['hits']
 
+    @speed_index({'base': 2})
     def get_builds(self: object, **kwargs: Argument):
         """
             Get builds from elasticsearch server.
@@ -168,6 +169,7 @@ class ElasticSearchOSP(Source):
 
         return AttributeDictValue("jobs", attr_type=Job, value=job_object)
 
+    @speed_index({'base': 2})
     def get_deployment(self, **kwargs):
         """Get deployment information for jobs from elasticsearch server.
 

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -24,7 +24,7 @@ from cibyl.models.ci.build import Build
 from cibyl.models.ci.job import Job
 from cibyl.plugins.openstack.deployment import Deployment
 from cibyl.sources.elasticsearch.client import ElasticSearchClient
-from cibyl.sources.source import Source
+from cibyl.sources.source import Source, speed_index
 from cibyl.utils.filtering import IP_PATTERN
 
 LOG = logging.getLogger(__name__)
@@ -51,6 +51,7 @@ class ElasticSearchOSP(Source):
                       from exception
             self.es_client = ElasticSearchClient(host, port)
 
+    @speed_index({'jobs': 3})
     def get_jobs(self: object, **kwargs: Argument) -> list:
         """Get jobs from elasticsearch
 

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -221,7 +221,7 @@ class Jenkins(Source):
 
         return json.loads(response.text)
 
-    @speed_index({'jobs': 2, 'job_url': 2, 'builds': 1})
+    @speed_index({'base': 2})
     def get_jobs(self, **kwargs):
         """
             Get jobs from jenkins server.
@@ -239,6 +239,7 @@ class Jenkins(Source):
 
         return AttributeDictValue("jobs", attr_type=Job, value=job_objects)
 
+    @speed_index({'base': 1, 'last_build': 1})
     def get_builds(self, **kwargs):
         """
             Get builds from jenkins server.
@@ -298,6 +299,7 @@ try reducing verbosity for quicker query")
 
         return AttributeDictValue("jobs", attr_type=Job, value=job_objects)
 
+    @speed_index({'base': 2})
     def get_deployment(self, **kwargs):
         """Get deployment information for jobs from jenkins server.
 

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -30,7 +30,7 @@ from cibyl.models.ci.build import Build
 from cibyl.models.ci.job import Job
 from cibyl.plugins.openstack.deployment import Deployment
 from cibyl.plugins.openstack.utils import translate_topology_string
-from cibyl.sources.source import Source, safe_request_generic
+from cibyl.sources.source import Source, safe_request_generic, speed_index
 from cibyl.utils.filtering import (IP_PATTERN, PROPERTY_PATTERN,
                                    RELEASE_PATTERN, TOPOLOGY_PATTERN,
                                    apply_filters,
@@ -221,6 +221,7 @@ class Jenkins(Source):
 
         return json.loads(response.text)
 
+    @speed_index({'jobs': 2, 'job_url': 2, 'builds': 1})
     def get_jobs(self, **kwargs):
         """
             Get jobs from jenkins server.

--- a/cibyl/sources/jenkins_job_builder.py
+++ b/cibyl/sources/jenkins_job_builder.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from cibyl.exceptions.jenkins_job_builder import JenkinsJobBuilderError
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.job import Job
-from cibyl.sources.source import Source, safe_request_generic
+from cibyl.sources.source import Source, safe_request_generic, speed_index
 
 LOG = logging.getLogger(__name__)
 
@@ -106,6 +106,7 @@ class JenkinsJobBuilder(Source):
         """Use tox to generate jenkins job xml files."""
         subprocess.run(["tox",  "-e", "jobs"], check=True, cwd=self.dest)
 
+    @speed_index({'jobs': 1})
     def get_jobs(self, **kwargs):
         """Get all jobs from jenkins server.
 

--- a/cibyl/sources/jenkins_job_builder.py
+++ b/cibyl/sources/jenkins_job_builder.py
@@ -106,7 +106,7 @@ class JenkinsJobBuilder(Source):
         """Use tox to generate jenkins job xml files."""
         subprocess.run(["tox",  "-e", "jobs"], check=True, cwd=self.dest)
 
-    @speed_index({'jobs': 1})
+    @speed_index({'base': 1})
     def get_jobs(self, **kwargs):
         """Get all jobs from jenkins server.
 

--- a/cibyl/sources/zuul/source.py
+++ b/cibyl/sources/zuul/source.py
@@ -43,7 +43,6 @@ class Zuul(Source):
             self._parent = parent
             self._api = api
 
-        @speed_index({'jobs': 3})
         def get_jobs(self, fetch_builds=False, **kwargs):
             """Gets a set of jobs from the host formatted with the job model.
 
@@ -196,6 +195,7 @@ class Zuul(Source):
 
         return Zuul(api=ZuulRESTClient.from_url(url, cert), url=url, **kwargs)
 
+    @speed_index({'base': 3})
     def get_jobs(self, **kwargs):
         """Retrieves jobs present on the host.
 
@@ -206,6 +206,7 @@ class Zuul(Source):
         """
         return self._api.get_jobs(fetch_builds=False, **kwargs)
 
+    @speed_index({'base': 3})
     def get_builds(self, **kwargs):
         """Retrieves builds present on the host.
 

--- a/cibyl/sources/zuul/source.py
+++ b/cibyl/sources/zuul/source.py
@@ -18,7 +18,7 @@ from itertools import chain
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.build import Build
 from cibyl.models.ci.job import Job
-from cibyl.sources.source import Source
+from cibyl.sources.source import Source, speed_index
 from cibyl.sources.zuul.apis.rest import ZuulRESTClient
 from cibyl.utils.filtering import apply_filters
 
@@ -43,6 +43,7 @@ class Zuul(Source):
             self._parent = parent
             self._api = api
 
+        @speed_index({'jobs': 3})
         def get_jobs(self, fetch_builds=False, **kwargs):
             """Gets a set of jobs from the host formatted with the job model.
 

--- a/cibyl/utils/logger.py
+++ b/cibyl/utils/logger.py
@@ -62,8 +62,12 @@ def configure_file_logging(log_file, level):
 def configure_logging(log_mode, log_file, level=logging.INFO):
     """Configure logging format and level.
 
-    :param log_config: Configuration for the logger
-    :type log_config: dict
+    :param log_mode: Where to send the logs, file, terminal or both
+    :type log_mode: str
+    :param log_file: Path to log file
+    :param log_file: str
+    :param level: Logging level, default DEBUG
+    :type level: int
     """
     # configure a top-level cibyl logger instead of the root logger,
     # to suppress logging coming from other libraries

--- a/cibyl/utils/logger.py
+++ b/cibyl/utils/logger.py
@@ -59,23 +59,17 @@ def configure_file_logging(log_file, level):
     logger.addHandler(file_handler)
 
 
-def configure_logging(log_config, level=logging.INFO):
+def configure_logging(log_mode, log_file, level=logging.INFO):
     """Configure logging format and level.
 
     :param log_config: Configuration for the logger
     :type log_config: dict
-    :param level: Logging level, default DEBUG
-    :type level: int
     """
-    if log_config.get("debug", False):
-        level = logging.DEBUG
     # configure a top-level cibyl logger instead of the root logger,
     # to suppress logging coming from other libraries
     logger = logging.getLogger('cibyl')
     logger.setLevel(level)
 
-    log_mode = log_config["log_mode"]
-    log_file = log_config["log_file"]
     if log_mode == "terminal":
         configure_terminal_logging(level)
     elif log_mode == "file":

--- a/tests/unit/sources/test_sources.py
+++ b/tests/unit/sources/test_sources.py
@@ -14,11 +14,9 @@
 #    under the License.
 """
 from unittest import TestCase
-from unittest.mock import Mock, call
+from unittest.mock import Mock
 
-import cibyl
-from cibyl.exceptions.source import TooManyValidSources
-from cibyl.sources.source import get_source_method, is_source_valid
+from cibyl.sources.source import is_source_valid
 
 
 class TestIsSourceValid(TestCase):
@@ -54,27 +52,3 @@ class TestIsSourceValid(TestCase):
         source.func = Mock()
 
         self.assertTrue(is_source_valid(source, 'func'))
-
-
-class TestGetSourceMethod(TestCase):
-    """Tests for the get_source_method static function."""
-
-    def test_no_more_than_two_valid_sources_allowed(self):
-        """Checks that only a single source is allowed to provide the
-        desired function.
-        """
-        func = 'func'
-
-        source1 = Mock()
-        source2 = Mock()
-
-        validity_check = cibyl.sources.source.is_source_valid = Mock()
-        validity_check.return_value = True
-
-        with self.assertRaises(TooManyValidSources):
-            get_source_method('system', [source1, source2], func)
-
-        validity_check.assert_has_calls([
-            call(source1, func),
-            call(source2, func)
-        ])

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -140,7 +140,8 @@ class TestOrchestrator(TestCase):
         argument = Mock()
         argument.func = None
         self.orchestrator.select_source_method(system, argument)
-        patched_method.assert_called_with("system", [source], None)
+        patched_method.assert_called_with(
+            "system", [source], None, args=self.orchestrator.parser.ci_args)
 
     def test_orchestrator_select_source_invalid_source(self):
         """Testing Orchestrator select_source_method method with no valid


### PR DESCRIPTION
Right now, users will get an error if they use more
than one source that supports the argument they have used
as part of the CLI usage.

This far from optimal user experience because we don't
want to:
1. Stop cibyl execution just because user has choice, while
   we know exactly what the user is interested in
2. Let the user figure out alone which source is the best
   for each type of argument or query perfomed

This change tries to change this behavior and introduce
a mechanism which will allow developers to quite easily
specify the relative speed of not only the source they
are developing, but the speed of each argument in each
function used during the execution.

The mechanism will aggregate the score from each argument
(assuming it exists in the first place) and if the overall
score is bigger than the score of another source, then that
source will be the preferred one for the execution.

If no speed data is available, then the choice will be arbitrary,
but will not stop the execution anymore.
