### PR TITLE
Add support for range query mechanism for arguments

### DIFF
--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -26,7 +26,8 @@ class CustomAction(argparse.Action):
     whether an argument data is populated, the function associated
     with the argument and the level in the models.
     """
-    def __init__(self, *args, func=None, populated=False, level=-1, **kwargs):
+    def __init__(self, *args, func=None, populated=False, level=-1,
+                 ranged=False, **kwargs):
         """
         argparse custom action.
         :param func: the function the argument is associated with
@@ -34,6 +35,7 @@ class CustomAction(argparse.Action):
         self.func = func
         self.level = level
         self.populated = populated
+        self.ranged = ranged
         super().__init__(*args, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
@@ -42,7 +44,7 @@ class CustomAction(argparse.Action):
         setattr(namespace, self.dest, Argument(
             name=self.dest, description=self.help, arg_type=self.type,
             nargs=self.nargs, level=self.level, func=self.func,
-            populated=self.populated,
+            ranged=self.ranged, populated=self.populated,
             value=values))
 
 
@@ -141,6 +143,7 @@ class Parser:
                     arg.name, type=arg.arg_type,
                     help=arg.description, nargs=arg.nargs,
                     action=CustomAction, func=arg.func,
+                    ranged=arg.ranged,
                     populated=arg.populated,
                     default=arg.default,
                     level=level)

--- a/cibyl/cli/ranged_argument.py
+++ b/cibyl/cli/ranged_argument.py
@@ -13,24 +13,16 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from cibyl.exceptions import CibylException
+import operator
+import re
+from collections import namedtuple
 
+EXPRESSION_PATTERN = re.compile(r"([<>=!]*)(\d)+")
 
-class AbortedByUserError(CibylException):
-    """Represents an action that was interrupted by the user.
-    """
+Range = namedtuple('Range', 'operator operand')
 
-    def __init__(self, message='Operation aborted by user.'):
-        """Constructor.
-        """
-        super().__init__(message)
+RANGE_OPERATORS = {"==": operator.eq, "=": operator.eq, "<": operator.lt,
+                   ">": operator.gt, "<=": operator.le, ">=": operator.ge,
+                   "!=": operator.ne}
 
-
-class InvalidArgument(CibylException):
-    """Represents an argument with invalid format.
-    """
-
-    def __init__(self, message='Invalid argument provided.'):
-        """Constructor.
-        """
-        super().__init__(message)
+VALID_OPS = ",".join(RANGE_OPERATORS.keys())

