### PR TITLE
Deprecate --build-id and --test-name arguments

### DIFF
--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -28,9 +28,7 @@ class Build(Model):
     API = {
         'build_id': {
             'attr_type': str,
-            'arguments': [Argument(name='--build-id', arg_type=str,
-                                   nargs='*', func='get_builds',
-                                   description="Build ID")]
+            'arguments': []
         },
         'status': {
             'attr_type': str,

--- a/cibyl/models/ci/test.py
+++ b/cibyl/models/ci/test.py
@@ -40,9 +40,7 @@ class Test(Model):
         },
         'class_name': {
             'attr_type': int,
-            'arguments': [Argument(name='--test-class-name', arg_type=str,
-                                   func='get_tests',
-                                   description="Test class name")]
+            'arguments': []
         }
     }
 

--- a/cibyl/models/ci/test.py
+++ b/cibyl/models/ci/test.py
@@ -24,9 +24,7 @@ class Test(Model):
     API = {
         'name': {
             'attr_type': str,
-            'arguments': [Argument(name='--test-name', arg_type=str,
-                                   func='get_tests',
-                                   description="Test name")]
+            'arguments': []
         },
         'result': {
             'attr_type': str,

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -130,8 +130,8 @@ class ElasticSearchOSP(Source):
                                   kwargs.get('build_status').value]
 
             build_id_argument = None
-            if 'build_id' in kwargs:
-                build_id_argument = kwargs.get('build_id').value
+            if 'builds' in kwargs:
+                build_id_argument = kwargs.get('builds').value
 
             for build in builds:
 

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -107,12 +107,6 @@ def filter_builds(builds_found: List[Dict], **kwargs):
                                        user_input=builds_arg,
                                        field_to_check="number"))
 
-    build_ids = kwargs.get('build_id')
-    if build_ids:
-        checks_to_apply.append(partial(satisfy_exact_match,
-                                       user_input=build_ids,
-                                       field_to_check="number"))
-
     build_status = kwargs.get('build_status')
     if build_status:
         checks_to_apply.append(partial(satisfy_case_insensitive_match,
@@ -334,7 +328,7 @@ try reducing verbosity for quicker query")
             job_object = Job(name=job_name, url=job.get('url'))
             job_objects[job_name] = job_object
 
-            if kwargs.get('build_id'):
+            if kwargs.get('builds'):
                 # For specific build ids we have to fetch them
                 builds = self.send_request(item=f"job/{job_name}",
                                            query=self.jobs_builds_query.get(

--- a/cibyl/sources/zuul/source.py
+++ b/cibyl/sources/zuul/source.py
@@ -123,10 +123,10 @@ class Zuul(Source):
                 return build == builds[0]
 
             def build_id_filter(build):
-                if 'build_id' not in kwargs:
+                if 'builds' not in kwargs:
                     return True
 
-                return build['uuid'] in kwargs['build_id'].value
+                return build['uuid'] in kwargs['builds'].value
 
             def build_status_filter(build):
                 if 'build_status' not in kwargs:

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -95,16 +95,16 @@ Arguments Matrix
      - |:black_square_button:|
      - |:x:|
      - |:x:|
-   * - --test-class-name
-     - Test class name
-     - |:black_square_button:|
-     - |:black_square_button:|
-     - |:black_square_button:|
-     - |:x:|
-     - |:x:|
    * - --test-result
      - | Test result (default: all)
        | success, failed, skipped
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:x:|
+     - |:x:|
+   * - --test-duration
+     - | Test duration (default: all)
      - |:black_square_button:|
      - |:black_square_button:|
      - |:black_square_button:|

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -87,24 +87,10 @@ Arguments Matrix
      - |:ballot_box_with_check:|
      - |:x:|
      - |:x:|
-   * - --build-id
-     - Build number
-     - |:ballot_box_with_check:|
-     - |:ballot_box_with_check:|
-     - |:ballot_box_with_check:|
-     - |:x:|
-     - |:x:|
    * - --tests
      - | Test names or pattern
        | Default: all tests
      - |:ballot_box_with_check:|
-     - |:black_square_button:|
-     - |:black_square_button:|
-     - |:x:|
-     - |:x:|
-   * - --test-name
-     - Test name
-     - |:black_square_button:|
      - |:black_square_button:|
      - |:black_square_button:|
      - |:x:|

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -294,7 +294,7 @@ class TestJenkinsSource(TestCase):
         build_id_kwargs = MagicMock()
         type(build_id_kwargs).value = PropertyMock(return_value=['1'])
 
-        jobs = self.jenkins.get_tests(build_id=build_id_kwargs)
+        jobs = self.jenkins.get_tests(builds=build_id_kwargs)
         self.assertEqual(len(jobs), 1)
         job = jobs['ansible']
         self.assertEqual(job.name.value, 'ansible')
@@ -1173,26 +1173,6 @@ class TestFilters(TestCase):
                      'lastBuild': {'number': 2, 'result': "FAILURE"}}]
         self.assertEqual(jobs_filtered, expected)
 
-    def test_filter_builds_builds_build_id_build_status_empty(self):
-        """Test that filter builds filters the builds given the user input."""
-        response = [{'_class': 'org..job.WorkflowRun', 'number': 3,
-                     'result': 'SUCCESS'},
-                    {'_class': 'org..job.WorkflowRun', 'number': 4,
-                     'result': 'FAILURE'},
-                    {'_class': 'org..job.WorkflowRun', 'number': 5,
-                     'result': 'success'}]
-        builds = Mock()
-        builds.value = []
-        build_id = Mock()
-        build_id.value = ["3"]
-        build_status = Mock()
-        build_status.value = ["failure"]
-        builds_filtered = filter_builds(response, builds=builds,
-                                        build_status=build_status,
-                                        build_id=build_id)
-        expected = []
-        self.assertEqual(builds_filtered, expected)
-
     def test_filter_builds_builds_build_id_build_status(self):
         """Test that filter builds filters the builds given the user input."""
         response = [{'_class': 'org..job.WorkflowRun', 'number': 3,
@@ -1202,36 +1182,13 @@ class TestFilters(TestCase):
                     {'_class': 'org..job.WorkflowRun', 'number': 5,
                      'result': 'success'}]
         builds = Mock()
-        builds.value = []
-        build_id = Mock()
-        build_id.value = ["3"]
+        builds.value = ["3"]
         build_status = Mock()
         build_status.value = ["success"]
         builds_filtered = filter_builds(response, builds=builds,
-                                        build_status=build_status,
-                                        build_id=build_id)
+                                        build_status=build_status)
         expected = [{'_class': 'org..job.WorkflowRun', 'number': "3",
                      'result': 'SUCCESS'}]
-        self.assertEqual(builds_filtered, expected)
-
-    def test_filter_builds_builds_build_id(self):
-        """Test that filter builds filters the builds given the user input."""
-        response = [{'_class': 'org..job.WorkflowRun', 'number': 3,
-                     'result': 'SUCCESS'},
-                    {'_class': 'org..job.WorkflowRun', 'number': 3,
-                     'result': 'FAILURE'},
-                    {'_class': 'org..job.WorkflowRun', 'number': 5,
-                     'result': 'success'}]
-        builds = Mock()
-        builds.value = []
-        build_id = Mock()
-        build_id.value = ["3"]
-        builds_filtered = filter_builds(response, builds=builds,
-                                        build_id=build_id)
-        expected = [{'_class': 'org..job.WorkflowRun', 'number': "3",
-                     'result': 'SUCCESS'},
-                    {'_class': 'org..job.WorkflowRun', 'number': "3",
-                     'result': 'FAILURE'}]
         self.assertEqual(builds_filtered, expected)
 
     def test_filter_builds_builds_build_status(self):
@@ -1252,25 +1209,6 @@ class TestFilters(TestCase):
                      'result': 'SUCCESS'},
                     {'_class': 'org..job.WorkflowRun', 'number': "5",
                      'result': 'success'}]
