### PR TITLE
Allowing config file to be located on a URL

### DIFF
--- a/cibyl/cli/interactions.py
+++ b/cibyl/cli/interactions.py
@@ -1,0 +1,39 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+
+def ask_yes_no_question(question):
+    """Prints a question on the CLI that the user must respond with yes or no.
+
+    :param question: Text of the question to be performed.
+    :type question: str
+    :return: Whether the user said 'y' (True) or 'n' (False).
+    :rtype: bool
+    """
+    answer = ''
+
+    while answer not in ('y', 'n'):
+        print(f'{question} [y/n](n):')
+
+        answer = input()
+
+        if not answer:
+            answer = 'n'
+
+    if answer == 'y':
+        return True
+
+    return False

--- a/cibyl/cli/interactions.py
+++ b/cibyl/cli/interactions.py
@@ -16,9 +16,10 @@
 
 
 def ask_yes_no_question(question):
-    """Prints a question on the CLI that the user must respond with yes or no.
+    """Prints a question on the CLI that the user must respond
+    with a yes or no.
 
-    :param question: Text of the question to be performed.
+    :param question: Text of the question. Include question mark on it.
     :type question: str
     :return: Whether the user said 'y' (True) or 'n' (False).
     :rtype: bool

--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -17,6 +17,7 @@ import logging
 import sys
 
 from cibyl.exceptions import CibylException
+from cibyl.exceptions.config import ConfigurationNotFound
 from cibyl.orchestrator import Orchestrator
 from cibyl.plugins import DEFAULT_PLUGIN, extend_models
 from cibyl.utils.logger import configure_logging
@@ -70,9 +71,17 @@ def main():
         for plugin in plugins:
             extend_models(plugin)
 
-    orchestrator = Orchestrator(arguments.get('config_file_path'))
-    orchestrator.load_configuration(
-        skip_on_missing=arguments.get('help', False))
+    orchestrator = Orchestrator()
+
+    try:
+        orchestrator.load_configuration(arguments.get('config_file_path'))
+    except ConfigurationNotFound as ex:
+        # Check if the error is to be ignored
+        skip = arguments.get('help', False)
+
+        if not skip:
+            raise ex
+
     orchestrator.create_ci_environments()
     # Add arguments from CI & product models to the parser of the app
     for env in orchestrator.environments:

--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -19,6 +19,7 @@ from collections import UserDict
 
 import rfc3987
 
+from cibyl.cli.interactions import ask_yes_no_question
 from cibyl.exceptions.cli import AbortedByUserError
 from cibyl.exceptions.config import ConfigurationNotFound
 from cibyl.utils import yaml
@@ -158,23 +159,14 @@ class ConfigFactory:
 
         # Is there something on the download path?
         if is_file_available(dest):
-            # Ask user if they want to overwrite it then
-            user_answer = ''
+            # Overwrite it then?
+            print(f'Configuration file already found at: {dest}')
 
-            while user_answer not in ('y', 'n'):
-                print(f'Configuration file already found at: {dest}')
-                print('Overwrite file? [y/n](n):')
-                user_answer = input()
-
-                if not user_answer:
-                    user_answer = 'n'
-
-            if user_answer == 'n':
-                raise AbortedByUserError
-
-            if user_answer == 'y':
+            if ask_yes_no_question('Overwrite file?'):
                 LOG.info('Deleting file at: %s', dest)
                 os.remove(dest)
+            else:
+                raise AbortedByUserError
 
         # Download the file
         LOG.info("Downloading file into: %s", dest)

--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -54,7 +54,7 @@ class ConfigFactory:
     DEFAULT_USER_PATH = os.path.join(
         os.path.expanduser('~'), '.config/cibyl.yaml'
     )
-    """Default location on the user's filesystem where the configuration 
+    """Default location on the user's filesystem where the configuration
     file is expected.
     """
 
@@ -62,7 +62,7 @@ class ConfigFactory:
         DEFAULT_USER_PATH,
         '/etc/cibyl/cibyl.yaml'
     )
-    """List of locations where the configuration should be by defaults. 
+    """List of locations where the configuration should be by defaults.
     Ordered from user scope to system scope.
     """
 

--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -126,7 +126,13 @@ class ConfigFactory:
         return ConfigFactory.from_file(file)
 
     @staticmethod
