### PR TITLE
Add deployment info and tests

### DIFF
--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -162,7 +162,7 @@ class Orchestrator:
                     model_instances_dict = source_method(
                         **self.parser.ci_args, **self.parser.app_args)
                     end_time = time.time()
-                    LOG.info("Took %.2fs to query system %s using %s",
+                    LOG.debug("Took %.2fs to query system %s using %s",
                              end_time-start_time, system.name.value,
                              source_information_from_method(source_method))
                     system.populate(model_instances_dict)

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -163,8 +163,8 @@ class Orchestrator:
                         **self.parser.ci_args, **self.parser.app_args)
                     end_time = time.time()
                     LOG.debug("Took %.2fs to query system %s using %s",
-                             end_time-start_time, system.name.value,
-                             source_information_from_method(source_method))
+                              end_time-start_time, system.name.value,
+                              source_information_from_method(source_method))
                     system.populate(model_instances_dict)
             last_level = arg.level
 

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -173,10 +173,10 @@ class ElasticSearchOSP(Source):
         elasticsearch server
         :rtype: :class:`AttributeDictValue`
         """
-
+        jobs_to_search = []
         if 'job_name' in kwargs:
             jobs_to_search = kwargs.get('job_name').value
-        else:
+        elif 'jobs' in kwargs:
             jobs_to_search = kwargs.get('jobs').value
 
         query_body = QueryTemplate('jobName', jobs_to_search).get
@@ -230,7 +230,7 @@ class QueryTemplate():
                     "exists": {
                         "field": search_key
                     }
-                },
+                }
             }
         # Just one element that start with string
         # is better to use 'match_phrase_prefix'

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -22,6 +22,7 @@ from cibyl.exceptions.elasticsearch import ElasticSearchError
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.build import Build
 from cibyl.models.ci.job import Job
+from cibyl.plugins.openstack.deployment import Deployment
 from cibyl.sources.elasticsearch.client import ElasticSearchClient
 from cibyl.sources.source import Source
 
@@ -50,7 +51,6 @@ class ElasticSearchOSP(Source):
             self.es_client = ElasticSearchClient(host, port)
 
     def get_jobs(self: object, **kwargs: Argument) -> list:
-        self.es_connection = self.es_client.connect()
         """Get jobs from elasticsearch
 
             :returns: Job objects queried from elasticserach
@@ -85,11 +85,13 @@ class ElasticSearchOSP(Source):
         :return: List of hits.
         """
         try:
+            self.es_connection = self.es_client.connect()
             response = self.es_connection.search(
                 index=index,
                 body=query,
-                size=1000
+                size=10000,
             )
+            self.es_connection.transport.close()
         except Exception as exception:
             raise ElasticSearchError("Error getting the results") \
                   from exception
@@ -164,6 +166,50 @@ class ElasticSearchOSP(Source):
 
         return AttributeDictValue("jobs", attr_type=Job, value=job_object)
 
+    def get_deployment(self, **kwargs):
+        """Get deployment information for jobs from elasticsearch server.
+
+        :returns: container of jobs with deployment information from
+        elasticsearch server
+        :rtype: :class:`AttributeDictValue`
+        """
+
+        if 'job_name' in kwargs:
+            jobs_to_search = kwargs.get('job_name').value
+        else:
+            jobs_to_search = kwargs.get('jobs').value
+
+        query_body = QueryTemplate('jobName', jobs_to_search).get
+
+        hits = self.__query_get_hits(
+            query=query_body
+        )
+
+        job_objects = {}
+        for hit in hits:
+            job_name = hit['_source']['jobName']
+            url = hit['_source']['envVars']['JOB_URL']
+            # If the key exists assign the value otherwise assign unknown
+            topology = hit.get('_source', {}).get('envVars', {}).get(
+                "JP_IRVIRSH_TOPOLOGY_NODES", "unknown")
+            ip_version = hit.get('_source', {}).get('envVars', {}).get(
+                "JP_OSPD_NETWORK_PROTOCOL", "unknown")
+            release = hit.get('_source', {}).get('envVars', {}).get(
+                "JP_OSPD_PRODUCT_VERSION", "unknown")
+
+            job_objects[job_name] = Job(name=job_name, url=url)
+            deployment = Deployment(
+                release,
+                "unknown",
+                [],
+                [],
+                ip_version=ip_version,
+                topology=topology
+            )
+            job_objects[job_name].add_deployment(deployment)
+
+        return AttributeDictValue("jobs", attr_type=Job, value=job_objects)
+
 
 class QueryTemplate():
     """Used for template and substitutions according to the
@@ -184,7 +230,7 @@ class QueryTemplate():
                     "exists": {
                         "field": search_key
                     }
-                }
+                },
             }
         # Just one element that start with string
         # is better to use 'match_phrase_prefix'
@@ -227,4 +273,5 @@ class QueryTemplate():
     @property
     def get(self: object) -> dict:
         """Return DSL query in dictionary format"""
+        LOG.info(f"Using the following query: {self.query_body}")
         return self.query_body

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -85,13 +85,13 @@ class ElasticSearchOSP(Source):
         :return: List of hits.
         """
         try:
-            self.es_connection = self.es_client.connect()
-            response = self.es_connection.search(
-                index=index,
-                body=query,
-                size=10000,
-            )
-            self.es_connection.transport.close()
+            with self.es_client.connect() as es_connection:
+                response = es_connection.search(
+                    index=index,
+                    body=query,
+                    size=10000,
+                )
+            es_connection.transport.close()
         except Exception as exception:
             raise ElasticSearchError("Error getting the results") \
                   from exception

--- a/tests/unit/sources/elasticsearch/test_api.py
+++ b/tests/unit/sources/elasticsearch/test_api.py
@@ -33,7 +33,8 @@ class TestElasticsearchOSP(TestCase):
                 '_source': {
                     'jobName': 'test',
                     'envVars': {
-                        'JOB_URL': 'http://domain.tld/test'
+                        'JOB_URL': 'http://domain.tld/test',
+                        'JP_OSPD_PRODUCT_VERSION': '16',
                     }
                 }
             }
@@ -70,6 +71,21 @@ class TestElasticsearchOSP(TestCase):
         self.assertTrue('test' in jobs)
         self.assertEqual(jobs['test'].name.value, 'test')
         self.assertEqual(jobs['test'].url.value, "http://domain.tld/test")
+
+    @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
+    def test_get_deployment(self: object, mock_query_hits: object) -> None:
+        """Tests that the internal logic from :meth:`ElasticSearchOSP.get_jobs`
+            is correct.
+        """
+        mock_query_hits.return_value = self.job_hit
+
+        jobs_argument = Mock()
+        jobs_argument.value = ['test']
+        jobs = self.es_api.get_deployment(jobs=jobs_argument)
+        deployment = jobs['test'].deployment.value
+        self.assertEqual(deployment.release.value, '16')
+        self.assertEqual(deployment.ip_version.value, 'unknown')
+        self.assertEqual(deployment.topology.value, 'unknown')
 
     @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
     def test_get_builds(self: object, mock_query_hits: object) -> None:


### PR DESCRIPTION
- Added method get_deployment to elasticsearch.
- Added test test_get_deployment to test the logic
- Change the query size to 10K. This is the limit. Maybe we can try to find another way to optimize it using scrolls. It should be another task but right now it can show more than 1000 jobs, before not more than 300.
- Changed the connection sentence to the private method __query_get_hits. I also added the close connection method.