### PR TITLE
Support querying for dvr use in jenkins

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -69,6 +69,13 @@ class Deployment(Model):
                                    description="Topology used in the "
                                    "deployment")]
             },
+        'dvr': {
+            'attr_type': str,
+            'arguments': [Argument(name='--dvr', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   description="Whether dvr is used in the "
+                                   "deployment")]
+            },
         'network_backend': {
             'attr_type': str,
             'arguments': [Argument(name='--network-backend', arg_type=str,
@@ -98,12 +105,14 @@ class Deployment(Model):
     def __init__(self, release: float, infra_type: str,
                  nodes: List[Node], services: List[Service],
                  ip_version: str = None, topology: str = None,
-                 network_backend: str = None, storage_backend: str = None):
+                 network_backend: str = None, storage_backend: str = None,
+                 dvr: str = None):
         super().__init__({'release': release, 'infra_type': infra_type,
                           'nodes': nodes, 'services': services,
                           'ip_version': ip_version, 'topology': topology,
                           'network_backend': network_backend,
-                          'storage_backend': storage_backend})
+                          'storage_backend': storage_backend,
+                          'dvr': dvr})
 
     def __str__(self, indent=0, verbosity=0):
         indent_space = indent*' '
@@ -125,6 +134,9 @@ class Deployment(Model):
         if self.storage_backend.value:
             info += f'\n{indent_space}' + Colors.blue('Storage backend: ')
             info += f'{self.storage_backend}'
+        if self.dvr.value:
+            info += f'\n{indent_space}' + Colors.blue('DVR: ')
+            info += f'{self.dvr}'
         for node in self.nodes:
             info += f'\n{indent_space}  '
             info += f'{node.__str__(indent=indent+2, verbosity=verbosity)}'

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -26,6 +26,9 @@ PROPERTY_PATTERN = re.compile(r"=(.*)")
 NETWORK_BACKEND_PATTERN = re.compile("geneve|gre|vlan|vxlan")
 STORAGE_BACKEND_PATTERN = re.compile("ceph|lvm|netapp-iscsi|netapp-nfs|swift")
 DEPLOYMENT_PATTERN = re.compile("ovb|baremetal")
+DVR_OPTIONS = re.compile("yes|no|true|false")
+DVR_PATTERN_RUN = re.compile(rf"--network-dvr ({DVR_OPTIONS.pattern})")
+DVR_PATTERN_NAME = re.compile(r"(non*_)*dvr")
 
 
 def satisfy_regex_match(model: Dict[str, str], pattern: Pattern,

--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -77,7 +77,7 @@ Arguments Matrix
      - |:black_square_button:|
      - |:black_square_button:|
    * - --dvr
-     - |:black_square_button:|
+     - |:ballot_box_with_check:|
      - |:black_square_button:|
      - |:black_square_button:|
      - |:black_square_button:|

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock, patch
 
 from cibyl.cli.argument import Argument
 from cibyl.exceptions.jenkins import JenkinsError
+from cibyl.plugins import extend_models
 from cibyl.sources.jenkins import (Jenkins, filter_builds, filter_jobs,
                                    safe_request)
 
@@ -55,6 +56,9 @@ class TestJenkinsSource(TestCase):
 
     def setUp(self):
         self.jenkins = Jenkins("url", "user", "token")
+        # call opentstack plugin to ensure that get_deployment tests can always
+        # run
+        extend_models("openstack")
 
     # pylint: disable=protected-access
     def test_with_all_args(self):
@@ -677,6 +681,78 @@ class TestJenkinsSource(TestCase):
         self.assertEqual(deployment.ip_version.value, "4")
         self.assertEqual(deployment.topology.value, topology_value)
         self.assertEqual(deployment.infra_type.value, "ovb")
+
+    def test_get_deployment_filter_dvr(self):
+        """Test that get_deployment filters by dvr."""
+        job_names = ['test_17.3_ipv4_job_2comp_1cont_no_dvr',
+                     'test_16_ipv6_job_1comp_2cont_dvr', 'test_job']
+        topology_value = "compute:2,controller:1"
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastBuild': None})
+
+        self.jenkins.send_request = Mock(side_effect=[response])
+        arg = Argument("dvr", arg_type=str, description="",
+                       value=["False"])
+
+        jobs = self.jenkins.get_deployment(dvr=arg)
+        self.assertEqual(len(jobs), 1)
+        job_name = 'test_17.3_ipv4_job_2comp_1cont_no_dvr'
+        job = jobs[job_name]
+        deployment = job.deployment.value
+        self.assertEqual(job.name.value, job_name)
+        self.assertEqual(job.url.value, "url")
+        self.assertEqual(len(job.builds.value), 0)
+        self.assertEqual(deployment.release.value, "17.3")
+        self.assertEqual(deployment.ip_version.value, "4")
+        self.assertEqual(deployment.topology.value, topology_value)
+        self.assertEqual(deployment.dvr.value, "False")
+
+    def test_get_deployment_artifacts_dvr(self):
+        """ Test that get_deployment reads properly the information obtained
+        from jenkins using artifacts.
+        """
+        job_names = ['test_17.3_ipv4_job', 'test_16_ipv6_job', 'test_job']
+        ip_versions = ['4', '6', 'unknown']
+        releases = ['17.3', '16', '']
+        dvr_status = ['True', 'True', '']
+        topologies = ["compute:2,controller:3", "compute:1,controller:2",
+                      "compute:2,controller:2"]
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastBuild': {}})
+        # ensure that all deployment properties are found in the artifact so
+        # that it does not fallback to reading values from job name
+        fill = "STORAGE_BACKEND\nNETWORK_BACKEND\nNETWORK_PROTOCOL"
+        artifacts = [
+           f"bl\nJP_TOPOLOGY='{topologies[0]}'\nPRODUCT_VERSION=17.3\n{fill}" +
+           "\nNETWORK_DVR='yes'",
+           f"bl\nJP_TOPOLOGY='{topologies[1]}'\nPRODUCT_VERSION=16\n{fill}" +
+           "\n--network-dvr true",
+           f"bla\nJP_TOPOLOGY='{topologies[2]}'\nPRODUCT_VERSION=\n{fill}",
+            ]
+
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
+
+        jobs = self.jenkins.get_deployment()
+        self.assertEqual(len(jobs), 3)
+        for job_name, ip, release, topology, dvr in zip(job_names, ip_versions,
+                                                        releases, topologies,
+                                                        dvr_status):
+            job = jobs[job_name]
+            deployment = job.deployment.value
+            self.assertEqual(job.name.value, job_name)
+            self.assertEqual(job.url.value, "url")
+            self.assertEqual(len(job.builds.value), 0)
+            self.assertEqual(deployment.release.value, release)
+            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(deployment.topology.value, topology)
+            self.assertEqual(deployment.dvr.value, dvr)
 
 
 class TestFilters(TestCase):


### PR DESCRIPTION
Extract dvr information from the artifacts or the job name. The job name
extraction is probably less reliable, but it seems well-defined in the
artifacts.
