### PR TITLE
Add support for --topology argument in jenkins

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -59,15 +59,22 @@ class Deployment(Model):
                                    func='get_deployment', nargs='*',
                                    description="Ip version used in the "
                                    "deployment")]
+            },
+        'topology': {
+            'attr_type': str,
+            'arguments': [Argument(name='--topology', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   description="Topology used in the "
+                                   "deployment")]
             }
     }
 
     def __init__(self, release: float, infra_type: str,
                  nodes: List[Node], services: List[Service],
-                 ip_version: str = None):
+                 ip_version: str = None, topology: str = None):
         super().__init__({'release': release, 'infra_type': infra_type,
                           'nodes': nodes, 'services': services,
-                          'ip_version': ip_version})
+                          'ip_version': ip_version, 'topology': topology})
 
     def __str__(self, indent=0, verbosity=0):
         indent_space = indent*' '
@@ -79,10 +86,13 @@ class Deployment(Model):
         for node in self.nodes:
             info += f'\n{indent_space}  '
             info += f'{node.__str__(indent=indent+2, verbosity=verbosity)}'
-        if self.services:
+        if self.services.value:
             info += f'\n{indent_space}' + Colors.blue('Service: ')
             info += f'{self.services.value}'
-        if self.ip_version:
+        if self.ip_version.value:
             info += f'\n{indent_space}' + Colors.blue('IP version: ')
             info += f'{self.ip_version}'
+        if self.topology.value:
+            info += f'\n{indent_space}' + Colors.blue('Topology: ')
+            info += f'{self.topology}'
         return info

--- a/cibyl/plugins/openstack/utils.py
+++ b/cibyl/plugins/openstack/utils.py
@@ -1,0 +1,65 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import logging
+import re
+
+LOG = logging.getLogger(__name__)
+SHORT_TOPOLOGY_PATTERN = re.compile(r"(\d)+(.*)")
+
+
+class TopologyAbbreviations:
+    """Translate the typical abbreviation used in the topology of openstack
+    deployments."""
+    abbreviations = {'comp': 'compute', 'cont': 'controller', 'ceph': 'ceph',
+                     'freeipa': 'freeipa', 'net': 'networker',
+                     'novactl': 'novacontrol'}
+
+    @staticmethod
+    def translate(abbreviation):
+        """Translate an abbreviation into a long form name of a component of an
+        openstack deployment topology. If the short form does not have a long
+        form associated, return the short form.
+
+        :param abbreviation: Short form of the component
+        :type abbreviation: str
+        :returns: The long form name of the component
+        :rtype: str
+        """
+        return TopologyAbbreviations.abbreviations.get(abbreviation,
+                                                       abbreviation)
+
+
+def translate_topology_string(short_topology: str):
+    """Translate a topology string in short form (as typically found in job
+    names) to a long form one.
+
+    :param short_topology: Openstack topology in short form
+    :type short_topology: str
+    :returns: The long form topology string
+    :rtype: str
+    """
+    topology = short_topology.split("_")
+    long_topology = []
+    for component in topology:
+        match_string = SHORT_TOPOLOGY_PATTERN.search(component)
+        if not match_string:
+            LOG.debug("component %s in topology string %s not identified",
+                      component, short_topology)
+            continue
+        number = match_string.group(1)
+        component_long = TopologyAbbreviations.translate(match_string.group(2))
+        long_topology.append(f"{component_long}:{number}")
+    return ",".join(long_topology)

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -33,8 +33,9 @@ class ElasticSearchOSP(Source):
 
     def __init__(self: object, driver: str = 'elasticsearch',
                  name: str = "elasticsearch", priority: int = 0,
-                 **kwargs) -> None:
-        super().__init__(name=name, driver=driver, priority=priority)
+                 enabled: bool = True, **kwargs) -> None:
+        super().__init__(name=name, driver=driver, priority=priority,
+                         enabled=enabled)
 
         if 'elastic_client' in kwargs:
             self.es_client = kwargs.get('elastic_client')

