### PR TITLE
Support querying multiple sources

### DIFF
--- a/cibyl/exceptions/__init__.py
+++ b/cibyl/exceptions/__init__.py
@@ -1,3 +1,4 @@
+"""
 #    Copyright 2022 Red Hat
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -11,15 +12,17 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+"""
 import sys
 
 from cibyl.utils.colors import Colors
 
 
 class CibylException(Exception):
+    """Parent class for all cibyl exceptions for easier control of the
+    exceptions' representation."""
     def __init__(self, message=''):
-        """Constructor.
-        """
+        """Constructor."""
         super().__init__(*[message])
 
     @staticmethod

--- a/cibyl/exceptions/elasticsearch.py
+++ b/cibyl/exceptions/elasticsearch.py
@@ -13,10 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from cibyl.exceptions import CibylException
+from cibyl.exceptions.source import SourceException
 
 
-class ElasticSearchError(CibylException):
+class ElasticSearchError(SourceException):
     """Elasticsearch error.
     Used for personalized elasticsearch exceptions
     """

--- a/cibyl/exceptions/jenkins.py
+++ b/cibyl/exceptions/jenkins.py
@@ -13,8 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from cibyl.exceptions import CibylException
+from cibyl.exceptions.source import SourceException
 
 
-class JenkinsError(CibylException):
+class JenkinsError(SourceException):
     """Represents an error occurring while querying Jenkins."""

--- a/cibyl/exceptions/jenkins_job_builder.py
+++ b/cibyl/exceptions/jenkins_job_builder.py
@@ -13,8 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from cibyl.exceptions import CibylException
+from cibyl.exceptions.source import SourceException
 
 
-class JenkinsJobBuilderError(CibylException):
+class JenkinsJobBuilderError(SourceException):
     """Represents an error occurring while querying JenkinsJobBuilder."""

--- a/cibyl/exceptions/source.py
+++ b/cibyl/exceptions/source.py
@@ -42,3 +42,8 @@ specified sources with --source argument are present in the
 configuration.""".replace("\n", " ")
 
         super().__init__(self.message)
+
+
+class SourceException(CibylException):
+    """Abstract exception to representation any error while querying a
+    source."""

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -21,7 +21,7 @@ from cibyl.cli.parser import Parser
 from cibyl.cli.validator import Validator
 from cibyl.config import Config, ConfigFactory
 from cibyl.exceptions.config import InvalidConfiguration
-from cibyl.exceptions.source import NoValidSources
+from cibyl.exceptions.source import NoValidSources, SourceException
 from cibyl.models.ci.environment import Environment
 from cibyl.publisher import Publisher
 from cibyl.sources.source import get_source_method
@@ -115,8 +115,9 @@ class Orchestrator:
         :param argument: argument that is considered for the query
         :type argument: :class:`.Argument`
 
-        :returns: method to call from the selected source
-        :rtype: function
+        :returns: List of pairs with source method and its speed index sorted
+        by the speed index value
+        :rtype: tuple
         """
         sources_user = self.parser.ci_args.get("sources")
         system_sources = system.sources
@@ -150,25 +151,40 @@ class Orchestrator:
                 # because the environment information is not used from this
                 # point forward
                 for system in valid_systems:
