### PR TITLE
Fixed error when fetching tests for jobs with childReport

### DIFF
--- a/cibyl/models/ci/test.py
+++ b/cibyl/models/ci/test.py
@@ -61,7 +61,7 @@ class Test(Model):
         if self.result.value:
             test_str += f"\n{indent_space}  {Colors.blue('Result: ')}"
             success_values = ['SUCCESS', 'PASSED']
-            failure_values = ['FAILURE', 'FAILED']
+            failure_values = ['FAILURE', 'FAILED', 'REGRESSION']
             if self.result.value in success_values:
                 test_str += Colors.green(f"{self.result.value}")
             elif self.result.value in failure_values:


### PR DESCRIPTION
Added support for fetching tests for jobs which have them in childReports instead of testReport (API)
Added status REGRESSION to the test fail statuses
Fixed duration calculation. It has to be in milliseconds and Jenkins returns seconds