### PR TITLE
Support querying for deployment type in jenkins

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -38,6 +38,7 @@ class Deployment(Model):
         'infra_type': {
             'attr_type': str,
             'arguments': [Argument(name='--infra-type', arg_type=str,
+                                   func='get_deployment', nargs='*',
                                    description="Infra type")]
         },
         'nodes': {
@@ -109,8 +110,9 @@ class Deployment(Model):
         info = f'{indent_space}' + Colors.blue("Release: ")
         info += f'{self.release.value}'
 
-        info += f'\n{indent_space}' + Colors.blue('Infra type: ')
-        info += f'{self.infra_type.value}'
+        if self.infra_type.value:
+            info += f'\n{indent_space}' + Colors.blue('Infra type: ')
+            info += f'{self.infra_type.value}'
         for node in self.nodes:
             info += f'\n{indent_space}  '
             info += f'{node.__str__(indent=indent+2, verbosity=verbosity)}'

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -25,6 +25,7 @@ TOPOLOGY_PATTERN = re.compile(r"(\d([a-zA-Z])+_?)+")
 PROPERTY_PATTERN = re.compile(r"=(.*)")
 NETWORK_BACKEND_PATTERN = re.compile("geneve|gre|vlan|vxlan")
 STORAGE_BACKEND_PATTERN = re.compile("ceph|lvm|netapp-iscsi|netapp-nfs|swift")
+DEPLOYMENT_PATTERN = re.compile("ovb|baremetal")
 
 
 def satisfy_regex_match(model: Dict[str, str], pattern: Pattern,

--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -52,6 +52,12 @@ Arguments Matrix
      - |:black_square_button:|
      - |:black_square_button:|
      - |:black_square_button:|
+   * - --infra-type
+     - |:ballot_box_with_check:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
    * - --topology
      - |:ballot_box_with_check:|
      - |:black_square_button:|

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -642,6 +642,34 @@ class TestJenkinsSource(TestCase):
         self.assertEqual(deployment.ip_version.value, "4")
         self.assertEqual(deployment.topology.value, topology_value)
 
+    def test_get_deployment_filter_infra_type(self):
+        """Test that get_deployment filters by infra type."""
+        job_names = ['test_17.3_ipv4_job_2comp_1cont_ovb',
+                     'test_16_ipv6_job_1comp_2cont_virt', 'test_job']
+        topology_value = "compute:2,controller:1"
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastBuild': None})
+
+        self.jenkins.send_request = Mock(side_effect=[response])
+        arg = Argument("infra_type", arg_type=str, description="",
+                       value=["ovb"])
+
+        jobs = self.jenkins.get_deployment(infra_type=arg)
+        self.assertEqual(len(jobs), 1)
+        job_name = 'test_17.3_ipv4_job_2comp_1cont_ovb'
+        job = jobs[job_name]
+        deployment = job.deployment.value
+        self.assertEqual(job.name.value, job_name)
+        self.assertEqual(job.url.value, "url")
+        self.assertEqual(len(job.builds.value), 0)
+        self.assertEqual(deployment.release.value, "17.3")
+        self.assertEqual(deployment.ip_version.value, "4")
+        self.assertEqual(deployment.topology.value, topology_value)
+        self.assertEqual(deployment.infra_type.value, "ovb")
+
 
 class TestFilters(TestCase):
     """Tests for filter functions in jenkins source module."""


### PR DESCRIPTION
Extract the deployment type information from job name. At this point
there seems to be any robust way to extract it from any artifact.