-        self.assertEqual(builds_filtered, expected)
-
-    def test_filter_builds_build_id_build_status(self):
-        """Test that filter builds filters the builds given the user input."""
-        response = [{'_class': 'org..job.WorkflowRun', 'number': 3,
-                     'result': 'SUCCESS'},
-                    {'_class': 'org..job.WorkflowRun', 'number': 4,
-                     'result': 'FAILURE'},
-                    {'_class': 'org..job.WorkflowRun', 'number': 5,
-                     'result': 'success'}]
-        build_id = Mock()
-        build_id.value = ["3"]
-        build_status = Mock()
-        build_status.value = ["success"]
-        builds_filtered = filter_builds(response,
-                                        build_status=build_status,
-                                        build_id=build_id)
-        expected = [{'_class': 'org..job.WorkflowRun', 'number': "3",
-                     'result': 'SUCCESS'}]
         self.assertEqual(builds_filtered, expected)
 
     def test_filter_builds_builds(self):
@@ -1306,20 +1244,4 @@ class TestFilters(TestCase):
                      'result': 'SUCCESS'},
                     {'_class': 'org..job.WorkflowRun', 'number': "5",
                      'result': 'success'}]
-        self.assertEqual(builds_filtered, expected)
-
-    def test_filter_builds_build_id(self):
-        """Test that filter builds filters the builds given the user input."""
-        response = [{'_class': 'org..job.WorkflowRun', 'number': 3,
-                     'result': 'SUCCESS'},
-                    {'_class': 'org..job.WorkflowRun', 'number': 4,
-                     'result': 'FAILURE'},
-                    {'_class': 'org..job.WorkflowRun', 'number': 5,
-                     'result': 'success'}]
-        build_id = Mock()
-        build_id.value = ["3"]
-        builds_filtered = filter_builds(response,
-                                        build_id=build_id)
-        expected = [{'_class': 'org..job.WorkflowRun', 'number': "3",
-                     'result': 'SUCCESS'}]
         self.assertEqual(builds_filtered, expected)

--- a/tests/unit/sources/zuul/test_source.py
+++ b/tests/unit/sources/zuul/test_source.py
@@ -446,7 +446,7 @@ class TestBuildFilters(TestCase):
 
         kwargs = {
             'jobs': Argument('name', list, '', value=[]),
-            'build_id': Argument('uuid', list, '', value=[build1, build3])
+            'builds': Argument('uuid', list, '', value=[build1, build3])
         }
 
         client1 = Mock()


### PR DESCRIPTION
The deprecated arguments are a duplicated of --builds and --tests
respectively, so there is no point in maintaining them all.