--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -73,8 +73,18 @@ class Deployment(Model):
             'arguments': [Argument(name='--network-backend', arg_type=str,
                                    func='get_deployment', nargs='*',
                                    description="Network backend used in the "
-                                   "deployment")]
-            },
+                                   "deployment"),
+                          Argument(name='--controllers', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   ranged=True,
+                                   description="Number of controllers used "
+                                   "in the deployment"),
+                          Argument(name='--computes', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   ranged=True,
+                                   description="Number of computes used "
+                                   "in the deployment")]
+            }
     }
 
     def __init__(self, release: float, infra_type: str,

--- a/tests/unit/cli/test_argument.py
+++ b/tests/unit/cli/test_argument.py
@@ -1,0 +1,118 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.cli.argument import Argument
+from cibyl.cli.ranged_argument import VALID_OPS, Range
+from cibyl.exceptions.cli import InvalidArgument
+
+
+class TestArgument(TestCase):
+    """Test Argument class."""
+
+    def setUp(self):
+        self.name = "test"
+        self.description = "Test argument"
+        self.value = ["value"]
+        self.arg_type = str
+        self.nargs = 1
+        self.argument = Argument(name=self.name, description=self.description,
+                                 arg_type=self.arg_type, nargs=self.nargs,
+                                 value=self.value)
+        self.second_argument = Argument(name=self.name, description="",
+                                        arg_type=float, nargs="*",
+                                        value=self.value)
+        self.ranged_argument = Argument(name=self.name,
+                                        description=self.description,
+                                        arg_type=self.arg_type, nargs="*",
+                                        value=[">4", "!=5"], ranged=True)
+
+    def test_check_attributes(self):
+        """Check that attributes are properly set."""
+        self.assertEqual(self.argument.name, self.name)
+        self.assertEqual(self.argument.description, self.description)
+        self.assertEqual(self.argument.value, self.value)
+        self.assertEqual(self.argument.arg_type, self.arg_type)
+        self.assertEqual(self.argument.nargs, self.nargs)
+        self.assertIsNone(self.argument.func)
+        self.assertIsNone(self.argument.default)
+        self.assertEqual(self.argument.level, 0)
+        self.assertFalse(self.argument.populated)
+        self.assertFalse(self.argument.ranged)
+
+    def test_str(self):
+        """Test __str__ method of Argument."""
+        self.assertEqual(str(self.argument), str(self.value))
+
+    def test_eq(self):
+        """Test __eq__ method of Argument."""
+        self.assertEqual(self.argument, self.second_argument)
+        argument_different_name = Argument(name="not-test",
+                                           description=self.description,
+                                           arg_type=self.arg_type,
+                                           nargs=self.nargs,
+                                           value=self.value)
+        argument_different_value = Argument(name=self.name,
+                                            description=self.description,
+                                            arg_type=self.arg_type,
+                                            nargs=self.nargs,
+                                            value=[])
+        self.assertNotEqual(self.argument, argument_different_name)
+        self.assertNotEqual(self.argument, argument_different_value)
+
+    def test_ranged_expression(self):
+        """Test that the ranged value is parsed correctly."""
+        ranges = [Range(">", "4"), Range("!=", "5")]
+        self.assertEqual(self.ranged_argument.value, ranges)
+
+    def test_not_valid_expression(self):
+        """Test that an invalid ranged expression raises an exception."""
+        exception_msg = f"Expression 'a' in argument {self.name} is not valid"
+        with self.assertRaises(InvalidArgument, msg=exception_msg):
+            Argument(name=self.name,
+                     description=self.description,
+                     arg_type=self.arg_type, nargs="*",
+                     value=["a"], ranged=True)
+
+    def test_not_multiple_value(self):
+        """Test that argument with one value raises an exception."""
+        exception_msg = f"Argument '{self.name}' should accept multiple values"
+
+        with self.assertRaises(InvalidArgument, msg=exception_msg):
+            Argument(name=self.name,
+                     description=self.description,
+                     arg_type=self.arg_type, nargs=1,
+                     value="<4", ranged=True)
+
+    def test_unknown_operator(self):
+        """Test that an unknown operator raises an exception."""
+        exception_msg = f"Operator '<<' in argument {self.name} is not valid."
+        exception_msg += f"Valid operators include: {VALID_OPS}"
+
+        with self.assertRaises(InvalidArgument, msg=exception_msg):
+            Argument(name=self.name,
+                     description=self.description,
+                     arg_type=self.arg_type, nargs=1,
+                     value=["<<4"], ranged=True)
+
+    def test_implicit_operator(self):
+        """Test that omitted operator default to equal."""
+
+        arg = Argument(name=self.name,
+                       description=self.description,
+                       arg_type=self.arg_type, nargs=1,
+                       value=["4"], ranged=True)
+        self.assertEqual(arg.value[0].operator, "==")

--- a/tests/unit/cli/test_ranged_argument.py
+++ b/tests/unit/cli/test_ranged_argument.py
@@ -1,0 +1,63 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.cli.ranged_argument import (EXPRESSION_PATTERN, RANGE_OPERATORS,
+                                       VALID_OPS, Range)
+
+
+def is_valid_regex(match_obj, operator, operand):
+    """Check that a string is matched correctly by the regex."""
+    operator_str = match_obj.group(1)
+    operand_str = match_obj.group(2)
+    return operand_str == operand and operator == operator_str
+
+
+class TestRange(TestCase):
+    """Test helper module for ranged Arguments."""
+
+    def test_regex(self):
+        """Check that the range regex works as intended."""
+        self.assertIsNone(EXPRESSION_PATTERN.search("abcd"))
+        matched_str = EXPRESSION_PATTERN.search(">>4")
+        self.assertTrue(is_valid_regex(matched_str, ">>", "4"))
+        matched_str = EXPRESSION_PATTERN.search("!=4")
+        self.assertTrue(is_valid_regex(matched_str, "!=", "4"))
+
+    def test_Range(self):
+        """Test that Range namedtuple works as intended."""
+        range1 = Range(">", "2")
+        range2 = Range("<", "2")
+        self.assertEqual(range1.operator, ">")
+        self.assertEqual(range1.operand, "2")
+        self.assertEqual(range2.operator, "<")
+        self.assertEqual(range2.operand, "2")
+        self.assertNotEqual(range1, range2)
+
+    def test_range_operators(self):
+        """Test that range operator dictionary works as intended."""
+        self.assertTrue(RANGE_OPERATORS["<"](2, 3))
+        self.assertTrue(RANGE_OPERATORS[">"](5, 3))
+        self.assertTrue(RANGE_OPERATORS[">="](3, 3))
+        self.assertTrue(RANGE_OPERATORS["<="](3, 3))
+        self.assertTrue(RANGE_OPERATORS["=="](3, 3))
+        self.assertTrue(RANGE_OPERATORS["="](3, 3))
+        self.assertTrue(RANGE_OPERATORS["!="](2, 3))
+
+    def test_valid_operators_str(self):
+        """Test that VALID_OPS string contains all supported operators."""
+        for op in RANGE_OPERATORS:
+            self.assertIn(op, VALID_OPS)


### PR DESCRIPTION
Arguments created with ranged=True will parse their values assuming that
they contain expressions querying for range. Only simple operations
are supported (>, <, >=, <=, ==, !=). The parsed expressions will be
stored as a namedtuple containing (opertor, operand) so that they can be
later simply used in the sources.