--- a/tests/unit/plugins/test_openstack.py
+++ b/tests/unit/plugins/test_openstack.py
@@ -19,6 +19,7 @@ from cibyl.models.ci.environment import Environment
 from cibyl.models.ci.job import Job
 from cibyl.plugins import extend_models
 from cibyl.plugins.openstack.deployment import Deployment
+from cibyl.plugins.openstack.utils import translate_topology_string
 
 
 class TestOpenstackPlugin(TestCase):
@@ -69,3 +70,28 @@ class TestJobWithPlugin(TestCase):
         job_str = self.job.__str__(indent=2, verbosity=2)
         self.assertNotIn("Release: ", job_str)
         self.assertNotIn("Infra type: ", job_str)
+
+
+class TestOpenstackPluginUtils(TestCase):
+    """Test openstack plugin utils module."""
+    def test_translate_toplogy_string(self):
+        """Test normal usage of translate_topology_string function."""
+        input_str = "1comp_2cont_2ceph_3freeipa_5net_1novactl"
+        expected = "compute:1,controller:2,ceph:2,freeipa:3,networker:5,"
+        expected += "novacontrol:1"
+        output = translate_topology_string(input_str)
+        self.assertEqual(expected, output)
+
+    def test_translate_toplogy_string_non_existing(self):
+        """Test test_translate_toplogy_string with an unknown type."""
+        input_str = "1comp_2cont_2ceph_3freeipa_1unk"
+        expected = "compute:1,controller:2,ceph:2,freeipa:3,unk:1"
+        output = translate_topology_string(input_str)
+        self.assertEqual(expected, output)
+
+    def test_translate_toplogy_string_malformed_component(self):
+        """Test test_translate_toplogy_string with an malformed comonent."""
+        input_str = "1comp_2cont_2ceph_3freeipa_unk"
+        expected = "compute:1,controller:2,ceph:2,freeipa:3"
+        output = translate_topology_string(input_str)
+        self.assertEqual(expected, output)

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -215,13 +215,49 @@ class TestJenkinsSource(TestCase):
             verify=self.jenkins.cert, timeout=None
         )
 
+    @patch("requests.get")
+    def test_send_request_with_item(self, patched_get):
+        """
+            Test that send_request method parses the response correctly.
+        """
+        response = {'jobs': [{'_class': 'org..job.WorkflowRun',
+                              'name': "ansible", 'url': 'url1'}]}
+        patched_get.return_value = Mock(text=json.dumps(response))
+        self.assertEqual(response, self.jenkins.send_request("test",
+                                                             item="item"))
+        api_part = "item/api/jsontest"
+        patched_get.assert_called_with(
+            f'://{self.jenkins.username}:{self.jenkins.token}@/{api_part}',
+            verify=self.jenkins.cert, timeout=None
+        )
+
+    @patch("requests.get")
+    def test_send_request_with_raw_response(self, patched_get):
+        """
+            Test that send_request returns the raw response.
+        """
+        response = {'jobs': [{'_class': 'org..job.WorkflowRun',
+                              'name': "ansible", 'url': 'url1'}]}
+        response = json.dumps(response)
+        patched_get.return_value = Mock(text=response)
+        self.assertEqual(response,
+                         self.jenkins.send_request("test", raw_response=True))
+
+        api_part = "api/jsontest"
+        patched_get.assert_called_with(
+            f'://{self.jenkins.username}:{self.jenkins.token}@/{api_part}',
+            verify=self.jenkins.cert, timeout=None
+        )
+
     def test_get_deployment(self):
         """ Test that get_deployment reads properly the information obtained
         from jenkins.
         """
-        job_names = ['test_17.3_ipv4_job', 'test_16_ipv6_job', 'test_job']
+        job_names = ['test_17.3_ipv4_job_2comp_1cont',
+                     'test_16_ipv6_job_1comp_2cont', 'test_job']
         ip_versions = ['4', '6', 'unknown']
         releases = ['17.3', '16', '']