-    def from_url(url, dest=DEFAULT_USER_PATH):
+    def _ask_user_for_overwrite():
+        return ask_yes_no_question('Overwrite file?')
+
+    @staticmethod
+    def from_url(url,
+                 dest=DEFAULT_USER_PATH,
+                 overwrite_call=_ask_user_for_overwrite):
         """Builds a configuration from a definition located on a remote
         host. The definition is accessed and downloaded into the provided path.
 
@@ -135,9 +141,9 @@ class ConfigFactory:
 
         Warnings
         -------
-        In case a file already exists at the destination, this will ask
-        the user whether they want to overwrite it or not. This requires
-        interaction with the CLI and can block callers.
+        In case a file already exists at the destination, this will ask by
+        default if the user wants to overwrite it or not. This requires
+        interaction with the CLI and therefore is a blocker.
 
         Examples
         --------
@@ -150,6 +156,8 @@ class ConfigFactory:
         :param dest: Path where the definition will be downloaded
             into. Must contain name of the file.
         :type dest: str
+        :param overwrite_call: The function used to ask the user if they
+            may overwrite the file. Change to avoid blocker.
         :return: The configuration instance
         :rtype: :class:`Config`
         :raise ConfigurationNotFound: If the definition could not
@@ -162,7 +170,7 @@ class ConfigFactory:
             # Overwrite it then?
             print(f'Configuration file already found at: {dest}')
 
-            if ask_yes_no_question('Overwrite file?'):
+            if overwrite_call():
                 LOG.info('Deleting file at: %s', dest)
                 os.remove(dest)
             else:

--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -134,7 +134,7 @@ class ConfigFactory:
 
         Warnings
         -------
-        In case that a file already exists at the destination, this will ask
+        In case a file already exists at the destination, this will ask
         the user whether they want to overwrite it or not. This requires
         interaction with the CLI and can block callers.
 

--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -56,16 +56,14 @@ class ConfigFactory:
     )
 
     @staticmethod
-    def from_args(**kwargs):
-        arg = kwargs.get('file_path')
-
-        if not arg:
+    def from_path(path):
+        if not path:
             return ConfigFactory.from_search()
 
-        if rfc3987.match(arg, 'URI'):
-            return ConfigFactory.from_url(arg)
+        if rfc3987.match(path, 'URI'):
+            return ConfigFactory.from_url(path)
 
-        return ConfigFactory.from_file(arg)
+        return ConfigFactory.from_file(path)
 
     @staticmethod
     def from_file(file):

--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -23,7 +23,7 @@ from cibyl.exceptions.cli import AbortedByUserError
 from cibyl.exceptions.config import ConfigurationNotFound
 from cibyl.utils import yaml
 from cibyl.utils.files import get_first_available_file, is_file_available
-from cibyl.utils.net import download_file, DownloadError
+from cibyl.utils.net import DownloadError, download_file
 
 LOG = logging.getLogger(__name__)
 

--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -165,7 +165,6 @@ class ConfigFactory:
                 print(f'Configuration file already found at: {dest}')
                 print('Overwrite file? [y/n](n):')
                 user_answer = input()
-                user_answer.lower()
 
                 if not user_answer:
                     user_answer = 'n'

--- a/cibyl/exceptions/__init__.py
+++ b/cibyl/exceptions/__init__.py
@@ -17,15 +17,21 @@ from cibyl.utils.colors import Colors
 
 
 class CibylException(Exception):
+    def __init__(self, message):
+        """Constructor.
+        """
+        super().__init__(*[message])
 
     @staticmethod
     def setup_quiet_exceptions():
         """Sets up quiet exceptions, without tracebacks, if they are
         of the type CibylException
         """
+
         def quiet_hook(kind, message, traceback):
             if CibylException in kind.__bases__:
                 print(Colors.red(f'{message}'))
             else:
                 sys.__excepthook__(kind, message, traceback)
+
         sys.excepthook = quiet_hook

--- a/cibyl/exceptions/cli.py
+++ b/cibyl/exceptions/cli.py
@@ -17,5 +17,10 @@ from cibyl.exceptions import CibylException
 
 
 class AbortedByUserError(CibylException):
+    """Represents an action that was interrupted by the user.
+    """
+
     def __init__(self, message='Operation aborted by user.'):
+        """Constructor.
+        """
         super().__init__(message)

--- a/cibyl/exceptions/cli.py
+++ b/cibyl/exceptions/cli.py
@@ -16,21 +16,6 @@
 from cibyl.exceptions import CibylException
 
 
-class InvalidConfiguration(CibylException):
-    """Invalid configuration exception"""
-
-    def __init__(self, message="""
-Invalid Configuration.
-A valid configuration should specify an environment, its system(s) and the
-system(s) details
-
-environments:
-    env_1:
-        jenkins_system:
-            system_type: jenkins"""):
-        self.message = message
-        super().__init__(self.message)
-
-
-class ConfigurationNotFound(CibylException):
-    """Configuration file not found exception"""
+class AbortedByUserError(CibylException):
+    def __init__(self, message='Operation aborted by user.'):
+        super().__init__(message)

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -19,7 +19,7 @@ import time
 
 from cibyl.cli.parser import Parser
 from cibyl.cli.validator import Validator
-from cibyl.config import Config
+from cibyl.config import Config, ConfigFactory
 from cibyl.exceptions.config import InvalidConfiguration
 from cibyl.exceptions.source import NoValidSources
 from cibyl.models.ci.environment import Environment
@@ -64,15 +64,15 @@ class Orchestrator:
     def __init__(self, config_file_path: str = None,
                  environments: list = None):
         """Orchestrator constructor method"""
-        self.config = Config(path=config_file_path)
+        self.config = Config()
         self.parser = Parser()
         self.publisher = Publisher()
         if not environments:
             self.environments = []
 
-    def load_configuration(self, skip_on_missing=False):
+    def load_configuration(self, path):
         """Loads the configuration of the application."""
-        self.config.load(skip_on_missing)
+        self.config = ConfigFactory.from_path(path)
 
     def create_ci_environments(self) -> None:
         """Creates CI environment entities based on loaded configuration."""

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -61,8 +61,7 @@ class Orchestrator:
     :type config_file_path: str, optional
     """
 
