### PR TITLE
Adding the Pipeline model.

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -23,9 +23,11 @@ class QueryType(Enum):
     """No data from host is requested."""
     TENANTS = 1
     """Only retrieve data concerning tenants."""
-    JOBS = 2
+    PIPELINES = 2
+    """Retrieve data concerning pipelines and above."""
+    JOBS = 3
     """Retrieve data concerning jobs and above."""
-    BUILDS = 3
+    BUILDS = 4
     """Retrieve data concerning builds and above."""
 
 

--- a/cibyl/models/ci/pipeline.py
+++ b/cibyl/models/ci/pipeline.py
@@ -1,0 +1,68 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from cibyl.cli.argument import Argument
+from cibyl.models.attribute import AttributeDictValue
+from cibyl.models.ci.job import Job
+from cibyl.models.model import Model
+
+
+class Pipeline(Model):
+    API = {
+        'name': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'jobs': {
+            'attr_type': Job,
+            'attribute_value_class': AttributeDictValue,
+            'arguments': [
+                Argument(
+                    name='--jobs',
+                    arg_type=str, nargs='*',
+                    description='Jobs belonging to pipeline',
+                    func='get_jobs'
+                )
+            ]
+        }
+    }
+
+    def __init__(self, name, jobs=None):
+        # Let IDEs know this model's attributes
+        self.name = None
+        self.jobs = None
+
+        # Set up the model
+        super().__init__({'name': name, 'jobs': jobs})
+
+    def __eq__(self, other):
+        if not isinstance(other, Pipeline):
+            return False
+
+        return self.name == other.name
+
+    def merge(self, other):
+        for job in other.jobs.values():
+            self.add_job(job)
+
+    def add_job(self, job):
+        key = job.name.value
+
+        if key in self.jobs:
+            # Extract unknown contents of job
+            self.jobs[key].merge(job)
+        else:
+            # Register brand-new job
+            self.jobs[key] = job

--- a/cibyl/models/ci/printers/__init__.py
+++ b/cibyl/models/ci/printers/__init__.py
@@ -50,6 +50,15 @@ class CIPrinter(Printer, ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def print_pipeline(self, pipeline):
+        """
+        :param pipeline: The pipeline.
+        :return: Textual representation of the provided model.
+        :rtype: str
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def print_job(self, job):
         """
         :param job: The job.

--- a/cibyl/models/ci/printers/colored.py
+++ b/cibyl/models/ci/printers/colored.py
@@ -15,6 +15,8 @@
 """
 import logging
 
+from overrides import overrides
+
 from cibyl.cli.query import QueryType
 from cibyl.models.attribute import (AttributeDictValue, AttributeListValue,
                                     AttributeValue)
@@ -56,6 +58,7 @@ class CIColoredPrinter(CIPrinter):
         """
         return self._palette
 
+    @overrides
     def print_environment(self, env):
         printer = IndentedTextBuilder()
 
@@ -67,6 +70,7 @@ class CIColoredPrinter(CIPrinter):
 
         return printer.build()
 
+    @overrides
     def print_system(self, system):
         printer = IndentedTextBuilder()
 
@@ -120,6 +124,7 @@ class CIColoredPrinter(CIPrinter):
 
         return printer.build()
 
+    @overrides
     def print_tenant(self, tenant):
         result = IndentedTextBuilder()
 
@@ -137,6 +142,25 @@ class CIColoredPrinter(CIPrinter):
 
         return result.build()
 
+    @overrides
+    def print_pipeline(self, pipeline):
+        result = IndentedTextBuilder()
+
+        result.add(self._palette.blue('Pipeline: '), 0)
+        result[-1].append(pipeline.name.value)
+
+        for job in pipeline.jobs.values():
+            result.add(self.print_job(job), 1)
+
+        if self.query != QueryType.PIPELINES:
+            result.add(self._palette.blue('Total jobs found in pipeline '), 1)
+            result[-1].append(self._palette.underline(pipeline.name))
+            result[-1].append(self._palette.blue(': '))
+            result[-1].append(len(pipeline.jobs))
+
+        return result.build()
+
+    @overrides
     def print_job(self, job):
         printer = IndentedTextBuilder()
 
@@ -191,6 +215,7 @@ class CIColoredPrinter(CIPrinter):
 
         return printer.build()
 
+    @overrides
     def print_build(self, build):
         printer = IndentedTextBuilder()
 
@@ -226,6 +251,7 @@ class CIColoredPrinter(CIPrinter):
 
         return printer.build()
 
+    @overrides
     def print_test(self, test):
         printer = IndentedTextBuilder()
 

--- a/tests/unit/models/ci/printers/test_raw.py
+++ b/tests/unit/models/ci/printers/test_raw.py
@@ -23,8 +23,8 @@ from cibyl.models.ci.system import JobsSystem
 from cibyl.models.ci.test import Test
 
 
-class TestCIRawParser(TestCase):
-    """Tests for :class:`CIRawParser`.
+class TestCIRawPrinter(TestCase):
+    """Tests for :class:`CIRawPrinter`.
     """
 
     def test_str_environment(self):

--- a/tests/unit/models/ci/test_pipeline.py
+++ b/tests/unit/models/ci/test_pipeline.py
@@ -1,0 +1,95 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.models.ci.pipeline import Pipeline
+
+
+class TestPipeline(TestCase):
+    """Tests for :class:`Pipeline`.
+    """
+
+    def test_not_equal_by_type(self):
+        """Checks that if pipeline is compared with something of another
+        type, they will not be equal.
+        """
+        pipeline = Pipeline('pipeline')
+        other = Mock()
+
+        self.assertNotEqual(other, pipeline)
+
+    def test_equal_by_name(self):
+        """Checks that two pipelines are the same if they share the same name.
+        """
+        name = 'pipeline'
+
+        pipeline1 = Pipeline(name)
+        pipeline2 = Pipeline(name)
+
+        self.assertEqual(pipeline2, pipeline1)
+
+    def test_merge_pipeline(self):
+        """Checks that the jobs from one pipeline is added to the other
+        during a merge.
+        """
+        name1 = 'job1'
+        name2 = 'job2'
+
+        job1 = Mock()
+        job1.name = Mock()
+        job1.name.value = name1
+
+        job2 = Mock()
+        job2.name = Mock()
+        job2.name.value = name2
+
+        pipeline1 = Pipeline('pipeline1', {name1: job1})
+        pipeline2 = Pipeline('pipeline2', {name2: job2})
+
+        pipeline1.merge(pipeline2)
+
+        self.assertEqual(
+            {
+                name1: job1,
+                name2: job2
+            },
+            pipeline1.jobs.value
+        )
+
+    def test_merge_job(self):
+        """Checks that a job that already exists on the pipeline gets merged
+        instead overwritten.
+        """
+        name = 'job'
+
+        job = Mock()
+        job.name = Mock()
+        job.name.value = name
+        job.merge = Mock()
+
+        pipeline = Pipeline('pipeline', {name: job})
+
+        pipeline.add_job(job)
+
+        self.assertEqual(
+            {
+                name: job
+            },
+            pipeline.jobs.value
+        )
+
+        job.merge.assert_called_once_with(job)


### PR DESCRIPTION
Adding: 
- A model for zuul pipelines called 'Pipeline'
- An entry on CIPrinter to print pipelines.

These are still used nowhere, that is the task of future requests.