### PR TITLE
Introduce --spec argument for Jenkins source

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -32,7 +32,11 @@ class Deployment(Model):
             'attr_type': str,
             'arguments': [Argument(name='--release', arg_type=str,
                                    func='get_deployment', nargs='*',
-                                   description="Deployment release version")]
+                                   description="Deployment release version"),
+                          Argument(name='--spec', arg_type=str,
+                                   func='get_deployment', nargs=0,
+                                   description="Print complete openstack"
+                                   " deployment")]
         },
         'infra_type': {
             'attr_type': str,
@@ -61,7 +65,7 @@ class Deployment(Model):
             'attr_type': Service,
             'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--services', arg_type=str,
-                                   nargs='*',
+                                   func='get_deployment', nargs='*',
                                    description="Services in the deployment")]
         },
         'ip_version': {

--- a/cibyl/plugins/openstack/node.py
+++ b/cibyl/plugins/openstack/node.py
@@ -45,14 +45,14 @@ class Node(Model):
             'attr_type': Container,
             'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--containers', arg_type=str,
-                                   nargs='*',
+                                   func='get_deployment', nargs='*',
                                    description="Containers on the node")]
         },
         'packages': {
             'attr_type': Package,
             'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--packages', arg_type=str,
-                                   nargs='*',
+                                   func='get_deployment', nargs='*',
                                    description="Packages in the node")]
         }
     }

--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -125,16 +125,7 @@ Arguments Matrix
    * - --containers
      - | List of containers running
        | on the hosts
-     - |:black_square_button:|
-     - |:black_square_button:|
-     - |:black_square_button:|
-     - |:x:|
-     - |:x:|
-   * - --container-image
-     - | List of images used for
-       | the containers running
-       | on the hosts
-     - |:black_square_button:|
+     - |:ballot_box_with_check:|
      - |:black_square_button:|
      - |:black_square_button:|
      - |:x:|
@@ -142,15 +133,15 @@ Arguments Matrix
    * - --packages
      - | Package installed by the
        | deployment
-     - |:black_square_button:|
+     - |:ballot_box_with_check:|
      - |:black_square_button:|
      - |:black_square_button:|
      - |:x:|
      - |:x:|
-   * - --package-origin
-     - | Origin of package installed
-       | by the deployment
-     - |:black_square_button:|
+   * - --services
+     - | Services installed by the
+       | deployment
+     - |:ballot_box_with_check:|
      - |:black_square_button:|
      - |:black_square_button:|
      - |:x:|

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -23,8 +23,11 @@ import yaml
 from cibyl.cli.argument import Argument
 from cibyl.exceptions.jenkins import JenkinsError
 from cibyl.plugins import extend_models
+from cibyl.plugins.openstack.container import Container
 from cibyl.plugins.openstack.node import Node
+from cibyl.plugins.openstack.service import Service
 from cibyl.sources.jenkins import (Jenkins, filter_builds, filter_jobs,
+                                   filter_models_by_name, filter_nodes,
                                    safe_request)
 
 
@@ -781,7 +784,12 @@ tripleo_ironic_conductor.service loaded    active     running
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
-        jobs = self.jenkins.get_deployment()
+        services = Argument("services", str, "", value=[])
+        packages = Argument("packages", str, "", value=[])
+        containers = Argument("containers", str, "", value=[])
+        jobs = self.jenkins.get_deployment(containers=containers,
+                                           services=services,
+                                           packages=packages)
         self.assertEqual(len(jobs), 3)
         for job_name, ip, release, topology in zip(job_names, ip_versions,
                                                    releases, topologies):
@@ -811,6 +819,48 @@ tripleo_ironic_conductor.service loaded    active     running
             self.assertTrue("tripleo_heat_engine" in services.value)
             self.assertTrue("tripleo_ironic_api" in services.value)
             self.assertTrue("tripleo_ironic_conductor" in services.value)
