### PR TITLE
Use logs for deployment information in Jenkins

### DIFF
--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -16,6 +16,7 @@
 
 import json
 import logging
+import os
 import re
 from functools import partial
 from typing import Dict, List
@@ -23,24 +24,25 @@ from urllib.parse import urlparse
 
 import requests
 import urllib3
+import yaml
 
 from cibyl.exceptions.jenkins import JenkinsError
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.build import Build
 from cibyl.models.ci.job import Job
 from cibyl.models.ci.test import Test
+from cibyl.plugins.openstack.container import Container
 from cibyl.plugins.openstack.deployment import Deployment
 from cibyl.plugins.openstack.node import Node
+from cibyl.plugins.openstack.package import Package
+from cibyl.plugins.openstack.service import Service
 from cibyl.plugins.openstack.utils import translate_topology_string
 from cibyl.sources.source import Source, safe_request_generic, speed_index
 from cibyl.utils.filtering import (DEPLOYMENT_PATTERN, DVR_PATTERN_NAME,
-                                   DVR_PATTERN_RUN, IP_PATTERN,
-                                   NETWORK_BACKEND_PATTERN, OPTIONS,
-                                   PROPERTY_PATTERN, RELEASE_PATTERN,
-                                   RELEASE_RUN, RELEASE_VERSION,
-                                   STORAGE_BACKEND_PATTERN, TLS_PATTERN_RUN,
-                                   TOPOLOGY_PATTERN, apply_filters,
-                                   filter_topology,
+                                   IP_PATTERN, NETWORK_BACKEND_PATTERN,
+                                   RELEASE_PATTERN, SERVICES_PATTERN,
+                                   STORAGE_BACKEND_PATTERN, TOPOLOGY_PATTERN,
+                                   apply_filters, filter_topology,
                                    satisfy_case_insensitive_match,
                                    satisfy_exact_match, satisfy_regex_match)
 
@@ -135,6 +137,8 @@ class Jenkins(Source):
     jobs_last_completed_build_query = \
         "?tree=jobs[name,url,lastCompletedBuild[number,result,duration]]"
     build_tests_query = "?tree=suites[cases[name,status,duration,className]]"
+    jobs_query_for_deployment = \
+        "?tree=jobs[name,url,lastCompletedBuild[number,result,description]]"
 
     # pylint: disable=too-many-arguments
     def __init__(self, url: str, username: str = None, token: str = None,
@@ -167,7 +171,8 @@ class Jenkins(Source):
 
     @safe_request
     def send_request(self, query, timeout=None, item="",
-                     api_entrypoint="/api/json", raw_response=False):
+                     api_entrypoint="/api/json", raw_response=False,
+                     url=None):
         """
             Send a request to the jenkins instance and parse its json response.
 
@@ -185,6 +190,9 @@ class Jenkins(Source):
             :param raw_response: Whether to return the text of the response
             without any processing
             :type raw_response: bool
+            :param url: url to send the request to
+            :type url: str
+
             :returns: Information from the jenkins instance
             :rtype: dict
         """
@@ -215,8 +223,10 @@ class Jenkins(Source):
 
             return url
 
+        if url is None:
+            url = generate_query_url()
         response = requests.get(
-            generate_query_url(), verify=self.cert, timeout=timeout
+            url, verify=self.cert, timeout=timeout
         )
 
         response.raise_for_status()
@@ -411,7 +421,7 @@ try reducing verbosity for quicker query")
         :rtype bool:
         """
         for attr in self.deployment_attr:
-            if attr not in job:
+            if attr not in job or not job[attr]:
                 return True
         return False
 
@@ -423,7 +433,7 @@ try reducing verbosity for quicker query")
         jenkins server
         :rtype: :class:`AttributeDictValue`
         """
-        jobs_found = self.send_request(self.jobs_last_build_query)["jobs"]
+        jobs_found = self.send_request(self.jobs_query_for_deployment)["jobs"]
         jobs_found = filter_jobs(jobs_found, **kwargs)
 
         use_artifacts = True
@@ -435,7 +445,7 @@ accurate results", len(jobs_found))
 
         job_deployment_info = []
         for job in jobs_found:
-            last_build = job.get("lastBuild")
+            last_build = job.get("lastCompletedBuild")
             if use_artifacts and last_build is not None:
                 # if we have a lastBuild, we will have artifacts to pull
                 self.add_job_info_from_artifacts(job)
@@ -478,18 +488,19 @@ accurate results", len(jobs_found))
             name = job.get('name')
             job_objects[name] = Job(name=name, url=job.get('url'))
             topology = job["topology"]
-            nodes = {}
-            if topology:
+            if not job.get("nodes") and topology:
+                job["nodes"] = {}
                 for component in topology.split(","):
                     role, amount = component.split(":")
                     for i in range(int(amount)):
                         node_name = role+f"-{i}"
