### PR TITLE
Create all arguments of a group at the same level

### DIFF
--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -176,9 +176,11 @@ from {source_method.__self__.get('driver')}")
         for attr_dict in attributes.values():
             arguments = attr_dict.get('arguments')
             if arguments:
-                self.parser.extend(arguments, group_name, level=level)
                 class_type = attr_dict.get('attr_type')
                 if class_type not in [str, list, dict, int] and \
                    hasattr(class_type, 'API'):
+                    self.parser.extend(arguments, group_name, level=level+1)
                     self.extend_parser(class_type.API, class_type.__name__,
                                        level=level+1)
+                else:
+                    self.parser.extend(arguments, group_name, level=level)


### PR DESCRIPTION
This change ensures that all arguments that belong to the same group (jobs, builds, systems) are on the same level.
For example all jobs related arguments (--jobs, --job-name, --job-url) are on the same level, and a different
one that --builds. This fixes the issue causing an unnecessary call to
get_jobs with a command like cibyl --job-name name --builds (thanks @adrianfusco  for noticing).
