### PR TITLE
Add Service model and extend Deployment

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -13,10 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from typing import List
+from typing import Dict
 
 from cibyl.cli.argument import Argument
-from cibyl.models.attribute import AttributeListValue
+from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.model import Model
 from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.service import Service
@@ -43,14 +43,14 @@ class Deployment(Model):
         },
         'nodes': {
             'attr_type': Node,
-            'attribute_value_class': AttributeListValue,
+            'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--nodes', arg_type=str,
                                    nargs='*',
                                    description="Nodes on the deployment")]
         },
         'services': {
             'attr_type': Service,
-            'attribute_value_class': AttributeListValue,
+            'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--services', arg_type=str,
                                    nargs='*',
                                    description="Services in the deployment")]
@@ -109,8 +109,8 @@ class Deployment(Model):
             }
     }
 
-    def __init__(self, release: float, infra_type: str,
-                 nodes: List[Node], services: List[Service],
+    def __init__(self, release: str, infra_type: str,
+                 nodes: Dict[str, Node], services: Dict[str, Service],
                  ip_version: str = None, topology: str = None,
                  network_backend: str = None, storage_backend: str = None,
                  dvr: str = None, tls_everywhere: str = None):
@@ -147,10 +147,58 @@ class Deployment(Model):
         if self.tls_everywhere.value:
             info += f'\n{indent_space}' + Colors.blue('TLS everywhere: ')
             info += f'{self.tls_everywhere}'
-        for node in self.nodes:
+        for node in self.nodes.values():
             info += f'\n{node.__str__(indent=indent+2, verbosity=verbosity)}'
-        if self.services.value:
-            info += f'\n{indent_space}' + Colors.blue('Service: ')
-            info += f'{self.services.value}'
+        for service in self.services.values():
+            info += '\n'
+            info += f'{service.__str__(indent=indent+2, verbosity=verbosity)}'
 
         return info
+
+    def add_node(self, node: Node):
+        """Add a node to the deployment.
+
+        :param node: Node to add to the deployment
+        :type node: Node
+        """
+        node_name = node.name.value
+        if node_name in self.nodes:
+            self.nodes[node_name].merge(node)
+        else:
+            self.nodes[node_name] = node
+
+    def add_service(self, service: Service):
+        """Add a service to the deployment.
+
+        :param service: Service to add to the deployment
+        :type service: Service
+        """
+        service_name = service.name.value
+        if service_name in self.services:
+            self.services[service_name].merge(service)
+        else:
+            self.services[service_name] = service
+
+    def merge(self, other):
+        """Merge the information of two deployment objects representing the
+        same deployment.
+
+        :param other: The Deployment object to merge
+        :type other: :class:`.Deployment`
+        """
+        if not self.ip_version.value:
+            self.ip_version.value = other.ip_version.value
+        if not self.topology.value:
+            self.topology.value = other.topology.value
+        if not self.network_backend.value:
+            self.network_backend.value = other.network_backend.value
+        if not self.storage_backend.value:
+            self.storage_backend.value = other.storage_backend.value
+        if not self.dvr.value:
+            self.dvr.value = other.dvr.value
+        if not self.tls_everywhere.value:
+            self.tls_everywhere.value = other.tls_everywhere.value
+        for node in other.nodes.values():
+            self.add_node(node)
+        for service in other.services.values():
+            self.add_service(service)

--- a/cibyl/plugins/openstack/service.py
+++ b/cibyl/plugins/openstack/service.py
@@ -14,17 +14,44 @@
 #    under the License.
 """
 
-# flake8: noqa from cibyl.cli.argument import Argument
-# flake8: noqa from cibyl.models.attribute import AttributeListValue
+from typing import Dict
+
+from cibyl.cli.argument import Argument
 from cibyl.models.model import Model
+from cibyl.utils.colors import Colors
 
 # pylint: disable=no-member
 
 
 class Service(Model):
-    """
-    Model for services found on Openstack deployment
-    """
-    # To be implemented in future PR
+    """Model for services found on Openstack deployment."""
 
-    API = {}
+    API = {
+        'name': {
+            'attr_type': str,
+            'arguments': [Argument(name='--service-name', arg_type=str,
+                          description="Service name")]
+        },
+        'configuration': {
+            'attr_type': dict,
+            'arguments': [Argument(name='--service-config', arg_type=str,
+                          description="Service configuration")]
+        }
+    }
+
+    def __init__(self, name: str, configuration: Dict[str, str] = None):
+        super().__init__({'name': name, 'configuration': configuration})
+
+    def __str__(self, indent=2, verbosity=0):
+        indent_space = indent*' '
+        info = f'{indent_space}'
+        info += Colors.blue('Service name: ') + f'{self.name.value}'
+        if self.configuration.value and verbosity > 0:
+            for parameter, value in self.configuration.value.items():
+                info += f'\n{indent_space}  ' + Colors.blue(f'{parameter}: ')
+                info += f'{value}'
+        return info
+
+    def merge(self, other):
+        """Merge two Service objects representing the same service."""
+        self.configuration.value.update(other.configuration.value)

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -247,8 +247,8 @@ class ElasticSearchOSP(Source):
             deployment = Deployment(
                 release,
                 "unknown",
-                [],
-                [],
+                {},
+                {},
                 ip_version=ip_version,
                 topology=topology,
                 network_backend=network_backend

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -462,17 +462,18 @@ accurate results", len(jobs_found))
             name = job.get('name')
             job_objects[name] = Job(name=name, url=job.get('url'))
             topology = job["topology"]
-            nodes = []
+            nodes = {}
             if topology:
                 for component in topology.split(","):
                     role, amount = component.split(":")
                     for i in range(int(amount)):
-                        nodes.append(Node(role+f"-{i}", role=role))
+                        node_name = role+f"-{i}"
+                        nodes[node_name] = Node(node_name, role=role)
 
             # TODO: (jgilaber) query for services
             deployment = Deployment(job["release"],
                                     job["infra_type"],
-                                    nodes, [], ip_version=job["ip_version"],
+                                    nodes, {}, ip_version=job["ip_version"],
                                     topology=topology,
                                     network_backend=job["network_backend"],
                                     storage_backend=job["storage_backend"],

--- a/tests/unit/plugins/openstack/__init__.py
+++ b/tests/unit/plugins/openstack/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/unit/plugins/openstack/test_deployment.py
+++ b/tests/unit/plugins/openstack/test_deployment.py
@@ -1,0 +1,103 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.plugins.openstack.deployment import Deployment
+from cibyl.plugins.openstack.node import Node
+from cibyl.plugins.openstack.service import Service
+
+
+class TestOpenstackDeployment(TestCase):
+    """Test openstack deployment model."""
+    def setUp(self):
+        self.release = '17.0'
+        self.infra = 'ovb'
+        self.services = {'nova': Service('nova', {})}
+        self.nodes = {'controller-0': Node('controller-0', 'controller')}
+        self.ip_version = "4"
+        self.topology = "controllers:1"
+        self.network = "vxlan"
+        self.storage = "ceph"
+        self.dvr = "true"
+        self.tls_everywhere = "false"
+
+        self.deployment = Deployment(self.release, self.infra, {}, {})
+        self.second_deployment = Deployment(self.release, self.infra,
+                                            self.nodes,
+                                            self.services,
+                                            ip_version=self.ip_version,
+                                            topology=self.topology,
+                                            network_backend=self.network,
+                                            storage_backend=self.storage,
+                                            dvr=self.dvr,
+                                            tls_everywhere=self.tls_everywhere)
+
+    def test_str_method(self):
+        """Test that the string representation of Deployment works."""
+        deployment_str = self.second_deployment.__str__(verbosity=1)
+        self.assertIn("Release:", deployment_str)
+        self.assertIn(self.release, deployment_str)
+        self.assertIn("Infra type:", deployment_str)
+        self.assertIn(self.infra, deployment_str)
+        self.assertIn("IP version:", deployment_str)
+        self.assertIn(self.ip_version, deployment_str)
+        self.assertIn("Topology:", deployment_str)
+        self.assertIn(self.topology, deployment_str)
+        self.assertIn("Network backend:", deployment_str)
+        self.assertIn(self.network, deployment_str)
+        self.assertIn("Storage backend:", deployment_str)
+        self.assertIn(self.storage, deployment_str)
+        self.assertIn("DVR:", deployment_str)
+        self.assertIn(self.dvr, deployment_str)
+        self.assertIn("TLS everywhere:", deployment_str)
+        self.assertIn(self.tls_everywhere, deployment_str)
+        self.assertIn("Service name:", deployment_str)
+        self.assertIn('nova', deployment_str)
+        self.assertIn("Node name:", deployment_str)
+        self.assertIn('controller-0', deployment_str)
+
+    def test_merge_method(self):
+        """Test merge method of Deployment class."""
+        self.assertIsNone(self.deployment.ip_version.value)
+        self.assertEqual({}, self.deployment.services.value)
+        self.assertEqual({}, self.deployment.nodes.value)
+        self.deployment.merge(self.second_deployment)
+        self.assertEqual(self.nodes, self.deployment.nodes.value)
+        self.assertEqual(self.services, self.deployment.services.value)
+        self.assertEqual(self.ip_version, self.deployment.ip_version.value)
+
+    def test_add_node(self):
+        """Test add_node method of Deployment class."""
+        self.assertEqual({}, self.deployment.nodes.value)
+        self.deployment.add_node(self.nodes['controller-0'])
+        self.assertEqual(self.nodes, self.deployment.nodes.value)
+
+    def test_add_service(self):
+        """Test add_service method of Deployment class."""
+        self.assertEqual({}, self.deployment.services.value)
+        self.deployment.add_service(self.services['nova'])
+        self.assertEqual(self.services, self.deployment.services.value)
+
+    def test_merge_method_existing_service(self):
+        """Test merge method of Deployment class."""
+
+        service_to_add = Service('nova', {'option': 'false'})
+        self.deployment.add_service(service_to_add)
+        self.second_deployment.merge(self.deployment)
+        service = self.second_deployment.services.value['nova']
+        self.assertEqual(service.name.value, service_to_add.name.value)
+        self.assertEqual(service.configuration.value,
+                         service_to_add.configuration.value)

--- a/tests/unit/plugins/openstack/test_node.py
+++ b/tests/unit/plugins/openstack/test_node.py
@@ -1,0 +1,34 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.plugins.openstack.node import Node
+
+
+class TestOpenstackNode(TestCase):
+    """Test openstack node model."""
+    def setUp(self):
+        self.name = 'controller-0'
+        self.role = 'controller'
+        self.node = Node(self.name, self.role)
+
+    def test_str_method(self):
+        """Test that the string representation of Node works."""
+        node_str = self.node.__str__(verbosity=1)
+        self.assertIn("Node name:", node_str)
+        self.assertIn(self.name, node_str)
+        self.assertIn("Role: ", node_str)
+        self.assertIn(self.role, node_str)

--- a/tests/unit/plugins/openstack/test_openstack.py
+++ b/tests/unit/plugins/openstack/test_openstack.py
@@ -40,8 +40,8 @@ class TestJobWithPlugin(TestCase):
 
     def setUp(self):
         extend_models("openstack")
-        self.deployment = Deployment(17.0, "test", [], [])
-        self.deployment2 = Deployment(17.1, "test", [], [])
+        self.deployment = Deployment(17.0, "test", {}, {})
+        self.deployment2 = Deployment(17.1, "test", {}, {})
         self.job = Job("job1", "url1")
         self.job2 = Job("job2", "url2")
 

--- a/tests/unit/plugins/openstack/test_service.py
+++ b/tests/unit/plugins/openstack/test_service.py
@@ -1,0 +1,34 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.plugins.openstack.service import Service
+
+
+class TestOpenstackService(TestCase):
+    """Test openstack service model."""
+    def setUp(self):
+        self.name = 'test-service'
+        self.config = {'option1': 'true'}
+        self.service = Service(self.name, self.config)
+
+    def test_str_method(self):
+        """Test that the string representation of Service works."""
+        service_str = self.service.__str__(verbosity=1)
+        self.assertIn("Service name:", service_str)
+        self.assertIn(self.name, service_str)
+        self.assertIn("option1:", service_str)
+        self.assertIn("true", service_str)

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -472,9 +472,10 @@ class TestJenkinsSource(TestCase):
             self.assertEqual(deployment.release.value, release)
             self.assertEqual(deployment.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
-            for node, node_name in zip(deployment.nodes, node_list):
-                self.assertEqual(node.name.value, node_name)
-                self.assertEqual(node.role.value, node_name.split("-")[0])
+            for node_name, node_expected in zip(deployment.nodes, node_list):
+                node = deployment.nodes[node_name]
+                self.assertEqual(node.name.value, node_expected)
+                self.assertEqual(node.role.value, node_expected.split("-")[0])
 
     def test_get_deployment_many_jobs(self):
         """ Test that get_deployment reads properly the information obtained


### PR DESCRIPTION
Extend the Openstack plugin by populating the Service model and adding
additional method to the Deployment model (merge, add_node, add_service).