-    def __init__(self, config_file_path: str = None,
-                 environments: list = None):
+    def __init__(self, environments: list = None):
         """Orchestrator constructor method"""
         self.config = Config()
         self.parser = Parser()

--- a/cibyl/sources/zuul/source.py
+++ b/cibyl/sources/zuul/source.py
@@ -118,7 +118,7 @@ class Zuul(Source):
 
             return apply_filters(
                 builds,
-                lambda build: apply_last_build_filter(build)
+                apply_last_build_filter
             )
 
         @staticmethod

--- a/cibyl/utils/colors.py
+++ b/cibyl/utils/colors.py
@@ -26,17 +26,22 @@ class Colors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
+    @staticmethod
     def red(text):
         return f"{Colors.RED}{Colors.BOLD}{text}{Colors.CLOSE}"
 
+    @staticmethod
     def green(text):
         return f"{Colors.GREEN}{Colors.BOLD}{text}{Colors.CLOSE}"
 
+    @staticmethod
     def blue(text):
         return f"{Colors.BLUE}{Colors.BOLD}{text}{Colors.CLOSE}"
 
+    @staticmethod
     def yellow(text):
         return f"{Colors.YELLOW}{text}{Colors.CLOSE}"
 
+    @staticmethod
     def underline(text):
         return f"{Colors.UNDERLINE}{text}{Colors.CLOSE}"

--- a/cibyl/utils/files.py
+++ b/cibyl/utils/files.py
@@ -20,7 +20,7 @@ from os import PathLike
 LOG = logging.getLogger(__name__)
 
 
-def _is_file_available(filename):
+def is_file_available(filename):
     """Checks if a file is present on the filesystem.
 
     :param filename: A path pointing to the file to be checked.
@@ -31,7 +31,7 @@ def _is_file_available(filename):
     return os.path.isfile(filename)
 
 
-def get_first_available_file(filenames, file_check=_is_file_available):
+def get_first_available_file(filenames, file_check=is_file_available):
     """Searches for the first file out of the provided paths that exists
     on the host's drive.
 

