### PR TITLE
More robust job filtering in jenkins source

### DIFF
--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -68,7 +68,8 @@ def is_job(job):
     :returns: Whether the job representation actually corresponds to a job
     :rtype: bool
     """
-    return "job" in job["_class"]
+    job_class = job["_class"].lower()
+    return not ("view" in job_class or "folder" in job_class)
 
 
 def filter_jobs(jobs_found: List[Dict], **kwargs):

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -106,7 +106,7 @@ class TestJenkinsSource(TestCase):
                               'name': "ansible", 'url': 'url1'},
                     {'_class': 'org..job.WorkflowRun', 'name': "job2",
                      'url': 'url2'},
-                    {'_class': 'empty', 'name': 'ansible-empty'}]}
+                    {'_class': 'folder', 'name': 'ansible-empty'}]}
         self.jenkins.send_request = Mock(return_value=response)
         jobs_arg = Mock()
         jobs_arg.value = ["ansible"]
@@ -599,6 +599,32 @@ class TestFilters(TestCase):
                      'name': "ansible", 'url': 'url1',
                      'lastBuild': {'number': 1, 'result': "SUCCESS"}},
                     {'_class': 'org..job.WorkflowRun',
+                     'name': "ans2", 'url': 'url3',
+                     'lastBuild': {'number': 0, 'result': "FAILURE"}},
+                    ]
+        self.assertEqual(jobs_filtered, expected)
+
+    def test_filter_jobs_class(self):
+        """
+            Test that filter_jobs filters the jobs given the job _class.
+        """
+        response = [{'_class': 'org..job.WorkflowRun',
+                     'name': "ansible", 'url': 'url1',
+                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
+                    {'_class': 'jenkins.branch.OrganizationFolder',
+                     'name': "test_jobs", 'url': 'url2',
+                     'lastBuild': {'number': 2, 'result': "FAILURE"}},
+                    {'_class': 'com.cloudbees.hudson.plugins.folder.Folder',
+                     'name': "test_jobs", 'url': 'url2',
+                     'lastBuild': {'number': 2, 'result': "FAILURE"}},
+                    {'_class': 'hudson.model.FreeStyleProject',
+                     'name': "ans2", 'url': 'url3',
+                     'lastBuild': {'number': 0, 'result': "FAILURE"}}]
+        jobs_filtered = filter_jobs(response)
+        expected = [{'_class': 'org..job.WorkflowRun',
+                     'name': "ansible", 'url': 'url1',
+                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
+                    {'_class': 'hudson.model.FreeStyleProject',
                      'name': "ans2", 'url': 'url3',
                      'lastBuild': {'number': 0, 'result': "FAILURE"}},
                     ]


### PR DESCRIPTION
The is_job function in jenkins source expected the jenkins jobs to have
the string "job" in their "_class" argument. However jenkins jobs can
also be of type "hudson.model.FreeStyleProject". With this type, the
function checks that the jenkins object is not a folder or a view, so
freestyle projects are not filtered.

Solves OSPCRE-360
