### PR TITLE
Support querying for storage backend in jenkins

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -84,17 +84,25 @@ class Deployment(Model):
                                    ranged=True,
                                    description="Number of computes used "
                                    "in the deployment")]
+            },
+        'storage_backend': {
+            'attr_type': str,
+            'arguments': [Argument(name='--storage-backend', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   description="Storage backend used in the "
+                                   "deployment")]
             }
     }
 
     def __init__(self, release: float, infra_type: str,
                  nodes: List[Node], services: List[Service],
                  ip_version: str = None, topology: str = None,
-                 network_backend: str = None):
+                 network_backend: str = None, storage_backend: str = None):
         super().__init__({'release': release, 'infra_type': infra_type,
                           'nodes': nodes, 'services': services,
                           'ip_version': ip_version, 'topology': topology,
-                          'network_backend': network_backend})
+                          'network_backend': network_backend,
+                          'storage_backend': storage_backend})
 
     def __str__(self, indent=0, verbosity=0):
         indent_space = indent*' '
@@ -116,7 +124,10 @@ class Deployment(Model):
             info += f'\n{indent_space}' + Colors.blue('Topology: ')
             info += f'{self.topology}'
         if self.network_backend.value:
-            info += f'\n{indent_space}' + Colors.blue('Nework backend: ')
+            info += f'\n{indent_space}' + Colors.blue('Network backend: ')
             info += f'{self.network_backend}'
+        if self.storage_backend.value:
+            info += f'\n{indent_space}' + Colors.blue('Storage backend: ')
+            info += f'{self.storage_backend}'
 
         return info

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -24,6 +24,7 @@ RELEASE_PATTERN = re.compile(r"\d\d\.?\d?")
 TOPOLOGY_PATTERN = re.compile(r"(\d([a-zA-Z])+_?)+")
 PROPERTY_PATTERN = re.compile(r"=(.*)")
 NETWORK_BACKEND_PATTERN = re.compile("geneve|gre|vlan|vxlan")
+STORAGE_BACKEND_PATTERN = re.compile("ceph|lvm|netapp-iscsi|netapp-nfs|swift")
 
 
 def satisfy_regex_match(model: Dict[str, str], pattern: Pattern,

--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -83,7 +83,7 @@ Arguments Matrix
      - |:black_square_button:|
      - |:black_square_button:|
    * - --storage-backend
-     - |:black_square_button:|
+     - |:ballot_box_with_check:|
      - |:black_square_button:|
      - |:black_square_button:|
      - |:black_square_button:|


### PR DESCRIPTION
Extract the storage backend either from the job name or from artifacts.
This change also attempts to read the run.sh artifact to extract
deployment information.
