### PR TITLE
Distinguish between not-yet-implemented and non-supported

### DIFF
--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -42,67 +42,67 @@ Arguments Matrix
      - Zuul.d
    * - --ip-version
      - |:ballot_box_with_check:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
    * - --release
      - |:ballot_box_with_check:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
    * - --topology
      - |:ballot_box_with_check:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
    * - --controllers
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
    * - --computes
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
    * - --dvr
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
    * - --network-backend
      - |:ballot_box_with_check:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
    * - --storage-backend
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
    * - --packages
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
      - |:x:|
      - |:x:|
    * - --tls-everywhere
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
      - |:x:|
      - |:x:|
    * - --containers
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
      - |:x:|
      - |:x:|

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -55,14 +55,14 @@ Arguments Matrix
      - |:x:|
    * - --job-name
      - |:ballot_box_with_check:|
-     - |:x:|
+     - |:black_square_button:|
      - |:ballot_box_with_check:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
    * - --job-url
      - |:ballot_box_with_check:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
      - |:x:|
      - |:x:|
    * - --builds
@@ -79,37 +79,37 @@ Arguments Matrix
      - |:x:|
    * - --build-status
      - |:ballot_box_with_check:|
-     - |:x:|
+     - |:black_square_button:|
      - |:ballot_box_with_check:|
      - |:x:|
      - |:x:|
    * - --build-number
      - |:ballot_box_with_check:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
      - |:x:|
      - |:x:|
    * - --tests
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
      - |:x:|
      - |:x:|
    * - --test-name
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
      - |:x:|
      - |:x:|
    * - --test-class-name
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
      - |:x:|
      - |:x:|
    * - --test-result
-     - |:x:|
-     - |:x:|
-     - |:x:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
      - |:x:|
      - |:x:|


### PR DESCRIPTION
Right now, we use the same emoji for non-supported arguments
and not-yet-implemented arguments.

This change distinguishes between the two types by using a different
emoji for not-yet-implemented.
