### PR TITLE
Fix Zuul source by making it being part of a job system

### DIFF
--- a/cibyl/models/ci/system_factory.py
+++ b/cibyl/models/ci/system_factory.py
@@ -48,6 +48,10 @@ class SystemFactory:
             return JobsSystem(name=name, system_type=system_type, **kwargs)
 
         if system_type == SystemType.ZUUL:
-            return PipelineSystem(name=name, system_type=system_type, **kwargs)
+            # NOTE: Not functional yet -> Swap then needed
+            # return PipelineSystem(
+            #     name=name, system_type=system_type, **kwargs
+            # )
+            return JobsSystem(name=name, system_type=system_type, **kwargs)
 
         raise NotImplementedError(f"Unknown system type '{system_type}'")

--- a/cibyl/models/ci/system_factory.py
+++ b/cibyl/models/ci/system_factory.py
@@ -15,7 +15,7 @@
 """
 from enum import Enum
 
-from cibyl.models.ci.system import JobsSystem, PipelineSystem
+from cibyl.models.ci.system import JobsSystem
 
 
 class SystemType(str, Enum):

--- a/tests/e2e/test_zuul.py
+++ b/tests/e2e/test_zuul.py
@@ -37,4 +37,4 @@ class TestZuul(ZuulTest):
 
         main()
 
-        self.assertIn('Total jobs: 0', self.output)
+        self.assertIn('Total jobs: 65', self.output)


### PR DESCRIPTION
Pipelines systems are not ready for use yet, we still have not decided either on the model hierarchy that we want to use or the data that we want to extract, so for the time being I am making Zuul be a job system once more. That way it will at least be as usable as the Jenkins source.