### PR TITLE
Filtering by release

### DIFF
--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -186,6 +186,12 @@ class ElasticSearchOSP(Source):
             query=query_body
         )
 
+        ip_version_argument = None
+        if 'ip_version' in kwargs:
+            ip_version_argument = kwargs.get('ip_version').value
+        release_argument = None
+        if 'release' in kwargs:
+            release_argument = kwargs.get('release').value
         job_objects = {}
         for hit in hits:
             job_name = hit['_source']['jobName']
@@ -203,18 +209,14 @@ class ElasticSearchOSP(Source):
                 ip_version = matches.group(1)
 
             # Check if necessary filter by IP version:
-            if 'ip_version' in kwargs:
-                ip_version_argument = kwargs.get('ip_version').value
-                if ip_version_argument and \
-                        ip_version not in ip_version_argument:
-                    continue
+            if ip_version_argument and \
+                    ip_version not in ip_version_argument:
+                continue
 
             # Check if necessary filter by release version:
-            if 'release' in kwargs:
-                release_argument = kwargs.get('release').value
-                if release_argument and \
-                        release not in release_argument:
-                    continue
+            if release_argument and \
+                    release not in release_argument:
+                continue
 
             job_objects[job_name] = Job(name=job_name, url=url)
             deployment = Deployment(

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -203,10 +203,18 @@ class ElasticSearchOSP(Source):
                 ip_version = matches.group(1)
 
             # Check if necessary filter by IP version:
-            ip_version_argument = kwargs.get('ip_version').value
-            if ip_version_argument and \
-                    ip_version not in ip_version_argument:
-                continue
+            if 'ip_version' in kwargs:
+                ip_version_argument = kwargs.get('ip_version').value
+                if ip_version_argument and \
+                        ip_version not in ip_version_argument:
+                    continue
+
+            # Check if necessary filter by release version:
+            if 'release' in kwargs:
+                release_argument = kwargs.get('release').value
+                if release_argument and \
+                        release not in release_argument:
+                    continue
 
             job_objects[job_name] = Job(name=job_name, url=url)
             deployment = Deployment(


### PR DESCRIPTION
- Added filtering by release. It's simple because if it doesn't match it just continues and we won't have another `Deployment` object.
- We also need to check if the arguments are in kwargs otherwise it will throw an error because it's trying to search by .value and it does not exist