+
+    def test_get_deployment_artifacts_all_missing(self):
+        """ Test that get_deployment handles properly the case where the logs
+        do not contain the relevant information.
+        """
+        job_names = ['test_17.3_ipv4_job', 'test_16_ipv6_job', 'test_job']
+        ip_versions = ['4', '6', 'unknown']
+        releases = ['17.3', '16', '']
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        logs_url = 'href="link">Browse logs'
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastCompletedBuild': {'description':
+                                                            logs_url}})
+        services = ""
+        # ensure that all deployment properties are found in the artifact so
+        # that it does not fallback to reading values from job name
+        artifacts = [JenkinsError()]*9
+
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
+
+        services = Argument("services", str, "", value=[])
+        jobs = self.jenkins.get_deployment(services=services)
+        self.assertEqual(len(jobs), 3)
+        for job_name, ip, release in zip(job_names, ip_versions, releases):
+            job = jobs[job_name]
+            deployment = job.deployment.value
+            self.assertEqual(job.name.value, job_name)
+            self.assertEqual(job.url.value, "url")
+            self.assertEqual(len(job.builds.value), 0)
+            self.assertEqual(deployment.release.value, release)
+            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(deployment.topology.value, "")
+            self.assertEqual(deployment.storage_backend.value, "")
+            self.assertEqual(deployment.network_backend.value, "")
+            self.assertEqual(deployment.dvr.value, "")
+            self.assertEqual(deployment.tls_everywhere.value, "")
+            self.assertEqual(deployment.infra_type.value, "")
+            self.assertEqual(deployment.nodes.value, {})
+            self.assertEqual(deployment.services.value, {})
 
     def test_get_deployment_artifacts_missing_property(self):
         """ Test that get_deployment detects missing information from
@@ -1134,27 +1184,17 @@ tripleo_ironic_conductor.service loaded    active     running
         artifacts = [
                 get_yaml_from_topology_string(topologies[0]),
                 get_yaml_overcloud(ip_versions[0], releases[0],
-                                   "ceph", "geneve", dvr_status[0], False, "")]
-        # one call to get_packages_node and get_containers_node per node, plus
-        # one to get_services
-        artifacts.extend([JenkinsError()]*(5*2+1))
-        artifacts.extend([
+                                   "ceph", "geneve", dvr_status[0], False, ""),
                 get_yaml_from_topology_string(topologies[1]),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", dvr_status[1],
-                                   False, "")])
-        # one call to get_packages_node and get_containers_node per node, plus
-        # one to get_services
-        artifacts.extend([JenkinsError()]*(3*2+1))
-
-        artifacts.extend([
+                                   False, ""),
                 get_yaml_from_topology_string(topologies[2]),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", dvr_status[2],
-                                   False, "")])
+                                   False, "")]
         # one call to get_packages_node and get_containers_node per node, plus
         # one to get_services
-        artifacts.extend([JenkinsError()]*(4*2+1))
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -1222,29 +1262,15 @@ tripleo_ironic_conductor.service loaded    active     running
         artifacts = [
                 get_yaml_from_topology_string(topologies[0]),
                 get_yaml_overcloud(ip_versions[0], releases[0],
-                                   "ceph", "geneve", False, tls_status[0], "")]
-        # one call to get_packages_node and get_containers_node per node, plus
-        # one to get_services
-        artifacts.extend([JenkinsError()]*(5*2+1))
-        artifacts.extend([
+                                   "ceph", "geneve", False, tls_status[0], ""),
                 get_yaml_from_topology_string(topologies[1]),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", False,
-                                   tls_status[1], "")])
-        # one call to get_packages_node and get_containers_node per node, plus
-        # one to get_services
-        artifacts.extend([JenkinsError()]*(3*2+1))
-
-        artifacts.extend([
+                                   tls_status[1], ""),
                 get_yaml_from_topology_string(topologies[2]),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", False,
-                                   tls_status[2], "")])
-        # one call to get_packages_node and get_containers_node per node, plus
-        # one to get_services
-        artifacts.extend([JenkinsError()]*(4*2+1))
-
-        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
+                                   tls_status[2], "")]
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -1285,29 +1311,15 @@ tripleo_ironic_conductor.service loaded    active     running
         artifacts = [
                 get_yaml_from_topology_string(""),
                 get_yaml_overcloud(ip_versions[0], releases[0],
-                                   "ceph", "geneve", False, tls_status[0], "")]
-        # one call to get_packages_node and get_containers_node per node, plus
-        # one to get_services
-        artifacts.extend([JenkinsError()]*(5*2+1))
-        artifacts.extend([
+                                   "ceph", "geneve", False, tls_status[0], ""),
                 get_yaml_from_topology_string(""),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", False,
-                                   tls_status[1], "")])
-        # one call to get_packages_node and get_containers_node per node, plus
-        # one to get_services
-        artifacts.extend([JenkinsError()]*(3*2+1))
-
-        artifacts.extend([
+                                   tls_status[1], ""),
                 get_yaml_from_topology_string(""),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", False,
-                                   tls_status[2], "")])
-        # one call to get_packages_node and get_containers_node per node, plus
-        # one to get_services
-        artifacts.extend([JenkinsError()]*(4*2+1))
-
-        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
+                                   tls_status[2], "")]
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -1406,7 +1418,7 @@ basesystem-11-5.el8.noarch"""
         containers_expected = ["nova_libvirt", "nova_migration_target"]
 
         self.jenkins.send_request = Mock(side_effect=[response, JenkinsError(),
-                                                      JenkinsError])
+                                                      JenkinsError()])
         base_url = "url/node/var/log/extra/podman/containers"
         urls = [base_url,
                 f"{base_url}/nova_libvirt/log/dnf.rpm.log.gz",
@@ -1423,6 +1435,259 @@ basesystem-11-5.el8.noarch"""
                                              containers_expected):
             self.assertEqual(container.name.value, container_name)
             self.assertEqual(container.packages.value, {})
+
+    def test_get_deployment_artifacts_filter_services(self):
+        """ Test that get_deployment reads properly the information obtained
+        from jenkins using artifacts.
+        """
+        job_names = ['test_17.3_ipv4_job', 'test_16_ipv6_job', 'test_job']
+        ip_versions = ['4', '6', 'unknown']
+        releases = ['17.3', '16', '']
+        topologies = ["compute:2,controller:3", "compute:1,controller:2",
+                      "compute:2,controller:2"]
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        logs_url = 'href="link">Browse logs'
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastCompletedBuild': {'description':
+                                                            logs_url}})
+        services = """
+tripleo_heat_api_cron.service loaded    active     running
+tripleo_heat_engine.service loaded    active     running
+tripleo_ironic_api.service loaded    active     running
+tripleo_ironic_conductor.service loaded    active     running
+        """
+        # ensure that all deployment properties are found in the artifact so
+        # that it does not fallback to reading values from job name
+        artifacts = [
+                get_yaml_from_topology_string(topologies[0]),
+                get_yaml_overcloud(ip_versions[0], releases[0],
+                                   "ceph", "geneve", False,
+                                   False, "path/to/ovb")]
+        # one call to get_packages_node and get_containers_node per node
+        artifacts.extend([JenkinsError()]*(5*2))
+        artifacts.extend([services])
+        artifacts.extend([
+                get_yaml_from_topology_string(topologies[1]),
+                get_yaml_overcloud(ip_versions[1], releases[1],
+                                   "ceph", "geneve", False,
+                                   False, "path/to/ovb")])
+        # one call to get_packages_node and get_containers_node per node
+        artifacts.extend([JenkinsError()]*(3*2))
+        artifacts.extend([services])
+
+        artifacts.extend([
+                get_yaml_from_topology_string(topologies[2]),
+                get_yaml_overcloud(ip_versions[2], releases[2],
+                                   "ceph", "geneve", False,
+                                   False, "path/to/ovb")])
+        # one call to get_packages_node and get_containers_node per node
+        artifacts.extend([JenkinsError()]*(4*2))
+        artifacts.extend([services])
+
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
+
+        services = Argument("services", str, "", value=['tripleo_heat_engine'])
+        packages = Argument("packages", str, "", value=[])
+        containers = Argument("containers", str, "", value=[])
+        jobs = self.jenkins.get_deployment(containers=containers,
+                                           services=services,
+                                           packages=packages)
+        self.assertEqual(len(jobs), 3)
+        for job_name, ip, release, topology in zip(job_names, ip_versions,
+                                                   releases, topologies):
+            job = jobs[job_name]
+            deployment = job.deployment.value
+            self.assertEqual(job.name.value, job_name)
+            self.assertEqual(job.url.value, "url")
+            self.assertEqual(len(job.builds.value), 0)
+            self.assertEqual(deployment.release.value, release)
+            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(deployment.topology.value, topology)
+            self.assertEqual(deployment.storage_backend.value, "ceph")
+            self.assertEqual(deployment.network_backend.value, "geneve")
+            self.assertEqual(deployment.dvr.value, "False")
+            self.assertEqual(deployment.tls_everywhere.value, "False")
+            self.assertEqual(deployment.infra_type.value, "ovb")
+            for component in topology.split(","):
+                role, amount = component.split(":")
+                for i in range(int(amount)):
+                    node_name = role+f"-{i}"
+                    node = Node(node_name, role)
+                    node_found = deployment.nodes[node_name]
+                    self.assertEqual(node_found.name, node.name)
+                    self.assertEqual(node_found.role, node.role)
+            services = deployment.services
+            self.assertEqual(len(services), 1)
+            self.assertTrue("tripleo_heat_engine" in services.value)
+
+    def test_get_deployment_spec_multiple_jobs(self):
+        """ Test that get_deployment fails if --spec is used with
+        multiple jobs.
+        """
+        job_names = ['test_17.3_ipv4_job', 'test_16_ipv6_job', 'test_job']
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        logs_url = 'href="link">Browse logs'
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastCompletedBuild': {'description':
+                                                            logs_url}})
+        self.jenkins.send_request = Mock(side_effect=[response])
+
+        spec = Argument("spec", str, "", value=[])
+        self.assertRaises(JenkinsError, self.jenkins.get_deployment, spec=spec)
+
+    def test_get_deployment_spec_one_job_no_builds(self):
+        """ Test that get_deployment fails if --spec is used with a job that
+        has no completed builds.
+        """
+        job_names = ['test_17.3_ipv4_job']
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastCompletedBuild': None})
+        self.jenkins.send_request = Mock(side_effect=[response])
+
+        spec = Argument("spec", str, "", value=[])
+        self.assertRaises(JenkinsError, self.jenkins.get_deployment, spec=spec)
+
+    def test_get_deployment_spec_correct_call(self):
+        """ Test get_deployment call with --spec and one job."""
+        job_names = ['test_17.3_ipv4_job']
+        ip_versions = ['4']
+        releases = ['17.3']
+        topologies = ["compute:2,controller:3"]
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        logs_url = 'href="link">Browse logs'
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastCompletedBuild': {'description':
+                                                            logs_url}})
+        services = """
+tripleo_heat_api_cron.service loaded    active     running
+tripleo_heat_engine.service loaded    active     running
+tripleo_ironic_api.service loaded    active     running
+tripleo_ironic_conductor.service loaded    active     running
+        """
+        # ensure that all deployment properties are found in the artifact so
+        # that it does not fallback to reading values from job name
+        artifacts = [
+                get_yaml_from_topology_string(topologies[0]),
+                get_yaml_overcloud(ip_versions[0], releases[0],
+                                   "ceph", "geneve", False,
+                                   False, "path/to/ovb")]
+        # one call to get_packages_node and get_containers_node per node
+        artifacts.extend([JenkinsError()]*(5*2))
+        artifacts.extend([services])
+
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
+
+        spec = Argument("spec", str, "", value=[])
+        jobs = self.jenkins.get_deployment(spec=spec)
+        self.assertEqual(len(jobs), 1)
+        for job_name, ip, release, topology in zip(job_names, ip_versions,
+                                                   releases, topologies):
+            job = jobs[job_name]
+            deployment = job.deployment.value
+            self.assertEqual(job.name.value, job_name)
+            self.assertEqual(job.url.value, "url")
+            self.assertEqual(len(job.builds.value), 0)
+            self.assertEqual(deployment.release.value, release)
+            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(deployment.topology.value, topology)
+            self.assertEqual(deployment.storage_backend.value, "ceph")
+            self.assertEqual(deployment.network_backend.value, "geneve")
+            self.assertEqual(deployment.dvr.value, "False")
+            self.assertEqual(deployment.tls_everywhere.value, "False")
+            self.assertEqual(deployment.infra_type.value, "ovb")
+            for component in topology.split(","):
+                role, amount = component.split(":")
+                for i in range(int(amount)):
+                    node_name = role+f"-{i}"
+                    node = Node(node_name, role)
+                    node_found = deployment.nodes[node_name]
+                    self.assertEqual(node_found.name, node.name)
+                    self.assertEqual(node_found.role, node.role)
+            services = deployment.services
+            self.assertEqual(len(services), 4)
+            self.assertTrue("tripleo_heat_api_cron" in services.value)
+            self.assertTrue("tripleo_heat_engine" in services.value)
+            self.assertTrue("tripleo_ironic_api" in services.value)
+            self.assertTrue("tripleo_ironic_conductor" in services.value)
+
+    def test_get_deployment_filter_containers(self):
+        """ Test get_deployment call with --containers."""
+        job_names = ['test_17.3_ipv4_job']
+        ip_versions = ['4']
+        releases = ['17.3']
+        topologies = ["compute:2,controller:3"]
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        logs_url = 'href="link">Browse logs'
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastCompletedBuild': {'description':
+                                                            logs_url}})
+        containers = """
+<a href="./nova_libvirt/">nova_libvirt/</a>
+<a href="./nova_libvirt/">nova/</a>
+<a href="./nova_migration_target/">nova_migration_target/</a>
+"""
+        # ensure that all deployment properties are found in the artifact so
+        # that it does not fallback to reading values from job name
+        artifacts = [
+                get_yaml_from_topology_string(topologies[0]),
+                get_yaml_overcloud(ip_versions[0], releases[0],
+                                   "ceph", "geneve", False,
+                                   False, "path/to/ovb")]
+        # two call to get_packages_node and get_containers_node per node
+        for _ in range(5):
+            artifacts.append(containers)
+            artifacts.append(JenkinsError())  # get_packages_container
+            artifacts.append(JenkinsError())  # get_packages_container
+
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
+
+        containers = Argument("containers", str, "", value=["nova_libvirt"])
+        jobs = self.jenkins.get_deployment(containers=containers)
+        self.assertEqual(len(jobs), 1)
+        for job_name, ip, release, topology in zip(job_names, ip_versions,
+                                                   releases, topologies):
+            job = jobs[job_name]
+            deployment = job.deployment.value
+            self.assertEqual(job.name.value, job_name)
+            self.assertEqual(job.url.value, "url")
+            self.assertEqual(len(job.builds.value), 0)
+            self.assertEqual(deployment.release.value, release)
+            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(deployment.topology.value, topology)
+            self.assertEqual(deployment.storage_backend.value, "ceph")
+            self.assertEqual(deployment.network_backend.value, "geneve")
+            self.assertEqual(deployment.dvr.value, "False")
+            self.assertEqual(deployment.tls_everywhere.value, "False")
+            self.assertEqual(deployment.infra_type.value, "ovb")
+            for component in topology.split(","):
+                role, amount = component.split(":")
+                for i in range(int(amount)):
+                    node_name = role+f"-{i}"
+                    node = Node(node_name, role)
+                    node_found = deployment.nodes[node_name]
+                    self.assertEqual(node_found.name, node.name)
+                    self.assertEqual(node_found.role, node.role)
+                    containers = node_found.containers.value
+                    self.assertEqual(len(containers), 1)
+                    self.assertIn("nova_libvirt", containers)
+            services = deployment.services
+            self.assertEqual(len(services), 0)
 
 
 class TestFilters(TestCase):
@@ -1596,3 +1861,30 @@ class TestFilters(TestCase):
                     {'_class': 'org..job.WorkflowRun', 'number': "5",
                      'result': 'success'}]
         self.assertEqual(builds_filtered, expected)
+
+    def test_filter_nodes(self):
+        """Test that filter_nodes filters nodes according to user input."""
+        job = {'nodes': {'node1': Node('node1', 'test',
+                                       containers={
+                                           'cont1': Container('cont1')}),
+                         'node2': Node('node2', 'test',
+                                       containers={
+                                           'cont2': Container('cont2')})}}
+        containers = Mock()
+        containers.value = ["cont2"]
+        self.assertTrue(filter_nodes(job, containers, 'containers'))
+        containers = job['nodes']['node2'].containers.value
+        self.assertEqual(containers['cont2'].name.value, 'cont2')
+        containers = job['nodes']['node1'].containers.value
+        self.assertEqual(containers, {})
+
+    def test_filter_models_by_name(self):
+        """Test that filter_models_by_name filters job according to
+        user input."""
+        job = {'services': {'service1': Service('service1'),
+                            'service2': Service('service2')}}
+        services = Mock()
+        services.value = ["service2"]
+        self.assertTrue(filter_models_by_name(job, services, 'services'))
+        self.assertEqual(len(job['services']), 1)
+        self.assertIn('service2', job['services'])


### PR DESCRIPTION
This change instroduces the --spec argument for the Jenkins source,
which will print the full Openstack specification for a job. It
also adds support for filtering using the --container, --packages
and --services arguments. With this change, informations about
containers, packages and services will only be queries if the respective
arguments are used, givent that it takes significantly longer that other
deployment details.
