### PR TITLE
Skip source setup when the source is disabled

### DIFF
--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -153,4 +153,4 @@ class Parser:
                     default=arg.default,
                     level=level)
         except argparse.ArgumentError:
-            LOG.debug("argument already exists: %s...ignoring", arg.name)
+            pass

--- a/cibyl/exceptions/model.py
+++ b/cibyl/exceptions/model.py
@@ -36,7 +36,7 @@ class NoValidSystem(CibylException):
             self.message += "\nPlease use one of the following available"
             self.message += " systems:\n"
             for system_name in valid_systems:
-                self.message += f"{system_name}\n"
+                self.message += f"  {Colors.blue(system_name)}\n"
         else:
             self.message += "\nPlease ensure the specified systems are present"
             self.message += " in the configuration."
@@ -52,7 +52,7 @@ class InvalidEnvironment(CibylException):
             self.message += "\nPlease use one of the following available"
             self.message += " environments:\n"
             for env_name in valid_environments:
-                self.message += f"{env_name}\n"
+                self.message += f"{Colors.blue(env_name)}\n"
         else:
             self.message += "\nPlease set at least one environment in the "
             self.message += "configuration file."

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -97,7 +97,8 @@ class Orchestrator:
                                 **source_data
                             )
                         )
-                        sources[-1].setup()
+                        if sources[-1].enabled:
+                            sources[-1].setup()
 
                     environment.add_system(
                         name=system_name,

--- a/cibyl/sources/jenkins_job_builder.py
+++ b/cibyl/sources/jenkins_job_builder.py
@@ -67,7 +67,6 @@ class JenkinsJobBuilder(GitSource):
         :rtype: list
         """
         all_jobs = {}
-        print(self.repos)
         for repo in self.repos:
             all_jobs.update(self.get_jobs_from_repo(repo, **kwargs))
         return AttributeDictValue("jobs", attr_type=Job, value=all_jobs)

--- a/cibyl/sources/source.py
+++ b/cibyl/sources/source.py
@@ -78,7 +78,7 @@ class Source(AttrDict):
     @abstractmethod
     def setup(self):
         """Setup everything required for the source to become operational."""
-        LOG.debug(f"Setting up source: {self.name}")
+        pass
 
 
 def is_source_valid(source: Source, desired_attr: str):

--- a/tests/unit/cli/test_parser.py
+++ b/tests/unit/cli/test_parser.py
@@ -51,13 +51,6 @@ class TestParser(TestCase):
             ['--config', '/some/path'])
         self.assertEqual(parsed_args.config_file_path, '/some/path')
 
-    def test_parser_extend(self):
-        """Tests parser extend method"""
-        self.parser.extend(self.environment.arguments, 'Environment')
-        # Extend again and see if a message is logged about it
-        with self.assertLogs('cibyl.cli.parser', level='DEBUG'):
-            self.parser.extend(self.environment.arguments, 'Environment')
-
     def test_parser_parse_args(self):
         """Testing parser extend method"""
         self.parser.parse()


### PR DESCRIPTION
This makes sure that we don't setup sources which
are disabled in the configuration.

This also introduces a couple of additional minor changes:

* Don't log every duplicated argument. It might look/work
reasonably well with one environment, maybe two, but
when including multiple environments, the amount of lines
we get about duplicated argument is just too big.
* Don't log "setting up source" if the source isn't really
setting up anything. Keep the method empty as an interface
reference for developers.
