### PR TITLE
Filter builds by ID

### DIFF
--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -29,7 +29,7 @@ class Build(Model):
         'build_id': {
             'attr_type': str,
             'arguments': [Argument(name='--build-id', arg_type=str,
-                                   func='get_builds',
+                                   nargs='*', func='get_builds',
                                    description="Build ID")]
         },
         'status': {

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -131,6 +131,10 @@ class ElasticSearchOSP(Source):
                                   for status in
                                   kwargs.get('build_status').value]
 
+            build_id_argument = None
+            if 'build_id' in kwargs:
+                build_id_argument = kwargs.get('build_id').value
+
             for build in builds:
 
                 build_result = None
@@ -144,7 +148,13 @@ class ElasticSearchOSP(Source):
                         build['_source']['buildResult'] not in build_statuses:
                     continue
 
-                job.add_build(Build(str(build['_source']['buildID']),
+                build_id = str(build['_source']['buildID'])
+
+                if build_id_argument and \
+                        build_id not in build_id_argument:
+                    continue
+
+                job.add_build(Build(build_id,
                                     build_result,
                                     build['_source']['runDuration']))
 

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -86,7 +86,7 @@ Arguments Matrix
    * - --build-number
      - |:ballot_box_with_check:|
      - |:black_square_button:|
-     - |:black_square_button:|
+     - |:ballot_box_with_check:|
      - |:x:|
      - |:x:|
    * - --tests


### PR DESCRIPTION
- We need to filter builds by ID. I've added the condition to elasticsearch get_builds method
- I'd like to change the --build-id argument in the build model. At this way we can pass more than one ID for filtering