### PR TITLE
Support querying for network backend in jenkins

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -67,15 +67,24 @@ class Deployment(Model):
                                    func='get_deployment', nargs='*',
                                    description="Topology used in the "
                                    "deployment")]
-            }
+            },
+        'network_backend': {
+            'attr_type': str,
+            'arguments': [Argument(name='--network-backend', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   description="Network backend used in the "
+                                   "deployment")]
+            },
     }
 
     def __init__(self, release: float, infra_type: str,
                  nodes: List[Node], services: List[Service],
-                 ip_version: str = None, topology: str = None):
+                 ip_version: str = None, topology: str = None,
+                 network_backend: str = None):
         super().__init__({'release': release, 'infra_type': infra_type,
                           'nodes': nodes, 'services': services,
-                          'ip_version': ip_version, 'topology': topology})
+                          'ip_version': ip_version, 'topology': topology,
+                          'network_backend': network_backend})
 
     def __str__(self, indent=0, verbosity=0):
         indent_space = indent*' '
@@ -96,4 +105,8 @@ class Deployment(Model):
         if self.topology.value:
             info += f'\n{indent_space}' + Colors.blue('Topology: ')
             info += f'{self.topology}'
+        if self.network_backend.value:
+            info += f'\n{indent_space}' + Colors.blue('Nework backend: ')
+            info += f'{self.network_backend}'
+
         return info

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -31,9 +31,9 @@ from cibyl.models.ci.job import Job
 from cibyl.plugins.openstack.deployment import Deployment
 from cibyl.plugins.openstack.utils import translate_topology_string
 from cibyl.sources.source import Source, safe_request_generic
-from cibyl.utils.filtering import (IP_PATTERN, PROPERTY_PATTERN,
-                                   RELEASE_PATTERN, TOPOLOGY_PATTERN,
-                                   apply_filters,
+from cibyl.utils.filtering import (IP_PATTERN, NETWORK_BACKEND_PATTERN,
+                                   PROPERTY_PATTERN, RELEASE_PATTERN,
+                                   TOPOLOGY_PATTERN, apply_filters,
                                    satisfy_case_insensitive_match,
                                    satisfy_exact_match, satisfy_regex_match)
 
@@ -320,6 +320,9 @@ accurate results", len(jobs_found))
             job["ip_version"] = detect_job_info_regex(job_name, IP_PATTERN,
                                                       group_index=1,
                                                       default="unknown")
+            network_backend = detect_job_info_regex(job_name,
+                                                    NETWORK_BACKEND_PATTERN)
+            job["network_backend"] = network_backend
             last_build = job.get("lastBuild")
             if use_artifacts and last_build is not None:
                 # if we have a lastBuild, we will have artifacts to pull
@@ -347,6 +350,12 @@ accurate results", len(jobs_found))
                                    user_input=input_release,
                                    field_to_check="release_version"))
 
+        input_network_backend = kwargs.get('network_backend')
+        if input_network_backend and input_network_backend.value:
+            checks_to_apply.append(partial(satisfy_exact_match,
+                                           user_input=input_network_backend,
+                                           field_to_check="network_backend"))
+
         job_deployment_info = apply_filters(job_deployment_info,
                                             *checks_to_apply)
 
@@ -357,7 +366,8 @@ accurate results", len(jobs_found))
             # TODO: (jgilaber) query for infra_type, nodes and services
             deployment = Deployment(job["release_version"], "unknown",
                                     [], [], ip_version=job["ip_version"],
-                                    topology=job["topology"])
+                                    topology=job["topology"],
+                                    network_backend=job["network_backend"])
             job_objects[name].add_deployment(deployment)
 
         return AttributeDictValue("jobs", attr_type=Job, value=job_objects)

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -22,6 +22,7 @@ IP_PATTERN = re.compile("ipv(.)")
 RELEASE_PATTERN = re.compile(r"\d\d\.?\d?")
 TOPOLOGY_PATTERN = re.compile(r"(\d([a-zA-Z])+_?)+")
 PROPERTY_PATTERN = re.compile(r"=(.*)")
+NETWORK_BACKEND_PATTERN = re.compile("geneve|gre|vlan|vxlan")
 
 
 def satisfy_regex_match(model: Dict[str, str], pattern: Pattern,

--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -77,7 +77,7 @@ Arguments Matrix
      - |:x:|
      - |:x:|
    * - --network-backend
-     - |:x:|
+     - |:ballot_box_with_check:|
      - |:x:|
      - |:x:|
      - |:x:|

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -493,6 +493,34 @@ class TestJenkinsSource(TestCase):
         jobs = self.jenkins.get_deployment(topology=arg, ip_version=arg_ip)
         self.assertEqual(len(jobs), 0)
 
+    def test_get_deployment_filter_network_backend(self):
+        """Test that get_deployment filters by topology and ip version."""
+        job_names = ['test_17.3_ipv4_job_2comp_1cont_geneve',
+                     'test_16_ipv6_job_1comp_2cont_vxlan', 'test_job']
+        topology_value = "compute:2,controller:1"
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastBuild': None})
+
+        self.jenkins.send_request = Mock(side_effect=[response])
+        arg = Mock()
+        arg.value = ["geneve"]
+
+        jobs = self.jenkins.get_deployment(network_backend=arg)
+        self.assertEqual(len(jobs), 1)
+        job_name = 'test_17.3_ipv4_job_2comp_1cont_geneve'
+        job = jobs[job_name]
+        deployment = job.deployment.value
+        self.assertEqual(job.name.value, job_name)
+        self.assertEqual(job.url.value, "url")
+        self.assertEqual(len(job.builds.value), 0)
+        self.assertEqual(deployment.release.value, "17.3")
+        self.assertEqual(deployment.ip_version.value, "4")
+        self.assertEqual(deployment.topology.value, topology_value)
+        self.assertEqual(deployment.network_backend.value, "geneve")
+
 
 class TestFilters(TestCase):
     """Tests for filter functions in jenkins source module."""


### PR DESCRIPTION
Jenkins source relies on the job name to extract the backend network
information since there is no apparent artifact that exposes the
information.
