### PR TITLE
Deprecate --job-name argument

### DIFF
--- a/cibyl/models/ci/job.py
+++ b/cibyl/models/ci/job.py
@@ -32,9 +32,7 @@ class Job(Model):
     API = {
         'name': {
             'attr_type': str,
-            'arguments': [Argument(name='--job-name', arg_type=str,
-                                   description="Job name",
-                                   func='get_jobs')]
+            'arguments': []
         },
         'url': {
             'attr_type': str,

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -63,9 +63,6 @@ class ElasticSearchOSP(Source):
         if 'jobs' in kwargs:
             jobs_to_search = kwargs.get('jobs').value
             key_filter = 'jobName'
-        if 'job_name' in kwargs:
-            jobs_to_search = kwargs.get('job_name').value
-            key_filter = 'jobName'
         if 'job_url' in kwargs:
             jobs_to_search = kwargs.get('job_url').value
             key_filter = 'envVars.JOB_URL'
@@ -195,9 +192,7 @@ class ElasticSearchOSP(Source):
         :rtype: :class:`AttributeDictValue`
         """
         jobs_to_search = []
-        if 'job_name' in kwargs:
-            jobs_to_search = kwargs.get('job_name').value
-        elif 'jobs' in kwargs:
+        if 'jobs' in kwargs:
             jobs_to_search = kwargs.get('jobs').value
 
         query_body = QueryTemplate('jobName', jobs_to_search).get

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -86,12 +86,6 @@ def filter_jobs(jobs_found: List[Dict], **kwargs):
         checks_to_apply.append(partial(satisfy_regex_match, pattern=pattern,
                                        field_to_check="name"))
 
-    job_names = kwargs.get('job_name')
-    if job_names:
-        checks_to_apply.append(partial(satisfy_exact_match,
-                                       user_input=job_names,
-                                       field_to_check="name"))
-
     job_urls = kwargs.get('job_url')
     if job_urls:
         checks_to_apply.append(partial(satisfy_exact_match,

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -53,12 +53,6 @@ Arguments Matrix
      - |:ballot_box_with_check:|
      - |:ballot_box_with_check:|
      - |:x:|
-   * - --job-name
-     - |:ballot_box_with_check:|
-     - |:black_square_button:|
-     - |:ballot_box_with_check:|
-     - |:black_square_button:|
-     - |:black_square_button:|
    * - --job-url
      - |:ballot_box_with_check:|
      - |:black_square_button:|

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -880,7 +880,7 @@ class TestFilters(TestCase):
                     ]
         self.assertEqual(jobs_filtered, expected)
 
-    def test_filter_job_name_job_url(self):
+    def test_filter_jobs_job_url(self):
         """
             Test that filter_jobs filters the jobs given the user input.
         """
@@ -893,36 +893,15 @@ class TestFilters(TestCase):
                     {'_class': 'org..job.WorkflowRun',
                      'name': "ans2", 'url': 'url3',
                      'lastBuild': {'number': 0, 'result': "FAILURE"}}]
-        job_name = Mock()
-        job_name.value = ["ans2"]
+        jobs = Mock()
+        jobs.value = ["ans2"]
         job_url = Mock()
         job_url.value = ["url3"]
-        jobs_filtered = filter_jobs(response, job_name=job_name,
+        jobs_filtered = filter_jobs(response, jobs=jobs,
                                     job_url=job_url)
         expected = [{'_class': 'org..job.WorkflowRun',
                      'name': "ans2", 'url': 'url3',
                      'lastBuild': {'number': 0, 'result': "FAILURE"}}]
-        self.assertEqual(jobs_filtered, expected)
-
-    def test_filter_job_name(self):
-        """
-            Test that filter_jobs filters the jobs given the user input.
-        """
-        response = [{'_class': 'org..job.WorkflowRun',
-                     'name': "ansible", 'url': 'url1',
-                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
-                    {'_class': 'org..job.WorkflowRun',
-                     'name': "test_jobs", 'url': 'url2',
-                     'lastBuild': {'number': 2, 'result': "FAILURE"}},
-                    {'_class': 'org..job.WorkflowRun',
-                     'name': "ans2", 'url': 'url3',
-                     'lastBuild': {'number': 0, 'result': "FAILURE"}}]
-        job_name = Mock()
-        job_name.value = ["ansible"]
-        jobs_filtered = filter_jobs(response, job_name=job_name)
-        expected = [{'_class': 'org..job.WorkflowRun',
-                     'name': "ansible", 'url': 'url1',
-                     'lastBuild': {'number': 1, 'result': "SUCCESS"}}]
         self.assertEqual(jobs_filtered, expected)
 
     def test_filter_job_url(self):
@@ -945,32 +924,6 @@ class TestFilters(TestCase):
         expected = [{'_class': 'org..job.WorkflowRun',
                      'name': "test_jobs", 'url': 'url2',
                      'lastBuild': {'number': 2, 'result': "FAILURE"}}]
-        self.assertEqual(jobs_filtered, expected)
-
-    def test_filter_job_name_job_url_jobs(self):
-        """
-            Test that filter_jobs filters the jobs given the user input.
-        """
-        response = [{'_class': 'org..job.WorkflowRun',
-                     'name': "ansible", 'url': 'url1',
-                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
-                    {'_class': 'org..job.WorkflowRun',
-                     'name': "test_jobs", 'url': 'url2',
-                     'lastBuild': {'number': 2, 'result': "FAILURE"}},
-                    {'_class': 'org..job.WorkflowRun',
-                     'name': "ans2", 'url': 'url3',
-                     'lastBuild': {'number': 0, 'result': "FAILURE"}}]
-        args = Mock()
-        args.value = ["ans"]
-        job_name = Mock()
-        job_name.value = ["ansible"]
-        job_url = Mock()
-        job_url.value = ["url1"]
-        jobs_filtered = filter_jobs(response, jobs=args, job_url=job_url,
-                                    job_name=job_name)
-        expected = [{'_class': 'org..job.WorkflowRun',
-                     'name': "ansible", 'url': 'url1',
-                     'lastBuild': {'number': 1, 'result': "SUCCESS"}}]
         self.assertEqual(jobs_filtered, expected)
 
     def test_filter_builds_builds_build_id_build_status_empty(self):


### PR DESCRIPTION
The funcionality of --job-name is already provided by --jobs.