+        topologies = ["compute:2,controller:1", "compute:1,controller:2", ""]
 
         response = {'jobs': [{'_class': 'folder'}]}
         for job_name in job_names:
@@ -235,7 +271,8 @@ class TestJenkinsSource(TestCase):
 
         jobs = self.jenkins.get_deployment(ip_version=arg)
         self.assertEqual(len(jobs), 3)
-        for job_name, ip, release in zip(job_names, ip_versions, releases):
+        for job_name, ip, release, topology in zip(job_names, ip_versions,
+                                                   releases, topologies):
             job = jobs[job_name]
             deployment = job.deployment.value
             self.assertEqual(job.name.value, job_name)
@@ -243,6 +280,118 @@ class TestJenkinsSource(TestCase):
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
             self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(deployment.topology.value, topology)
+
+    def test_get_deployment_many_jobs(self):
+        """ Test that get_deployment reads properly the information obtained
+        from jenkins.
+        """
+        job_names = ['test_17.3_ipv4_job_2comp_1cont',
+                     'test_16_ipv6_job_1comp_2cont', 'test_job']
+        ip_versions = ['4', '6', 'unknown']
+        releases = ['17.3', '16', '']
+        topologies = ["compute:2,controller:1", "compute:1,controller:2", ""]
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastBuild': None})
+        for _ in range(12):
+            # ensure that there are more than 12 jobs and jenkins source gets
+            # deployment information from job name
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': 'test_job', 'url': 'url',
+                                     'lastBuild': None})
+
+        self.jenkins.send_request = Mock(side_effect=[response])
+        arg = Mock()
+        arg.value = []
+
+        jobs = self.jenkins.get_deployment(ip_version=arg)
+        self.assertEqual(len(jobs), 3)
+        for job_name, ip, release, topology in zip(job_names, ip_versions,
+                                                   releases, topologies):
+            job = jobs[job_name]
+            deployment = job.deployment.value
+            self.assertEqual(job.name.value, job_name)
+            self.assertEqual(job.url.value, "url")
+            self.assertEqual(len(job.builds.value), 0)
+            self.assertEqual(deployment.release.value, release)
+            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(deployment.topology.value, topology)
+
+    def test_get_deployment_artifacts_fallback(self):
+        """ Test that get_deployment falls back to reading job_names after
+        failing to find artifacts.
+        """
+        job_names = ['test_17.3_ipv4_job_2comp_1cont',
+                     'test_16_ipv6_job_1comp_2cont', 'test_job']
+        ip_versions = ['4', '6', 'unknown']
+        releases = ['17.3', '16', '']
+        topologies = ["compute:2,controller:1", "compute:1,controller:2", ""]
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastBuild': {}})
+        # each job triggers 2 artifacts requests, if both fail, fallback to
+        # search the name
+        artifacts_fail = [JenkinsError for _ in range(6)]
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts_fail)
+        self.jenkins.add_job_info_from_name = Mock(
+                side_effect=self.jenkins.add_job_info_from_name)
+
+        jobs = self.jenkins.get_deployment()
+        self.jenkins.add_job_info_from_name.assert_called()
+        self.assertEqual(len(jobs), 3)
+        for job_name, ip, release, topology in zip(job_names, ip_versions,
+                                                   releases, topologies):
+            job = jobs[job_name]
+            deployment = job.deployment.value
+            self.assertEqual(job.name.value, job_name)
+            self.assertEqual(job.url.value, "url")
+            self.assertEqual(len(job.builds.value), 0)
+            self.assertEqual(deployment.release.value, release)
+            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(deployment.topology.value, topology)
+
+    def test_get_deployment_artifacts(self):
+        """ Test that get_deployment reads properly the information obtained
+        from jenkins using artifacts.
+        """
+        job_names = ['test_17.3_ipv4_job', 'test_16_ipv6_job', 'test_job']
+        ip_versions = ['4', '6', 'unknown']
+        releases = ['17.3', '16', '']
+        topologies = ["compute:2,controller:3", "compute:1,controller:2",
+                      "compute:2,controller:2"]
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastBuild': {}})
+        artifacts = [
+           f"bla\nJP_TOPOLOGY='{topologies[0]}'\nPRODUCT_VERSION=17.3",
+           f"bla\nJP_TOPOLOGY='{topologies[1]}'\nPRODUCT_VERSION=16",
+           f"bla\nJP_TOPOLOGY='{topologies[2]}'\nPRODUCT_VERSION=",
+            ]
+
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
+
+        jobs = self.jenkins.get_deployment()
+        self.assertEqual(len(jobs), 3)
+        for job_name, ip, release, topology in zip(job_names, ip_versions,
+                                                   releases, topologies):
+            job = jobs[job_name]
+            deployment = job.deployment.value
+            self.assertEqual(job.name.value, job_name)
+            self.assertEqual(job.url.value, "url")
+            self.assertEqual(len(job.builds.value), 0)
+            self.assertEqual(deployment.release.value, release)
+            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(deployment.topology.value, topology)
 
     def test_get_deployment_filter_ipv(self):
         """Test that get_deployment filters by ip_version."""