-                        nodes[node_name] = Node(node_name, role=role)
+                        job["nodes"][node_name] = Node(node_name, role=role)
 
-            # TODO: (jgilaber) query for services
             deployment = Deployment(job["release"],
                                     job["infra_type"],
-                                    nodes, {}, ip_version=job["ip_version"],
+                                    nodes=job.get("nodes", {}),
+                                    services=job.get("services", {}),
+                                    ip_version=job["ip_version"],
                                     topology=topology,
                                     network_backend=job["network_backend"],
                                     storage_backend=job["storage_backend"],
@@ -499,89 +510,227 @@ accurate results", len(jobs_found))
 
         return AttributeDictValue("jobs", attr_type=Job, value=job_objects)
 
-    def add_job_info_from_artifacts(self, job: Dict[str, str]):
+    def add_job_info_from_artifacts(self, job: dict):
         """Add information to the job by querying the last build artifacts.
 
         :param job: Dictionary representation of a jenkins job
         :type job: dict
         """
-        possible_artifacts = ["artifacts/jp.env", ".sh/run.sh", ".envrc"]
         job_name = job['name']
-        artifact = None
-        for artifact_path in possible_artifacts:
-            artifact_url = f"job/{job_name}/lastBuild/artifact/{artifact_path}"
-            try:
-                artifact = self.send_request(item=artifact_url, query="",
-                                             api_entrypoint="",
-                                             raw_response=True)
-                break
-            except JenkinsError:
-                LOG.debug("Found no artifact %s for job %s", artifact_path,
-                          job_name)
-                continue
-
-        if artifact is None:
+        build_description = job["lastCompletedBuild"].get("description")
+        if not build_description:
             LOG.debug("Resorting to get deployment information from job name"
                       " for job %s", job_name)
             self.add_job_info_from_name(job)
             return
+        logs_url_pattern = re.compile(r'href="(.*)">Browse logs')
+        logs_url = logs_url_pattern.search(build_description)
+        if logs_url is None:
+            LOG.debug("Resorting to get deployment information from job name"
+                      " for job %s", job_name)
+            self.add_job_info_from_name(job)
+            return
+        logs_url = logs_url.group(1)
 
-        for line in artifact.split("\n"):
-            if "TOPOLOGY=" in line:
-                topology_str = detect_job_info_regex(line, PROPERTY_PATTERN,
-                                                     group_index=1)
-                topology_str = topology_str.replace('"', '')
-                topology_str = topology_str.replace("'", '')
-                job["topology"] = topology_str
-            if "--version" in line:
-                job["release"] = detect_job_info_regex(line,
-                                                       RELEASE_RUN)
-            if "PRODUCT_VERSION" in line:
-                job["release"] = detect_job_info_regex(line,
-                                                       RELEASE_VERSION)
+        artifact_path = "infrared/provision.yml"
+        artifact_url = f"{logs_url.rstrip('/')}/{artifact_path}"
+        try:
+            artifact = self.send_request(item="", query="",
+                                         url=artifact_url,
+                                         raw_response=True)
+            artifact = yaml.safe_load(artifact)
+            nodes = artifact['provision']['topology'].get('nodes', {})
+            topology = []
+            for node_path, amount in nodes.items():
+                node = os.path.split(node_path)[1]
+                node = os.path.splitext(node)[0]
+                topology.append(f"{node}:{amount}")
+            job["topology"] = ",".join(topology)
 
-            if "--storage-backend" in line or "STORAGE_BACKEND" in line:
-                storage = detect_job_info_regex(line, STORAGE_BACKEND_PATTERN)
-                job["storage_backend"] = storage
+        except JenkinsError:
+            LOG.debug("Found no artifact %s for job %s", artifact_path,
+                      job_name)
 
-            if "--network-backend" in line or "NETWORK_BACKEND" in line:
-                network = detect_job_info_regex(line, NETWORK_BACKEND_PATTERN)
-                job["network_backend"] = network
+        artifact_path = "infrared/overcloud-install.yml"
+        artifact_url = f"{logs_url.rstrip('/')}/{artifact_path}"
+        try:
+            artifact = self.send_request(item="", query="",
+                                         url=artifact_url,
+                                         raw_response=True)
+            artifact = yaml.safe_load(artifact)
+            overcloud = artifact.get('install', {})
+            job["release"] = overcloud.get("version", "")
+            deployment = overcloud.get('deployment', {})
+            job["infra_type"] = os.path.split(deployment.get('files', ""))[1]
+            storage = overcloud.get("storage", {})
+            job["storage_backend"] = storage.get("backend", "")
+            network = overcloud.get("network", {})
+            job["network_backend"] = network.get("backend", "")
+            ip_string = network.get("protocol", "")
+            job["ip_version"] = detect_job_info_regex(ip_string, IP_PATTERN,
+                                                      group_index=1,
+                                                      default="unknown")
+            job["dvr"] = str(network.get("dvr", ""))
+            tls = overcloud.get("tls", {})
+            job["tls_everywhere"] = str(tls.get("everywhere", ""))
 
-            if "--network-protocol" in line or "NETWORK_PROTOCOL" in line:
-                job["ip_version"] = detect_job_info_regex(job_name, IP_PATTERN,
-                                                          group_index=1,
-                                                          default="unknown")
-            if "--network-dvr" in line:
-                dvr_option = detect_job_info_regex(line, DVR_PATTERN_RUN,
-                                                   group_index=1)
-                job["dvr"] = ""
-                if dvr_option:
-                    job["dvr"] = str(dvr_option in ('true', 'yes'))
+        except JenkinsError:
+            LOG.debug("Found no artifact %s for job %s", artifact_path,
+                      job_name)
 
-            if "NETWORK_DVR" in line:
-                dvr_option = detect_job_info_regex(line, OPTIONS)
-                job["dvr"] = ""
-                if dvr_option:
-                    job["dvr"] = str(dvr_option in ('true', 'yes'))
+        if not job.get("topology", ""):
+            self.get_topology_from_job_name(job)
+        topology = job["topology"]
+        job["nodes"] = {}
+        if topology:
+            for component in topology.split(","):
+                role, amount = component.split(":")
+                for i in range(int(amount)):
+                    node_name = role+f"-{i}"
+                    packages = self.get_packages_node(node_name, logs_url,
+                                                      job_name)
+                    containers = self.get_containers_node(node_name,
+                                                          logs_url,
+                                                          job_name)
+                    job["nodes"][node_name] = Node(node_name, role=role,
+                                                   containers=containers,
+                                                   packages=packages)
 
-            if "--tls-everywhere" in line:
-                tls_option = detect_job_info_regex(line, TLS_PATTERN_RUN,
-                                                   group_index=1)
-                job["tls_everywhere"] = ""
-                if tls_option:
-                    job["tls_everywhere"] = str(tls_option in ('true', 'yes'))
+        artifact_path = "undercloud-0/var/log/extra/services.txt.gz"
+        artifact_url = f"{logs_url.rstrip('/')}/{artifact_path}"
+        job["services"] = {}
+        try:
+            artifact = self.send_request(item="", query="",
+                                         url=artifact_url,
+                                         raw_response=True)
+            for service in SERVICES_PATTERN.findall(artifact):
+                job["services"][service] = Service(service)
 
-            if "TLS_EVERYWHERE" in line:
-                tls_option = detect_job_info_regex(line, OPTIONS)
-                job["tls_everywhere"] = ""
-                if tls_option:
-                    job["tls_everywhere"] = str(tls_option in ('true', 'yes'))
+        except JenkinsError:
+            LOG.debug("Found no artifact %s for job %s", artifact_path,
+                      job_name)
 
         if self.job_missing_deployment_info(job):
             LOG.debug("Resorting to get deployment information from job name"
                       " for job %s", job_name)
             self.add_job_info_from_name(job)
+
+    def get_packages_node(self, node_name, logs_url, job_name):
+        """Get a list of packages installed in a openstack node from the job
+        logs.
+
+        :params node_name: Name of the node to inspect
+        :type node_name: str
+        :params logs_url: Url of the job's logs
+        :type logs_url: str
+        :params job_name: Name of the job to inspect
+        :type job_name: str
+
+        :returns: Packages found in the node
+        :rtype: dict
+        """
+        artifact_path = "var/log/extra/rpm-list.txt.gz"
+        artifact_url = f"{logs_url.rstrip('/')}/{node_name}/{artifact_path}"
+        packages = {}
+        try:
+            artifact = self.send_request(item="", query="",
+                                         url=artifact_url,
+                                         raw_response=True)
+            package_list = artifact.rstrip().split("\n")
+            for package in package_list:
+                packages[package] = Package(package)
+
+        except JenkinsError:
+            LOG.debug("Found no artifact %s for job %s", artifact_path,
+                      job_name)
+        return packages
+
+    def get_packages_container(self, container_name, logs_url, job_name):
+        """Get a list of packages installed in a container from the job
+        logs.
+
+        :params container_name: Name of the container to inspect
+        :type node_name: str
+        :params logs_url: Url of the job's logs
+        :type logs_url: str
+        :params job_name: Name of the job to inspect
+        :type job_name: str
+
+        :returns: Packages found in the container
+        :rtype: dict
+        """
+        artifact_path = f"{container_name}/log/dnf.rpm.log.gz"
+        artifact_url = f"{logs_url.rstrip('/')}/{artifact_path}"
+        packages = {}
+        package_pattern = re.compile(r"SUBDEBUG .*: (.*)")
+        try:
+            artifact = self.send_request(item="", query="",
+                                         url=artifact_url,
+                                         raw_response=True)
+            for package in package_pattern.findall(artifact):
+                packages[package] = Package(package)
+
+        except JenkinsError:
+            LOG.debug("Found no artifact %s for job %s", artifact_path,
+                      job_name)
+        return packages
+
+    def get_containers_node(self, node_name, logs_url, job_name):
+        """Get a list of containers used in a openstack node from the job
+        logs.
+
+        :params node_name: Name of the node to inspect
+        :type node_name: str
+        :params logs_url: Url of the job's logs
+        :type logs_url: str
+        :params job_name: Name of the job to inspect
+        :type job_name: str
+
+        :returns: Packages found in the node
+        :rtype: dict
+        """
+        artifact_path = "var/log/extra/podman/containers"
+        artifact_url = f"{logs_url}/{node_name}/{artifact_path}"
+        containers = {}
+        try:
+            artifact = self.send_request(item="", query="",
+                                         url=artifact_url,
+                                         raw_response=True)
+            names_pattern = re.compile(r'<a href=\"([\w+/\.]*)\">([\w/]*)</a>')
+            for folder in names_pattern.findall(artifact):
+                # the page listing the containers has many links, most of them
+                # point to folders with container information, which have the
+                # same text in the link and the displayed text
+                if folder[1] not in folder[0]:
+                    continue
+                container_name = folder[1].rstrip("/")
+                packages = self.get_packages_container(container_name,
+                                                       artifact_url,
+                                                       job_name)
+                containers[container_name] = Container(container_name,
+                                                       packages=packages)
+
+        except JenkinsError:
+            LOG.debug("Found no artifact %s for job %s", artifact_path,
+                      job_name)
+        return containers
+
+    def get_topology_from_job_name(self, job: Dict[str, str]):
+        """Extract the openstack topology from the job name.
+
+        :param job: Dictionary representation of a jenkins job
+        :type job: dict
+        """
+        job_name = job["name"]
+        short_topology = detect_job_info_regex(job_name,
+                                               TOPOLOGY_PATTERN)
+        if short_topology:
+            # due to the regex used, short_topology may contain a trailing
+            # underscore that should be removed
+            short_topology = short_topology.rstrip("_")
+            job["topology"] = translate_topology_string(short_topology)
+        else:
+            job["topology"] = ""
 
     def add_job_info_from_name(self, job:  Dict[str, str]):
         """Add information to the job by using regex on the job name. Check if
@@ -593,15 +742,7 @@ accurate results", len(jobs_found))
         """
         job_name = job['name']
         if "topology" not in job or not job["topology"]:
-            short_topology = detect_job_info_regex(job_name,
-                                                   TOPOLOGY_PATTERN)
-            if short_topology:
-                # due to the regex used, short_topology may contain a trailing
-                # underscore that should be removed
-                short_topology = short_topology.rstrip("_")
-                job["topology"] = translate_topology_string(short_topology)
-            else:
-                job["topology"] = ""
+            self.get_topology_from_job_name(job)
 
         if "release" not in job or not job["release"]:
             job["release"] = detect_job_info_regex(job_name,

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -32,6 +32,8 @@ OPTIONS = re.compile("yes|no|true|false")
 DVR_PATTERN_RUN = re.compile(rf"--network-dvr ({OPTIONS.pattern})")
 DVR_PATTERN_NAME = re.compile(r"(non*_)*dvr")
 TLS_PATTERN_RUN = re.compile(rf"--tls-everywhere ({OPTIONS.pattern})")
+services_pattern_str = r"(tripleo_.*)\.service\s+loaded\s+active\s+running\s"
+SERVICES_PATTERN = re.compile(services_pattern_str)
 
 
 def satisfy_regex_match(model: Dict[str, str], pattern: Pattern,

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -16,13 +16,73 @@
 # pylint: disable=no-member
 import json
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, PropertyMock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
+
+import yaml
 
 from cibyl.cli.argument import Argument
 from cibyl.exceptions.jenkins import JenkinsError
 from cibyl.plugins import extend_models
+from cibyl.plugins.openstack.node import Node
 from cibyl.sources.jenkins import (Jenkins, filter_builds, filter_jobs,
                                    safe_request)
+
+
+def get_yaml_from_topology_string(topology):
+    """Transform a topology string into a dictionary of the same format used in
+    the infrared provision.yml file.
+
+    :param topology: Topology string in the format node: amount
+    :type topology: str
+
+    :returns: yaml representation of a provision.yml file
+    :rtype: str
+    """
+    provision = {'provision': {'topology': {}}}
+    if not topology:
+        return yaml.dump(provision)
+    topology_dict = {}
+    for component in topology.split(","):
+        name, amount = component.split(":")
+        topology_dict[name+".yml"] = int(amount)
+    provision['provision']['topology']['nodes'] = topology_dict
+    return yaml.dump(provision)
+
+
+def get_yaml_overcloud(ip, release, storage_backend, network_backend, dvr,
+                       tls_everywhere, infra_type):
+    """Provide a yaml representation for the paremeters obtained from an
+    infrared overcloud-install.yml file.
+
+    :param ip: Ip version used
+    :type ip: str
+    :param release: Openstack version used
+    :type release: str
+    :param storage_backend: Storage backend used
+    :type storage_backend: str
+    :param network_backend: Network backend used
+    :type network_backend: str
+    :param dvr: Whether dvr is used
+    :type dvr: bool
+    :param tls_everywhere: Whether tls_everywhere is used
+    :type tls_everywhere: bool
+
+    :returns: yaml representation of a overcloud-install.yml file
+    :rtype: str
+    """
+    if ip and ip != "unknown":
+        ip = f"ipv{ip}"
+    overcloud = {"version": release, }
+    overcloud["deployment"] = {"files": infra_type}
+    if storage_backend:
+        storage = {"backend": storage_backend}
+        overcloud["storage"] = storage
+    network = {"backend": network_backend, "protocol": ip, "dvr": dvr}
+    overcloud["network"] = network
+    if tls_everywhere != "":
+        tls = {"everywhere": tls_everywhere}
+        overcloud["tls"] = tls
+    return yaml.dump({"install": overcloud})
 
 
 class TestSafeRequestJenkinsError(TestCase):
@@ -595,7 +655,44 @@ class TestJenkinsSource(TestCase):
         for job_name in job_names:
             response['jobs'].append({'_class': 'org.job.WorkflowJob',
                                      'name': job_name, 'url': 'url',
-                                     'lastBuild': {}})
+                                     'lastCompletedBuild': {}})
+        # each job triggers 2 artifacts requests, if both fail, fallback to
+        # search the name
+        artifacts_fail = [JenkinsError for _ in range(3*len(job_names))]
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts_fail)
+        self.jenkins.add_job_info_from_name = Mock(
+                side_effect=self.jenkins.add_job_info_from_name)
+
+        jobs = self.jenkins.get_deployment()
+        self.jenkins.add_job_info_from_name.assert_called()
+        self.assertEqual(len(jobs), 3)
+        for job_name, ip, release, topology in zip(job_names, ip_versions,
+                                                   releases, topologies):
+            job = jobs[job_name]
+            deployment = job.deployment.value
+            self.assertEqual(job.name.value, job_name)
+            self.assertEqual(job.url.value, "url")
+            self.assertEqual(len(job.builds.value), 0)
+            self.assertEqual(deployment.release.value, release)
+            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(deployment.topology.value, topology)
+
+    def test_get_deployment_artifacts_fallback_no_logs_link(self):
+        """ Test that get_deployment falls back to reading job_names after
+        failing to find artifacts.
+        """
+        job_names = ['test_17.3_ipv4_job_2comp_1cont',
+                     'test_16_ipv6_job_1comp_2cont', 'test_job']
+        ip_versions = ['4', '6', 'unknown']
+        releases = ['17.3', '16', '']
+        topologies = ["compute:2,controller:1", "compute:1,controller:2", ""]
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastCompletedBuild': {'description':
+                                                            "link"}})
         # each job triggers 2 artifacts requests, if both fail, fallback to
         # search the name
         artifacts_fail = [JenkinsError for _ in range(3*len(job_names))]