--- a/cibyl/utils/net.py
+++ b/cibyl/utils/net.py
@@ -51,7 +51,7 @@ def download_file(url, dest):
     """
     LOG.debug('Creating path to: %s', dest)
 
-    os.makedirs(dest, exist_ok=True)
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
 
     with requests.get(url, stream=True) as request:
         if not request.ok:
@@ -62,6 +62,6 @@ def download_file(url, dest):
 
         LOG.debug('Saving to: %s', dest)
 
-        with open(dest, 'wb', encoding='utf8') as file:
+        with open(dest, 'wb') as file:
             for chunk in request.iter_content(chunk_size=8 * 1024):
                 file.write(chunk)

--- a/cibyl/utils/net.py
+++ b/cibyl/utils/net.py
@@ -1,0 +1,43 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import logging
+import os
+
+import requests
+
+LOG = logging.getLogger(__name__)
+
+
+class DownloadError(Exception):
+    pass
+
+
+def download_file(url, dest):
+    LOG.debug(f'Creating path to: {dest}')
+    os.makedirs(dest, exist_ok=True)
+
+    with requests.get(url, stream=True) as request:
+        if not request.ok:
+            raise DownloadError(
+                f'Download failed with: {request.status_code}\n'
+                f'{request.text}'
+            )
+
+        LOG.debug(f'Saving to: {dest}')
+
+        with open(dest, 'wb', encoding='utf8') as file:
+            for chunk in request.iter_content(chunk_size=8 * 1024):
+                file.write(chunk)

--- a/cibyl/utils/net.py
+++ b/cibyl/utils/net.py
@@ -22,11 +22,35 @@ LOG = logging.getLogger(__name__)
 
 
 class DownloadError(Exception):
-    pass
+    """Represents an error during the download of a file.
+    """
 
 
 def download_file(url, dest):
-    LOG.debug(f'Creating path to: {dest}')
+    """Downloads a file from a remote host into the local filesystem.
+
+    Supported protocols are:
+        * HTTP
+        * HTTPS
+
+    Examples
+    --------
+    >>> download_file(
+            'http://localhost/file.txt', '/home/user/my-file.txt'
+        )
+    >>> download_file(
+            'https://user@pass:localhost/file.txt, '/home/user/my-file.txt'
+        )
+
+    :param url: The URL where the file is at.
+    :type url: str
+    :param dest: Path where the file is going to be downloaded at. Must
+        contain name of the file.
+    :type dest: str
+    :raise DownloadError: If the download failed.
+    """
+    LOG.debug('Creating path to: %s', dest)
+
     os.makedirs(dest, exist_ok=True)
 
     with requests.get(url, stream=True) as request:
@@ -36,7 +60,7 @@ def download_file(url, dest):
                 f'{request.text}'
             )
 
-        LOG.debug(f'Saving to: {dest}')
+        LOG.debug('Saving to: %s', dest)
 
         with open(dest, 'wb', encoding='utf8') as file:
             for chunk in request.iter_content(chunk_size=8 * 1024):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests~=2.27.1
 elasticsearch~=7.17.1
 colorlog~=6.6.0
 urllib3~=1.26.9
+rfc3987~=1.3.8

--- a/tests/e2e/fixture/__init__.py
+++ b/tests/e2e/fixture/__init__.py
@@ -51,6 +51,28 @@ class EndToEndTest(TestCase):
         return self._buffer.getvalue()
 
 
+class HTTPDTest(EndToEndTest):
+    httpd = None
+
+    @classmethod
+    def setUpClass(cls):
+        # Define the image
+        cls.httpd = DockerCompose(
+            filepath='tests/e2e/images/httpd',
+            pull=True
+        )
+
+        # Launch the container
+        cls.httpd.start()
+
+        # Wait for HTTPD to be ready
+        wait_for('http://localhost:8080/')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.stop()
+
+
 class JenkinsTest(EndToEndTest):
     """Spawns a container with a simple installation for tests to work over.
 

--- a/tests/e2e/images/httpd/Dockerfile
+++ b/tests/e2e/images/httpd/Dockerfile
@@ -1,0 +1,3 @@
+FROM httpd:alpine
+
+COPY ./public/ /usr/local/apache2/htdocs/

--- a/tests/e2e/images/httpd/docker-compose.yml
+++ b/tests/e2e/images/httpd/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  httpd:
+    build: .
+    ports:
+      - "8080:80"

--- a/tests/e2e/images/httpd/public/jenkins.yaml
+++ b/tests/e2e/images/httpd/public/jenkins.yaml
@@ -1,7 +1,7 @@
 ---
 environments:
-  osp_phases:
-    osp_jenkins:
+  test_environment:
+    test_system:
       system_type: jenkins
       sources:
         jenkins:

--- a/tests/e2e/images/httpd/public/jenkins.yaml
+++ b/tests/e2e/images/httpd/public/jenkins.yaml
@@ -1,0 +1,9 @@
+---
+environments:
+  osp_phases:
+    osp_jenkins:
+      system_type: jenkins
+      sources:
+        jenkins:
+          driver: jenkins
+          url: 'http://localhost:8080/'

--- a/tests/e2e/test_config.py
+++ b/tests/e2e/test_config.py
@@ -1,0 +1,21 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from tests.e2e.fixture import HTTPDTest
+
+
+class TestConfig(HTTPDTest):
+    def test_config_on_url(self):
+        pass

--- a/tests/e2e/test_config.py
+++ b/tests/e2e/test_config.py
@@ -22,7 +22,13 @@ from tests.e2e.fixture import HTTPDTest
 
 
 class TestConfig(HTTPDTest):
+    """Test for configuration loading.
+    """
+
     def test_config_on_url(self):
