### PR TITLE
Add support for multiple Git repositories

### DIFF
--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -97,6 +97,7 @@ class Orchestrator:
                                 **source_data
                             )
                         )
+                        sources[-1].setup()
 
                     environment.add_system(
                         name=system_name,

--- a/cibyl/sources/source.py
+++ b/cibyl/sources/source.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 import logging
+from abc import abstractmethod
 from operator import itemgetter
 from typing import Dict
 
@@ -73,6 +74,11 @@ class Source(AttrDict):
         kwargs.setdefault('priority', 0)
 
         super().__init__(name=name, driver=driver, **kwargs)
+
+    @abstractmethod
+    def setup(self):
+        """Setup everything required for the source to become operational."""
+        LOG.debug(f"Setting up source: {self.name}")
 
 
 def is_source_valid(source: Source, desired_attr: str):

--- a/docs/source/sources/jenkins-job-builder.rst
+++ b/docs/source/sources/jenkins-job-builder.rst
@@ -15,7 +15,8 @@ To following is a configuration sample of how to configure the 'Jenkins Job Buil
           sources:
             jjb_source:
               driver: jenkins_job_builder
-              repo: 'https://jjb_repo_example.git'
+              repos:
+                  - url: 'https://jjb_repo_example.git'
 
 Plugin Support
 ^^^^^^^^^^^^^^

--- a/docs/source/sources/zuul.d.rst
+++ b/docs/source/sources/zuul.d.rst
@@ -15,7 +15,8 @@ To following is a configuration sample of how to configure the Jenkins source::
           sources:
             zuul_definitions_source:
               driver: zuul.d
-              url: 'http://zuul_defitions_repo.git
+              repos:
+                  - url: 'http://zuul_defitions_repo.git
 
 Plugin Support
 ^^^^^^^^^^^^^^

--- a/tests/unit/sources/test_jenkins_job_builder.py
+++ b/tests/unit/sources/test_jenkins_job_builder.py
@@ -72,12 +72,13 @@ class TestJenkinsJobBuilderSource(TestCase):
         url = 'url/to/repo'
         dest = 'dest_folder'
         branch = 'master'
+        repos = [{'url': url, 'dest': dest, 'branch': branch}]
 
-        jenkins = JenkinsJobBuilder(url, dest=dest, branch=branch)
+        jenkins = JenkinsJobBuilder(repos=repos)
 
-        self.assertEqual(dest, jenkins.dest)
-        self.assertEqual(url, jenkins.url)
-        self.assertEqual(branch, jenkins.branch)
+        self.assertEqual(dest, jenkins.repos[-1].get('dest'))
+        self.assertEqual(url, jenkins.repos[-1].get('url'))
+        self.assertEqual(branch, jenkins.repos[-1].get('branch'))
 
     def test_with_no_dest(self, _):
         """Checks that object is built correctly when the dest is not
@@ -85,13 +86,18 @@ class TestJenkinsJobBuilderSource(TestCase):
         """
         url = 'url/to/repo/'
         branch = 'master'
+        repos = [{'url': url, 'branch': branch}]
 
-        jenkins = JenkinsJobBuilder(url, branch=branch)
+        jenkins = JenkinsJobBuilder(repos=repos)
 
-        self.assertEqual(url, jenkins.url)
-        self.assertEqual(branch, jenkins.branch)
-        self.assertIsNotNone(jenkins.dest)
-        self.assertTrue(os.path.isdir(jenkins.dest))
+        self.assertIsNone(jenkins.repos[-1].get('dest'))
+
+        jenkins.setup()
+
+        self.assertEqual(url, jenkins.repos[-1].get('url'))
+        self.assertEqual(branch, jenkins.repos[-1].get('branch'))
+        self.assertIsNotNone(jenkins.repos[-1].get('dest'))
+        self.assertTrue(os.path.isdir(jenkins.repos[-1].get('dest')))
 
     def test_with_no_branch(self, _):
         """Checks that object is built correctly when the branch is not
@@ -99,12 +105,13 @@ class TestJenkinsJobBuilderSource(TestCase):
         """
         url = 'url/to/repo/'
         dest = 'dest'
+        repos = [{'url': url, 'dest': dest}]
 
-        jenkins = JenkinsJobBuilder(url, dest=dest)
+        jenkins = JenkinsJobBuilder(repos)
 
-        self.assertEqual(url, jenkins.url)
-        self.assertIsNone(jenkins.branch)
-        self.assertEqual(dest, jenkins.dest)
+        self.assertEqual(url, jenkins.repos[-1].get('url'))
+        self.assertIsNone(jenkins.repos[-1].get('branch'))
+        self.assertEqual(dest, jenkins.repos[-1].get('dest'))
 
     def test_get_jobs(self, _):
         """
@@ -112,7 +119,8 @@ class TestJenkinsJobBuilderSource(TestCase):
             is correct. The jenkins API method that should do the query is
             mocked so that it returns the query itself.
         """
-        jenkins = JenkinsJobBuilder("url", dest="out_jjb_test")
+        repos = [{'dest': 'out_jjb_test'}]
+        jenkins = JenkinsJobBuilder(repos=repos)
         jenkins._generate_xml = Mock()
 
         jobs = jenkins.get_jobs()


### PR DESCRIPTION
Right now Git-based sources support only cloning
one repository. While this works well for jjb, it
might not work out well for Zuul-based sources since
one job definition can span over multiple repositories.

In addition, instead of setting up the repository from
specific functions like jjb does with get_jobs, a setup
method is now defined on its own and will be executed
when sources are initialized.
