### PR TITLE
Clearer message for no sources found with --sources

### DIFF
--- a/cibyl/exceptions/source.py
+++ b/cibyl/exceptions/source.py
@@ -23,18 +23,22 @@ class NoSupportedSourcesFound(CibylException):
 
     def __init__(self, system, function):
         self.message = f"""Couldn't find any enabled source for the system
-{system} that implements the function {function}.
-"""
+{system} that implements the function {function}.""".replace("\n", " ")
         super().__init__(self.message)
 
 
 class NoValidSources(CibylException):
     """Exception for a case when no valid source is found."""
 
-    def __init__(self, system):
-        self.system = system
-        self.message = f"""No valid source defined for the system
+    def __init__(self, system=None):
+        if system:
+            self.system = system
+            self.message = f"""No valid source defined for the system
 {self.system}.  Please ensure the specified sources with --source argument
-are present in the configuration.
-"""
+are present in the configuration.""".replace("\n", " ")
+        else:
+            self.message = """No valid source found. Please ensure the
+specified sources with --source argument are present in the
+configuration.""".replace("\n", " ")
+
         super().__init__(self.message)


### PR DESCRIPTION
Until now, the environments and systems would be filtered according to
the values of --env-name, --systems and --sources arguments, presenting
a unique error message if no valid system was found. This was confusing
if the source of error was the --source value. With this change, the
checks for --systems and --sources are separated and provide to
different  messages in case of error for better user experience.