@@ -628,18 +725,45 @@ class TestJenkinsSource(TestCase):
                       "compute:2,controller:2"]
 
         response = {'jobs': [{'_class': 'folder'}]}
+        logs_url = 'href="link">Browse logs'
         for job_name in job_names:
             response['jobs'].append({'_class': 'org.job.WorkflowJob',
                                      'name': job_name, 'url': 'url',
-                                     'lastBuild': {}})
+                                     'lastCompletedBuild': {'description':
+                                                            logs_url}})
+        services = """
+tripleo_heat_api_cron.service loaded    active     running
+tripleo_heat_engine.service loaded    active     running
+tripleo_ironic_api.service loaded    active     running
+tripleo_ironic_conductor.service loaded    active     running
+        """
         # ensure that all deployment properties are found in the artifact so
         # that it does not fallback to reading values from job name
-        fill = "STORAGE_BACKEND\nNETWORK_BACKEND\nnNETWORK_PROTOCOL"
         artifacts = [
-           f"bla\nJP_TOPOLOGY='{topologies[0]}'\nPRODUCT_VERSION=17.3\n{fill}",
-           f"bla\nJP_TOPOLOGY='{topologies[1]}'\nPRODUCT_VERSION=16\n{fill}",
-           f"bla\nJP_TOPOLOGY='{topologies[2]}'\nPRODUCT_VERSION=\n{fill}",
-            ]
+                get_yaml_from_topology_string(topologies[0]),
+                get_yaml_overcloud(ip_versions[0], releases[0],
+                                   "ceph", "geneve", False,
+                                   False, "path/to/ovb")]
+        # one call to get_packages_node and get_containers_node per node
+        artifacts.extend([JenkinsError()]*(5*2))
+        artifacts.extend([services])
+        artifacts.extend([
+                get_yaml_from_topology_string(topologies[1]),
+                get_yaml_overcloud(ip_versions[1], releases[1],
+                                   "ceph", "geneve", False,
+                                   False, "path/to/ovb")])
+        # one call to get_packages_node and get_containers_node per node
+        artifacts.extend([JenkinsError()]*(3*2))
+        artifacts.extend([services])
+
+        artifacts.extend([
+                get_yaml_from_topology_string(topologies[2]),
+                get_yaml_overcloud(ip_versions[2], releases[2],
+                                   "ceph", "geneve", False,
+                                   False, "path/to/ovb")])
+        # one call to get_packages_node and get_containers_node per node
+        artifacts.extend([JenkinsError()]*(4*2))
+        artifacts.extend([services])
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -655,6 +779,24 @@ class TestJenkinsSource(TestCase):
             self.assertEqual(deployment.release.value, release)
             self.assertEqual(deployment.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
+            self.assertEqual(deployment.storage_backend.value, "ceph")
+            self.assertEqual(deployment.network_backend.value, "geneve")
+            self.assertEqual(deployment.dvr.value, "False")
+            self.assertEqual(deployment.tls_everywhere.value, "False")
+            self.assertEqual(deployment.infra_type.value, "ovb")
+            for component in topology.split(","):
+                role, amount = component.split(":")
+                for i in range(int(amount)):
+                    node_name = role+f"-{i}"
+                    node = Node(node_name, role)
+                    node_found = deployment.nodes[node_name]
+                    self.assertEqual(node_found.name, node.name)
+                    self.assertEqual(node_found.role, node.role)
+            services = deployment.services
+            self.assertTrue("tripleo_heat_api_cron" in services.value)
+            self.assertTrue("tripleo_heat_engine" in services.value)
+            self.assertTrue("tripleo_ironic_api" in services.value)
+            self.assertTrue("tripleo_ironic_conductor" in services.value)
 
     def test_get_deployment_artifacts_missing_property(self):
         """ Test that get_deployment detects missing information from
@@ -969,20 +1111,36 @@ class TestJenkinsSource(TestCase):
                       "compute:2,controller:2"]
 
         response = {'jobs': [{'_class': 'folder'}]}
+        logs_url = 'href="link">Browse logs'
         for job_name in job_names:
             response['jobs'].append({'_class': 'org.job.WorkflowJob',
                                      'name': job_name, 'url': 'url',
-                                     'lastBuild': {}})
-        # ensure that all deployment properties are found in the artifact so
-        # that it does not fallback to reading values from job name
-        fill = "STORAGE_BACKEND\nNETWORK_BACKEND\nNETWORK_PROTOCOL"
+                                     'lastCompletedBuild': {'description':
+                                                            logs_url}})
         artifacts = [
-           f"bl\nJP_TOPOLOGY='{topologies[0]}'\nPRODUCT_VERSION=17.3\n{fill}" +
-           "\nNETWORK_DVR='yes'",
-           f"bl\nJP_TOPOLOGY='{topologies[1]}'\nPRODUCT_VERSION=16\n{fill}" +
-           "\n--network-dvr true",
-           f"bla\nJP_TOPOLOGY='{topologies[2]}'\nPRODUCT_VERSION=\n{fill}",
-            ]
+                get_yaml_from_topology_string(topologies[0]),
+                get_yaml_overcloud(ip_versions[0], releases[0],
+                                   "ceph", "geneve", dvr_status[0], False, "")]
+        # one call to get_packages_node and get_containers_node per node, plus
+        # one to get_services
+        artifacts.extend([JenkinsError()]*(5*2+1))
+        artifacts.extend([
+                get_yaml_from_topology_string(topologies[1]),
+                get_yaml_overcloud(ip_versions[1], releases[1],
+                                   "ceph", "geneve", dvr_status[1],
+                                   False, "")])
+        # one call to get_packages_node and get_containers_node per node, plus
+        # one to get_services
+        artifacts.extend([JenkinsError()]*(3*2+1))
+
+        artifacts.extend([
+                get_yaml_from_topology_string(topologies[2]),
+                get_yaml_overcloud(ip_versions[2], releases[2],
+                                   "ceph", "geneve", dvr_status[2],
+                                   False, "")])
+        # one call to get_packages_node and get_containers_node per node, plus
+        # one to get_services
+        artifacts.extend([JenkinsError()]*(4*2+1))
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -1040,21 +1198,39 @@ class TestJenkinsSource(TestCase):
         topologies = ["compute:2,controller:3", "compute:1,controller:2",
                       "compute:2,controller:2"]
 
+        logs_url = 'href="link">Browse logs'
         response = {'jobs': [{'_class': 'folder'}]}
         for job_name in job_names:
             response['jobs'].append({'_class': 'org.job.WorkflowJob',
                                      'name': job_name, 'url': 'url',
-                                     'lastBuild': {}})
-        # ensure that all deployment properties are found in the artifact so
-        # that it does not fallback to reading values from job name
-        fill = "STORAGE_BACKEND\nNETWORK_BACKEND\nNETWORK_PROTOCOL"
+                                     'lastCompletedBuild': {'description':
+                                                            logs_url}})
         artifacts = [
-           f"bl\nJP_TOPOLOGY='{topologies[0]}'\nPRODUCT_VERSION=17.3\n{fill}" +
-           "\nTLS_EVERYWHERE='yes'",
-           f"bl\nJP_TOPOLOGY='{topologies[1]}'\nPRODUCT_VERSION=16\n{fill}" +
-           "\n--tls-everywhere true",
-           f"bla\nJP_TOPOLOGY='{topologies[2]}'\nPRODUCT_VERSION=\n{fill}",
-            ]
+                get_yaml_from_topology_string(topologies[0]),
+                get_yaml_overcloud(ip_versions[0], releases[0],
+                                   "ceph", "geneve", False, tls_status[0], "")]
+        # one call to get_packages_node and get_containers_node per node, plus
+        # one to get_services
+        artifacts.extend([JenkinsError()]*(5*2+1))
+        artifacts.extend([
+                get_yaml_from_topology_string(topologies[1]),
+                get_yaml_overcloud(ip_versions[1], releases[1],
+                                   "ceph", "geneve", False,
+                                   tls_status[1], "")])
+        # one call to get_packages_node and get_containers_node per node, plus
+        # one to get_services
+        artifacts.extend([JenkinsError()]*(3*2+1))
+
+        artifacts.extend([
+                get_yaml_from_topology_string(topologies[2]),
+                get_yaml_overcloud(ip_versions[2], releases[2],
+                                   "ceph", "geneve", False,
+                                   tls_status[2], "")])
+        # one call to get_packages_node and get_containers_node per node, plus
+        # one to get_services
+        artifacts.extend([JenkinsError()]*(4*2+1))
+
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -1072,6 +1248,167 @@ class TestJenkinsSource(TestCase):
             self.assertEqual(deployment.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
             self.assertEqual(deployment.tls_everywhere.value, tls)
+
+    def test_get_deployment_artifacts_missing_topology(self):
+        """ Test that get_deployment reads properly the information obtained
+        from jenkins using artifacts.
+        """
+        job_names = ['test_17.3_ipv4_2comp_3cont_job',
+                     'test_16_ipv6_1comp_2cont_job', 'test_2comp_2cont_job']
+        ip_versions = ['4', '6', 'unknown']
+        releases = ['17.3', '16', '']
+        tls_status = ['True', 'True', '']
+        topologies = ["compute:2,controller:3", "compute:1,controller:2",
+                      "compute:2,controller:2"]
+
+        logs_url = 'href="link">Browse logs'
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastCompletedBuild': {'description':
+                                                            logs_url}})
+        artifacts = [
+                get_yaml_from_topology_string(""),
+                get_yaml_overcloud(ip_versions[0], releases[0],
+                                   "ceph", "geneve", False, tls_status[0], "")]
+        # one call to get_packages_node and get_containers_node per node, plus
+        # one to get_services
+        artifacts.extend([JenkinsError()]*(5*2+1))
+        artifacts.extend([
+                get_yaml_from_topology_string(""),
+                get_yaml_overcloud(ip_versions[1], releases[1],
+                                   "ceph", "geneve", False,
+                                   tls_status[1], "")])
+        # one call to get_packages_node and get_containers_node per node, plus
+        # one to get_services
+        artifacts.extend([JenkinsError()]*(3*2+1))
+
+        artifacts.extend([
+                get_yaml_from_topology_string(""),
+                get_yaml_overcloud(ip_versions[2], releases[2],
+                                   "ceph", "geneve", False,
+                                   tls_status[2], "")])
+        # one call to get_packages_node and get_containers_node per node, plus
+        # one to get_services
+        artifacts.extend([JenkinsError()]*(4*2+1))
+
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
+
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
+
+        jobs = self.jenkins.get_deployment()
+        self.assertEqual(len(jobs), 3)
+        for job_name, ip, release, topology, tls in zip(job_names, ip_versions,
+                                                        releases, topologies,
+                                                        tls_status):
+            job = jobs[job_name]
+            deployment = job.deployment.value
+            self.assertEqual(job.name.value, job_name)
+            self.assertEqual(job.url.value, "url")
+            self.assertEqual(len(job.builds.value), 0)
+            self.assertEqual(deployment.release.value, release)
+            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(deployment.topology.value, topology)
+            self.assertEqual(deployment.tls_everywhere.value, tls)
+
+    def test_get_packages_node(self):
+        """ Test that get_packages_node reads properly the information obtained
+        from jenkins using artifacts.
+        """
+        response = """
+acl-2.2.53-1.el8.x86_64
+aide-0.16-14.el8_4.1.x86_64
+ansible-2.9.27-1.el8ae.noarch
+ansible-pacemaker-1.0.4-2.20210623224811.666f706.el8ost.noarch
+audit-3.0-0.17.20191104git1c2f876.el8.x86_64
+audit-libs-3.0-0.17.20191104git1c2f876.el8.x86_64
+augeas-libs-1.12.0-6.el8.x86_64
+authselect-1.2.2-2.el8.x86_64
+authselect-compat-1.2.2-2.el8.x86_64
+authselect-libs-1.2.2-2.el8.x86_64
+autofs-5.1.4-48.el8_4.1.x86_64
+autogen-libopts-5.18.12-8.el8.x86_64
+avahi-libs-0.7-20.el8.x86_64
+basesystem-11-5.el8.noarch"""
+        packages_expected = response.split("\n")
+
+        self.jenkins.send_request = Mock(side_effect=[response])
+
+        url = "url/node/var/log/extra/rpm-list.txt.gz"
+        packages = self.jenkins.get_packages_node("node", "url", "job-name")
+        self.jenkins.send_request.assert_called_with(query="", item="",
+                                                     raw_response=True,
+                                                     url=url)
+        self.assertEqual(len(packages), len(packages_expected))
+        for package, package_name in zip(packages.values(), packages_expected):
+            self.assertEqual(package.name.value, package_name)
+
+    def test_get_packages_container(self):
+        """ Test that get_packages_container reads properly the information
+        obtained from jenkins using artifacts.
+        """
+        response = """
+2022-03-28T14:27:24+00 SUBDEBUG Installed: crudini-0.9-11.el8ost.1
+2022-03-28T14:27:30+00 INFO --- logging initialized ---
+2022-03-28T14:28:32+00 INFO warning: /etc/sudoers created as /etc/sudoers.rw
+2022-03-28T14:31:28+00 SUBDEBUG Upgrade: openssl-libs-1:1.1.1g-16.el8_4
+2022-03-28T14:31:28+00 SUBDEBUG Upgraded: python3-dateutil-1:2.6.1-6.el8"""
+
+        packages_expected = ["crudini-0.9-11.el8ost.1",
+                             "openssl-libs-1:1.1.1g-16.el8_4",
+                             "python3-dateutil-1:2.6.1-6.el8"]
+
+        self.jenkins.send_request = Mock(side_effect=[response])
+
+        url = "url/container/log/dnf.rpm.log.gz"
+        packages = self.jenkins.get_packages_container("container", "url",
+                                                       "job-name")
+        self.jenkins.send_request.assert_called_with(query="", item="",
+                                                     raw_response=True,
+                                                     url=url)
+        self.assertEqual(len(packages), len(packages_expected))
+        for package, package_name in zip(packages.values(), packages_expected):
+            self.assertEqual(package.name.value, package_name)
+
+    def test_get_packages_container_raises(self):
+        """ Test that get_packages_container returns an empty dictionary after
+        an error is raised by send_request."""
+        self.jenkins.send_request = Mock(side_effect=JenkinsError)
+
+        packages = self.jenkins.get_packages_container("container", "", "")
+        self.assertEqual(packages, {})
+
+    def test_get_containers_node(self):
+        """ Test that get_containers_node reads properly the information
+        obtained from jenkins using artifacts.
+        """
+        response = """
+<a href="./nova_libvirt/">nova_libvirt/</a>
+<a href="./nova_libvirt/">nova/</a>
+<a href="./nova_migration_target/">nova_migration_target/</a>
+"""
+
+        containers_expected = ["nova_libvirt", "nova_migration_target"]
+
+        self.jenkins.send_request = Mock(side_effect=[response, JenkinsError(),
+                                                      JenkinsError])
+        base_url = "url/node/var/log/extra/podman/containers"
+        urls = [base_url,
+                f"{base_url}/nova_libvirt/log/dnf.rpm.log.gz",
+                f"{base_url}/nova_migration_target/log/dnf.rpm.log.gz"]
+
+        containers = self.jenkins.get_containers_node("node", "url",
+                                                      "job-name")
+        calls = [call(item="", query="", url=url,
+                      raw_response=True) for url in urls]
+
+        self.jenkins.send_request.assert_has_calls(calls)
+        self.assertEqual(len(containers), len(containers_expected))
+        for container, container_name in zip(containers.values(),
+                                             containers_expected):
+            self.assertEqual(container.name.value, container_name)
+            self.assertEqual(container.packages.value, {})
 
 
 class TestFilters(TestCase):


### PR DESCRIPTION
Instead of relying on the builds artifacts, get the deployment
information from the logs of the job. This allows to query for
information like the containers used in each openstck node, the services
or packages installed.
