### PR TITLE
Allow disabling systems in configuration file

### DIFF
--- a/cibyl/exceptions/model.py
+++ b/cibyl/exceptions/model.py
@@ -73,3 +73,15 @@ class InvalidSystem(CibylException):
             self.message += "\nPlease ensure the specified systems are present"
             self.message += " in the configuration."
         super().__init__(self.message)
+
+
+class NoEnabledSystem(CibylException):
+    """Exception for a case when no enabled system is found."""
+
+    def __init__(self, message=None):
+        """Constructor."""
+        if not message:
+            message = "No enabled system was found. Please ensure at least one"
+            message += " system is enabled in your configuration or specify a"
+            message += " system with the --systems argument to override it."
+        super().__init__(message)

--- a/cibyl/models/ci/environment.py
+++ b/cibyl/models/ci/environment.py
@@ -42,8 +42,9 @@ class Environment(Model):
         super().__init__({'name': name, 'systems': systems})
 
     def add_system(self, name: str, system_type: str, jobs_scope: str = None,
-                   sources: list = None):
+                   sources: list = None, enabled: bool = True):
         """Adds a CI system to the CI environment"""
         self.systems.append(SystemFactory.create_system(system_type, name,
                                                         sources=sources,
-                                                        jobs_scope=jobs_scope))
+                                                        jobs_scope=jobs_scope,
+                                                        enabled=enabled))

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -50,6 +50,10 @@ class System(Model):
             'attr_type': str,
             'arguments': []
         },
+        'enabled': {
+            'attr_type': bool,
+            'arguments': []
+        },
         'sources': {
             'attr_type': Source,
             'attribute_value_class': AttributeListValue,
@@ -68,15 +72,28 @@ class System(Model):
     def __init__(self, name: str,  # pylint: disable=too-many-arguments
                  system_type: str, jobs: Dict[str, Job] = None,
                  jobs_scope: str = "*", sources: List = None,
-                 pipelines: Dict[str, Pipeline] = None):
+                 pipelines: Dict[str, Pipeline] = None,
+                 enabled: bool = True):
         super().__init__({'name': name, 'system_type': system_type,
                           'jobs': jobs, 'jobs_scope': jobs_scope,
                           'sources': sources, 'pipelines': pipelines,
-                          'queried': False})
+                          'queried': False, 'enabled': enabled})
         # this variable describes which model will the system use as top-level
         # model. For most systems, this will be Job, for zuul systems it will
         # be Pipeline
         self.top_level_model = Job
+
+    def enable(self):
+        """Enable a system for querying."""
+        self.enabled.value = True
+
+    def is_enabled(self):
+        """Check whether a system is enabled.
+
+        :returns: Whether the system is enabled
+        :rtype: bool
+        """
+        return self.enabled.value
 
     def register_query(self):
         """Record that the system was queried."""
@@ -128,11 +145,12 @@ class JobsSystem(System):
     # pylint: disable=too-many-arguments
     def __init__(self, name: str, system_type: str,
                  jobs: Dict[str, Job] = None,
-                 jobs_scope: str = "*", sources: List = None):
+                 jobs_scope: str = "*", sources: List = None,
+                 enabled: bool = True):
 
         super().__init__(name=name, system_type=system_type,
                          pipelines=None, jobs_scope=jobs_scope,
-                         sources=sources, jobs=jobs)
+                         sources=sources, jobs=jobs, enabled=enabled)
 
     def add_toplevel_model(self, model: Job):
         """Add a top-level model to the system.

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -154,6 +154,8 @@ class Orchestrator:
                 # because the environment information is not used from this
                 # point forward
                 for system in valid_systems:
+                    if not system.is_enabled():
+                        continue
                     try:
                         source_methods = self.select_source_method(system, arg)
                     except NoSupportedSourcesFound as exception:

--- a/tests/unit/cli/test_validator.py
+++ b/tests/unit/cli/test_validator.py
@@ -18,7 +18,8 @@ from unittest.mock import Mock
 
 from cibyl.cli.validator import Validator
 from cibyl.exceptions.model import (InvalidEnvironment, InvalidSystem,
-                                    NoValidSystem)
+                                    NoEnabledSystem, NoValidSystem)
+from cibyl.exceptions.source import NoValidSources
 from cibyl.orchestrator import Orchestrator
 
 
@@ -41,6 +42,29 @@ class TestValidator(TestCase):
                 'env1': {
                     'system1': {
                         'system_type': 'zuul',
+                        'sources': {
+                            'zuul': {
+                                'driver': 'zuul',
+                                'url': ''
+                                }
+                            }}
+                }
+            }
+        }
+        self.config_enable = {
+            'environments': {
+                'env': {
+                    'system3': {
+                        'system_type': 'jenkins',
+                        'enabled': False},
+                    'system4': {
+                        'system_type': 'zuul',
+                        'enabled': False}
+                },
+                'env1': {
+                    'system1': {
+                        'system_type': 'zuul',
+                        'enabled': False,
                         'sources': {
                             'zuul': {
                                 'driver': 'zuul',
@@ -165,3 +189,47 @@ class TestValidator(TestCase):
         self.assertEqual("system1", systems[0].name.value)
         self.assertEqual("zuul", systems[0].system_type.value)
         self.assertEqual("env1", envs[0].name.value)
+
+    def test_validator_validate_no_sources(self):
+        """Test Validator validate_environments with no sources."""
+        self.orchestrator.config.data = self.config
+        self.orchestrator.create_ci_environments()
+        self.ci_args["env_name"] = Mock()
+        self.ci_args["env_name"].value = ["env"]
+        self.ci_args["sources"] = Mock()
+        self.ci_args["sources"].value = ["zuul"]
+
+        original_envs = self.orchestrator.environments
+        validator = Validator(self.ci_args)
+        self.assertRaises(NoValidSources,
+                          validator.validate_environments,
+                          original_envs)
+
+    def test_validator_validate_no_enabled_system(self):
+        """Test Validator validate_environments with no enabled systems."""
+        self.orchestrator.config.data = self.config_enable
+        self.orchestrator.create_ci_environments()
+
+        original_envs = self.orchestrator.environments
+        validator = Validator(self.ci_args)
+        self.assertRaises(NoEnabledSystem,
+                          validator.validate_environments,
+                          original_envs)
+
+    def test_validator_validate_override_no_enabled_system(self):
+        """Test Validator validate_environments overriding disabled systems."""
+        self.orchestrator.config.data = self.config_enable
+        self.orchestrator.create_ci_environments()
+        self.ci_args["systems"] = Mock()
+        self.ci_args["systems"].value = ["system3", "system4"]
+
+        original_envs = self.orchestrator.environments
+        validator = Validator(self.ci_args)
+        envs, systems = validator.validate_environments(original_envs)
+        self.assertEqual(1, len(envs))
+        self.assertEqual(2, len(systems))
+        self.assertEqual("env", envs[0].name.value)
+        self.assertEqual("system3", systems[0].name.value)
+        self.assertEqual("system4", systems[1].name.value)
+        self.assertEqual("jenkins", systems[0].system_type.value)
+        self.assertEqual("zuul", systems[1].system_type.value)


### PR DESCRIPTION
Add a 'enabled' parameter for systems in the configuration file. If                                                                                                              systems are not enabled, they will be ingnored completely. This                                                                                                           parameter can be overriden if the system is specified via the --systems                                                                                                       cli argument. If no enabled system is found, a specific error is raised.