+        """Checks that a configuration file can be downloaded from a host.
+        """
+
         sys.argv = [
             '',
             '--config',

--- a/tests/e2e/test_config.py
+++ b/tests/e2e/test_config.py
@@ -13,9 +13,27 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+import builtins
+import sys
+from unittest.mock import Mock
+
+from cibyl.cli.main import main
 from tests.e2e.fixture import HTTPDTest
 
 
 class TestConfig(HTTPDTest):
     def test_config_on_url(self):
-        pass
+        sys.argv = [
+            '',
+            '--config',
+            'http://localhost:8080/jenkins.yaml'
+        ]
+
+        builtins.input = Mock()
+        builtins.input.return_value = 'y'
+
+        main()
+
+        # Look for some keys that indicate that it is the desired file
+        self.assertIn('test_environment', self.output)
+        self.assertIn('test_system', self.output)

--- a/tests/unit/cli/test_interactions.py
+++ b/tests/unit/cli/test_interactions.py
@@ -1,0 +1,49 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import builtins
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.cli.interactions import ask_yes_no_question
+
+
+class TestYesNoQuestion(TestCase):
+    """Tests function :func:`cibyl.cli.interactions.ask_yes_no_question`.
+    """
+
+    def test_true_on_y(self):
+        """Checks that if the user says yes, then it returns true.
+        """
+        builtins.input = Mock()
+        builtins.input.return_value = 'y'
+
+        self.assertTrue(ask_yes_no_question('Question?'))
+
+    def test_false_on_n(self):
+        """Checks that if the user says no, then it returns false.
+        """
+        builtins.input = Mock()
+        builtins.input.return_value = 'n'
+
+        self.assertFalse(ask_yes_no_question('Question?'))
+
+    def test_false_on_nothing(self):
+        """Checks that if the user says nothing, then it returns false.
+        """
+        builtins.input = Mock()
+        builtins.input.return_value = ''
+
+        self.assertFalse(ask_yes_no_question('Question?'))

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -18,23 +18,11 @@ from unittest.mock import Mock
 
 import cibyl.config
 from cibyl.config import Config
-from cibyl.exceptions.config import ConfigurationNotFound
 
 
 class TestConfig(TestCase):
     """Test cases for the 'Config' class.
     """
-
-    def test_error_when_file_not_found(self):
-        """Checks that 'load' raises a ConfigurationNotFound when the config
-        file does not exist.
-        """
-        cibyl.config.get_first_available_file = Mock()
-        cibyl.config.get_first_available_file.return_value = None
-
-        config = Config()
-
-        self.assertRaises(ConfigurationNotFound, config.load)
 
     def test_contents_are_loaded(self):
         """Checks that the contents of the loaded file are made available by
@@ -48,16 +36,12 @@ class TestConfig(TestCase):
             }
         }
 
-        cibyl.config.get_first_available_file = Mock()
-        cibyl.config.get_first_available_file.return_value = file
-
         cibyl.config.yaml.parse = Mock()
         cibyl.config.yaml.parse.return_value = yaml
 
-        config = Config(file)
-        config.load()
+        config = Config()
+        config.load(file)
 
-        cibyl.config.get_first_available_file.assert_called_with([file])
         cibyl.config.yaml.parse.assert_called_with(file)
 
         self.assertEqual(config, yaml)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -16,6 +16,7 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
+import cibyl.orchestrator
 from cibyl.config import Config
 from cibyl.exceptions.config import InvalidConfiguration
 from cibyl.exceptions.source import NoValidSources
@@ -74,10 +75,16 @@ class TestOrchestrator(TestCase):
         """Testing Orchestrator config attribute and method"""
         self.assertTrue(hasattr(self.orchestrator, 'config'))
 
-        self.orchestrator.config = Mock()
-        self.orchestrator.load_configuration()
+        path_to_config = 'some/path'
 
-        self.orchestrator.config.load.assert_called()
+        factory_call = cibyl.orchestrator.ConfigFactory.from_path = Mock()
+        factory_call.return_value = Mock()
+
+        self.orchestrator.load_configuration(path_to_config)
+
+        self.assertEqual(factory_call.return_value, self.orchestrator.config)
+
+        factory_call.assert_called_once_with(path_to_config)
 
     def test_orchestrator_create_ci_environments(self):
         """Testing Orchestartor query method"""


### PR DESCRIPTION
Adding the chance of downloading a configuration file from an URL. The downloaded file will be stored on the user's default path: ~/.config/cibyl.yaml. If the file already exists, the user is prompted if they want to override it. If they do not, the application exists with an error. 

I have also changed how the config instances are generated, now a factory will implement its constructor for any type of source, including: path to a file, a URL, search on default paths and app's arguments.