### PR TITLE
Add node objects to deployment in jenkins source

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -113,12 +113,6 @@ class Deployment(Model):
         if self.infra_type.value:
             info += f'\n{indent_space}' + Colors.blue('Infra type: ')
             info += f'{self.infra_type.value}'
-        for node in self.nodes:
-            info += f'\n{indent_space}  '
-            info += f'{node.__str__(indent=indent+2, verbosity=verbosity)}'
-        if self.services.value:
-            info += f'\n{indent_space}' + Colors.blue('Service: ')
-            info += f'{self.services.value}'
         if self.ip_version.value:
             info += f'\n{indent_space}' + Colors.blue('IP version: ')
             info += f'{self.ip_version}'
@@ -131,5 +125,11 @@ class Deployment(Model):
         if self.storage_backend.value:
             info += f'\n{indent_space}' + Colors.blue('Storage backend: ')
             info += f'{self.storage_backend}'
+        for node in self.nodes:
+            info += f'\n{indent_space}  '
+            info += f'{node.__str__(indent=indent+2, verbosity=verbosity)}'
+        if self.services.value:
+            info += f'\n{indent_space}' + Colors.blue('Service: ')
+            info += f'{self.services.value}'
 
         return info

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -259,6 +259,8 @@ class TestJenkinsSource(TestCase):
         ip_versions = ['4', '6', 'unknown']
         releases = ['17.3', '16', '']
         topologies = ["compute:2,controller:1", "compute:1,controller:2", ""]
+        nodes = [["compute-0", "compute-1", "controller-0"],
+                 ["compute-0", "controller-0", "controller-1"]]
 
         response = {'jobs': [{'_class': 'folder'}]}
         for job_name in job_names:
@@ -272,8 +274,11 @@ class TestJenkinsSource(TestCase):
 
         jobs = self.jenkins.get_deployment(ip_version=arg)
         self.assertEqual(len(jobs), 3)
-        for job_name, ip, release, topology in zip(job_names, ip_versions,
-                                                   releases, topologies):
+        for job_name, ip, release, topology, node_list in zip(job_names,
+                                                              ip_versions,
+                                                              releases,
+                                                              topologies,
+                                                              nodes):
             job = jobs[job_name]
             deployment = job.deployment.value
             self.assertEqual(job.name.value, job_name)
@@ -282,6 +287,9 @@ class TestJenkinsSource(TestCase):
             self.assertEqual(deployment.release.value, release)
             self.assertEqual(deployment.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
+            for node, node_name in zip(deployment.nodes, node_list):
+                self.assertEqual(node.name.value, node_name)
+                self.assertEqual(node.role.value, node_name.split("-")[0])
 
     def test_get_deployment_many_jobs(self):
         """ Test that get_deployment reads properly the information obtained


### PR DESCRIPTION
When creating a deployment, use the topology to create a basic version
of node objects.
