### PR TITLE
Fix bug in release version in jenkins source

### DIFF
--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -37,6 +37,7 @@ from cibyl.utils.filtering import (DEPLOYMENT_PATTERN, DVR_PATTERN_NAME,
                                    DVR_PATTERN_RUN, IP_PATTERN,
                                    NETWORK_BACKEND_PATTERN, OPTIONS,
                                    PROPERTY_PATTERN, RELEASE_PATTERN,
+                                   RELEASE_RUN, RELEASE_VERSION,
                                    STORAGE_BACKEND_PATTERN, TLS_PATTERN_RUN,
                                    TOPOLOGY_PATTERN, apply_filters,
                                    filter_topology,
@@ -538,9 +539,13 @@ accurate results", len(jobs_found))
                 topology_str = topology_str.replace('"', '')
                 topology_str = topology_str.replace("'", '')
                 job["topology"] = topology_str
-            if "--version" in line or "PRODUCT_VERSION" in line:
+            if "--version" in line:
                 job["release"] = detect_job_info_regex(line,
-                                                       RELEASE_PATTERN)
+                                                       RELEASE_RUN)
+            if "PRODUCT_VERSION" in line:
+                job["release"] = detect_job_info_regex(line,
+                                                       RELEASE_VERSION)
+
             if "--storage-backend" in line or "STORAGE_BACKEND" in line:
                 storage = detect_job_info_regex(line, STORAGE_BACKEND_PATTERN)
                 job["storage_backend"] = storage

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -21,6 +21,8 @@ from cibyl.cli.ranged_argument import RANGE_OPERATORS
 
 IP_PATTERN = re.compile("ipv(.)")
 RELEASE_PATTERN = re.compile(r"\d\d\.?\d?")
+RELEASE_RUN = re.compile(rf"--version ({RELEASE_PATTERN})")
+RELEASE_VERSION = re.compile(rf"PRODUCT_VERSION:({RELEASE_PATTERN})")
 TOPOLOGY_PATTERN = re.compile(r"(\d([a-zA-Z])+_?)+")
 PROPERTY_PATTERN = re.compile(r"=(.*)")
 NETWORK_BACKEND_PATTERN = re.compile("geneve|gre|vlan|vxlan")


### PR DESCRIPTION
Use more specific regex patterns to read release versions from artifacts
of jenkins jobs.