-                    source_method = self.select_source_method(system, arg)
-                    if source_methods_store.has_been_called(source_method):
-                        # we want to avoid repeating calls to the same source
-                        # method if several argument with that method are
-                        # provided
-                        continue
-                    source_methods_store.add_call(source_method)
-                    start_time = time.time()
-                    LOG.debug(f"Running {source_method.__name__} method \
-from {source_method.__self__.get('driver')}")
-                    model_instances_dict = source_method(
-                        **self.parser.ci_args, **self.parser.app_args)
-                    end_time = time.time()
-                    LOG.info("Took %.2fs to query system %s using %s",
-                             end_time-start_time, system.name.value,
-                             source_information_from_method(source_method))
-                    # only update last_level if the query was successful
-                    last_level = arg.level
-                    system.populate(model_instances_dict)
+                    source_methods = self.select_source_method(system, arg)
+                    for source_method, speed_score in source_methods:
+                        if source_methods_store.has_been_called(source_method):
+                            # we want to avoid repeating calls to the same
+                            # source method if several argument with that
+                            # method are provided
+                            continue
+                        source_methods_store.add_call(source_method)
+                        source_driver = source_method.__self__.get('driver')
+                        source_name = source_method.__self__.get('name')
+                        start_time = time.time()
+                        LOG.debug("Running %s method from %s of type %s and"
+                                  " speed index %d", source_method.__name__,
+                                  source_name, source_driver, speed_score)
+                        try:
+                            model_instances_dict = source_method(
+                                **self.parser.ci_args, **self.parser.app_args)
+                        except SourceException as exception:
+                            if self.parser.app_args.get("debug"):
+                                LOG.error(exception, exc_info=True)
+                            else:
+                                LOG.error("Error in source %s. %s",
+                                          source_name, exception)
+                            continue
+                        end_time = time.time()
+                        LOG.info("Took %.2fs to query system %s using %s",
+                                 end_time-start_time, system.name.value,
+                                 source_information_from_method(source_method))
+                        # only update last_level if the query was successful
+                        last_level = arg.level
+                        system.populate(model_instances_dict)
+                        # if once source has provided the information, there is
+                        # no need to query the rest
+                        break
 
     def extend_parser(self, attributes, group_name='Environment',
                       level=0):

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -74,7 +74,8 @@ def is_job(job):
     :rtype: bool
     """
     job_class = job["_class"].lower()
-    return not ("view" in job_class or "folder" in job_class)
+    return not ("view" in job_class or "folder" in job_class or "multibranch"
+                in job_class)
 
 
 def filter_jobs(jobs_found: List[Dict], **kwargs):

--- a/cibyl/sources/source.py
+++ b/cibyl/sources/source.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 import logging
+from operator import itemgetter
 from typing import Dict
 
 import requests
@@ -58,7 +59,8 @@ def safe_request_generic(request, custom_error):
                  f"Got response {ex.response.status_code} from target host."
             ) from ex
         except Exception as ex:
-            raise custom_error('Failure on request to target host.') from ex
+            raise custom_error('Failure on request to target host.'
+                               f' {str(ex)}') from ex
 
     return request_handler
 
@@ -116,8 +118,8 @@ def get_source_speed_score(source, func_name: str, args: Dict[str, Argument]):
 
 def get_source_method(system_name: str, sources: list, func_name: str,
                       args: Dict[str, Argument]):
-    """Returns a method of a single source given all the sources
-    of the system and the name of function.
+    """Returns a list of sources' methods that provided the functionality
+    requested by the user sorted by the speed index.
 
     :param system_name: The name of system
     :type system_name: str
@@ -129,25 +131,23 @@ def get_source_method(system_name: str, sources: list, func_name: str,
     :type args: dict
     :raises: NoSupportedSourcesFound if no sources with the function name are
     found
+    :returns: List of pairs with source method and its speed index sorted by
+    the speed index
+    :rtype: tuple
     """
 
-    speed_score = 0
-    source_method = None
-
+    valid_sources = []
     for source in sources:
         if is_source_valid(source, func_name):
             source_speed_score = get_source_speed_score(source,
                                                         func_name, args)
-            if source_speed_score > speed_score:
-                source_method = getattr(source, func_name)
-                speed_score = source_speed_score
+            source_method = getattr(source, func_name)
+            valid_sources.append((source_method, source_speed_score))
 
-    if not source_method:
+    if not valid_sources:
         raise NoSupportedSourcesFound(system_name, func_name)
-    LOG.debug("chose source %s with speed score %d",
-              source_method.__self__.get('driver'), speed_score)
 
-    return source_method
+    return sorted(valid_sources, key=itemgetter(1), reverse=True)
 
 
 def speed_index(speed):

--- a/cibyl/sources/zuul/api.py
+++ b/cibyl/sources/zuul/api.py
@@ -15,8 +15,10 @@
 """
 from abc import ABC, abstractmethod
 
+from cibyl.exceptions.source import SourceException
 
-class ZuulAPIError(Exception):
+
+class ZuulAPIError(SourceException):
     """Represents an error occurring while performing a call to Zuul's API
     """
 


### PR DESCRIPTION
If multiple sources are available for a given argument, try to query
them sorted by the speed index, until one is sucessful. This change
introduces a SourceException type, to catch all exceptions ocurring
while querying a source (i.e. connection issues).

Solves OSPCRE-322
