### PR TITLE
Pass DOCKER_HOST environment variable to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ commands =
     python -m unittest discover tests/unit
 
 [testenv:e2e]
+passenv =
+    DOCKER_HOST
 deps =
     -r {toxinidir}/requirements.txt
     -r {toxinidir}/tests/e2e/requirements.txt


### PR DESCRIPTION
This variable enables a workaround to use podman to run the e2e tests.
