### PR TITLE
Add queried attribute to improve system printing

### DIFF
--- a/cibyl/models/ci/printers/colored.py
+++ b/cibyl/models/ci/printers/colored.py
@@ -83,8 +83,12 @@ class CIColoredPrinter(CIPrinter):
             for job in system.jobs.values():
                 printer.add(self.print_job(job), 1)
 
-            printer.add(self._palette.blue('Total jobs found in query: '), 1)
-            printer[-1].append(len(system.jobs))
+            if system.is_queried():
+                printer.add(self._palette.blue('Total jobs found in query: '),
+                            1)
+                printer[-1].append(len(system.jobs))
+            else:
+                printer.add(self._palette.blue('No query performed'), 1)
 
         return printer.build()
 

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -42,6 +42,10 @@ class System(Model):
             'arguments': [Argument(name='--system-type', arg_type=str,
                                    description="System type")]
         },
+        'queried': {
+            'attr_type': bool,
+            'arguments': []
+        },
         'jobs_scope': {
             'attr_type': str,
             'arguments': []
@@ -67,11 +71,24 @@ class System(Model):
                  pipelines: Dict[str, Pipeline] = None):
         super().__init__({'name': name, 'system_type': system_type,
                           'jobs': jobs, 'jobs_scope': jobs_scope,
-                          'sources': sources, 'pipelines': pipelines})
+                          'sources': sources, 'pipelines': pipelines,
+                          'queried': False})
         # this variable describes which model will the system use as top-level
         # model. For most systems, this will be Job, for zuul systems it will
         # be Pipeline
         self.top_level_model = Job
+
+    def register_query(self):
+        """Record that the system was queried."""
+        self.queried.value = True
+
+    def is_queried(self):
+        """Check whether a system was queried.
+
+        :returns: Whether the system was queried
+        :rtype: bool
+        """
+        return self.queried.value
 
     def add_source(self, source: Source):
         """Add a source to the CI system

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -190,6 +190,7 @@ class Orchestrator:
                         # only update last_level if the query was successful
                         last_level = arg.level
                         system.populate(model_instances_dict)
+                        system.register_query()
                         # if one source has provided the information, there is
                         # no need to query the rest
                         break

--- a/tests/unit/models/test_system.py
+++ b/tests/unit/models/test_system.py
@@ -98,6 +98,12 @@ class TestJobsSystem(unittest.TestCase):
       Status: SUCCESS"""
         self.assertIn(output, expected)
 
+    def test_query_attribute(self):
+        """Test system queried attribute."""
+        self.assertFalse(self.system.is_queried())
+        self.system.register_query()
+        self.assertTrue(self.system.is_queried())
+
 
 class TestPipelineSystem(unittest.TestCase):
     """Test the PipelineSystem class."""


### PR DESCRIPTION
Add a queried attribute to System, which will keep track of whether
a particular system has been queried during the run. This attribute will
later be used to provide a more informative output in the publisher.
This mechanism overlaps with the printing mode. I decided to leave them
both for the moment in case we later find another use for the simple
printing mode, otherwise we can remove it.

Solves OSPCRE-393