### PR TITLE
Add information on sources for developers

### DIFF
--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -9,4 +9,4 @@ To add/develop a new type of source, follow the following guidelines:
 
 * For a source to support an argument, it should implement the function name associated with that argument
 
-* Each source method that implements a method of an argument, should be returning an AttributeDict value of the top level entity associated with the CI systems (e.g. ``AttributeDictValue("jobs", attr_type=Job, value=job_objects)``) 
+* Each source method that implements a method of an argument, should be returning an AttributeDict value of the top level entity associated with the CI systems (e.g. ``AttributeDictValue("jobs", attr_type=Job, value=job_objects)``)

--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -1,0 +1,12 @@
+Sources
+=======
+
+To add/develop a new type of source, follow the following guidelines:
+
+* A source should be added to cibyl/sources/<SOURCE_NAME>
+
+* The source class you develop should inherit from the Source class (cibyl/sources/)
+
+* For a source to support an argument, it should implement the function name associated with that argument
+
+* Each source method that implements a method of an argument, should be returning an AttributeDict value of the top level entity associated with the CI systems (e.g. ``AttributeDictValue("jobs", attr_type=Job, value=job_objects)``) 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,6 +76,7 @@ Welcome to Cibyl's documentation!
    :caption: Developers
 
    development/tests
+   development/sources
    development/contribute
 
 


### PR DESCRIPTION
It probably doesn't makes sense to mix user documentation
and development documentation in the same page.

This change removes the development info on sources
into its own page under development section.
