### PR TITLE
Don't print Total jobs line if no query is done

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -101,7 +101,8 @@ def main():
     orchestrator.run_query()
     orchestrator.publisher.publish(
         orchestrator.environments,
-        verbosity=orchestrator.parser.app_args.get('verbosity'))
+        verbosity=orchestrator.parser.app_args.get('verbosity'),
+        user_arguments=len(orchestrator.parser.ci_args))
 
 
 if __name__ == "__main__":

--- a/cibyl/models/ci/environment.py
+++ b/cibyl/models/ci/environment.py
@@ -49,9 +49,11 @@ class Environment(Model):
                                                         sources=sources,
                                                         jobs_scope=jobs_scope))
 
-    def __str__(self, indent=0, verbosity=0):
+    def __str__(self, indent=0, verbosity=0, simple_representation=False):
         string = ""
         string += Colors.blue("Environment: ") + f"{self.name.value}"
         for system in self.systems:
-            string += f"\n{system.__str__(indent + 2, verbosity)}"
+            system_str = system.__str__(indent + 2, verbosity,
+                                        simple_representation)
+            string += f"\n{system_str}"
         return string

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -117,14 +117,16 @@ class JobsSystem(System):
                          pipelines=None, jobs_scope=jobs_scope,
                          sources=sources, jobs=jobs)
 
-    def __str__(self, indent=0, verbosity=0):
+    def __str__(self, indent=0, verbosity=0, simple_representation=False):
         string = indent*' ' + Colors.blue("System: ") + f"{self.name.value}"
         if verbosity > 0:
             string += f" (type: {self.system_type.value})"
         for job in self.jobs.values():
             string += f"\n{job.__str__(indent+2, verbosity)}"
-        string += "\n" + indent*' ' + \
-            Colors.blue("Total jobs: ") + f"{len(self.jobs)}"
+        if not simple_representation:
+            string += "\n" + indent*' '
+            string += Colors.blue("Total jobs found in query: ")
+            string += f"{len(self.jobs)}"
         return string
 
     def add_toplevel_model(self, model: Job):

--- a/cibyl/publisher.py
+++ b/cibyl/publisher.py
@@ -25,10 +25,14 @@ class Publisher:
     """
 
     @staticmethod
-    def publish(environments, dest="terminal", verbosity=0):
+    def publish(environments, dest="terminal", verbosity=0, user_arguments=0):
         """Publishes the data of the given environments to the
         chosen destination.
         """
+        # if the user did not pass any query argument (--jobs, --builds, ...)
+        # print only a simple representation of the environment
+        simple_representation = user_arguments == 0
         if dest == "terminal":
             for env in environments:
-                print(env.__str__(verbosity=verbosity))
+                print(env.__str__(verbosity=verbosity,
+                                  simple_representation=simple_representation))


### PR DESCRIPTION
If the user does not pass any argument to cibyl and no query is
performed, just the environments and systems are printed, the line about
total jobs is avoided.

With this change running `cibyl` shows 

```
Environment: osp_phases
  System: osp_ci_system
Environment: component_ci
  System: zuul_system
```

While running a query like `cibyl --jobs` shows
```
Environment: osp_phases
  System: osp_jenkins
    Job: job1
    Job: job2
  Total jobs found in query: 6
```
This is done introducing a variable to know whether any argument was passed to cibyl and avoid printing the additional line and passing it to system and environment `__str__` methods. A simpler change would be to just modify the total jobs message to make it less ambiguous, so running `cibyl` would show
```
Environment: osp_phases
  System: osp_ci_system
  Total jobs found in query: 0
Environment: component_ci
  System: zuul_system
  Total jobs found in query: 0
```