### PR TITLE
Filter by job URL

### DIFF
--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -57,12 +57,18 @@ class ElasticSearchOSP(Source):
             :returns: Job objects queried from elasticserach
             :rtype: :class:`AttributeDictValue`
         """
+        key_filter = None
+        if 'jobs' in kwargs:
+            jobs_to_search = kwargs.get('jobs').value
+            key_filter = 'jobName'
         if 'job_name' in kwargs:
             jobs_to_search = kwargs.get('job_name').value
-        else:
-            jobs_to_search = kwargs.get('jobs').value
+            key_filter = 'jobName'
+        if 'job_url' in kwargs:
+            jobs_to_search = kwargs.get('job_url').value
+            key_filter = 'envVars.JOB_URL'
 
-        query_body = QueryTemplate('jobName', jobs_to_search).get
+        query_body = QueryTemplate(key_filter, jobs_to_search).get
 
         hits = self.__query_get_hits(
             query=query_body

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -62,7 +62,7 @@ Arguments Matrix
    * - --job-url
      - |:ballot_box_with_check:|
      - |:x:|
-     - |:x:|
+     - |:ballot_box_with_check:|
      - |:x:|
      - |:x:|
    * - --builds


### PR DESCRIPTION
At this way the elasticsearch query will filter by URL using the default index
I've changed the conditions, if I pass jobs and at the same time job url, it will filter by job url