@@ -268,6 +417,54 @@ class TestJenkinsSource(TestCase):
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "17.3")
         self.assertEqual(deployment.ip_version.value, "4")
+        self.assertEqual(deployment.topology.value, "")
+
+    def test_get_deployment_filter_topology(self):
+        """Test that get_deployment filters by topology."""
+        job_names = ['test_17.3_ipv4_job_2comp_1cont',
+                     'test_16_ipv6_job_1comp_2cont', 'test_job']
+        topology_value = "compute:2,controller:1"
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastBuild': None})
+
+        self.jenkins.send_request = Mock(side_effect=[response])
+        arg = Mock()
+        arg.value = [topology_value]
+
+        jobs = self.jenkins.get_deployment(topology=arg)
+        self.assertEqual(len(jobs), 1)
+        job_name = 'test_17.3_ipv4_job_2comp_1cont'
+        job = jobs[job_name]
+        deployment = job.deployment.value
+        self.assertEqual(job.name.value, job_name)
+        self.assertEqual(job.url.value, "url")
+        self.assertEqual(len(job.builds.value), 0)
+        self.assertEqual(deployment.release.value, "17.3")
+        self.assertEqual(deployment.ip_version.value, "4")
+        self.assertEqual(deployment.topology.value, topology_value)
+
+    def test_get_deployment_filter_topology_ip_version(self):
+        """Test that get_deployment filters by topology and ip version."""
+        job_names = ['test_17.3_ipv4_job_2comp_1cont',
+                     'test_16_ipv6_job_1comp_2cont', 'test_job']
+        topology_value = "compute:2,controller:1"
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastBuild': None})
+
+        self.jenkins.send_request = Mock(side_effect=[response])
+        arg = Mock()
+        arg.value = [topology_value]
+        arg_ip = Mock()
+        arg_ip.value = ["6"]
+
+        jobs = self.jenkins.get_deployment(topology=arg, ip_version=arg_ip)
+        self.assertEqual(len(jobs), 0)
 
 
 class TestFilters(TestCase):


### PR DESCRIPTION
Modify the get_deployment method of the jenkins source to get topology                                                                                                                    
information. The information is obtained from the job name or from                                                                                                                        
artifacts. If many jobs are requested, it falls back to parsing the job                                                                                                                   
name. If few, it request some artifacts from the last build and tries to                                                                                                                  
find the information there. This is not completely robust, since                                                                                                                          
different jobs have different artifacts. If a job has no last build or                                                                                                                    
the artifacts used are not found, it will also fallback to extracting                                                                                                                     
the information from the jobs name.    