### PR TITLE
Improve SourceMethodsStore for multiple sources

### DIFF
--- a/cibyl/utils/source_methods_store.py
+++ b/cibyl/utils/source_methods_store.py
@@ -22,7 +22,7 @@ class SourceMethodsStore:
     and --build-status or --jobs and --jobs-url).
     """
     def __init__(self):
-        self.cache = set()
+        self.cache = dict()
 
     def _method_information_tuple(self, source_method):
         """Obtain a tuple representation in the format (source_name,
@@ -48,10 +48,21 @@ class SourceMethodsStore:
         """
         return self._method_information_tuple(source_method) in self.cache
 
-    def add_call(self, source_method):
-        """Add a particular source method to the call cache.
+    def add_call(self, source_method, success):
+        """Add a particular source method to the call cache, with a given
+        status.
+
+        :param source_method: Source method that is used
+        :type source_method: method
+        :param success: Whether the source method call was successful
+        :type success: bool
+        """
+        self.cache[self._method_information_tuple(source_method)] = success
+
+    def get_status(self, source_method):
+        """Return the success of a previous call to source_method.
 
         :param source_method: Source method that is used
         :type source_method: method
         """
-        self.cache.add(self._method_information_tuple(source_method))
+        return self.cache[self._method_information_tuple(source_method)]

--- a/tests/unit/utils/test_source_metdhods_store.py
+++ b/tests/unit/utils/test_source_metdhods_store.py
@@ -31,26 +31,36 @@ class TestSourceMethodsStore(TestCase):
     def test_add_call(self):
         """Test add_call method."""
         jenkins_get_jobs = self.jenkins.get_jobs
-        self.cache.add_call(jenkins_get_jobs)
+        self.cache.add_call(jenkins_get_jobs, True)
         self.assertEqual(self.cache.cache,
-                         set([("jenkins_source", "get_jobs")]))
+                         {("jenkins_source", "get_jobs"): True})
 
     def test_add_multiple_calls(self):
         """Test add_call method."""
         jenkins_get_jobs = self.jenkins.get_jobs
         zuul_get_builds = self.zuul.get_builds
-        self.cache.add_call(jenkins_get_jobs)
-        self.cache.add_call(zuul_get_builds)
+        self.cache.add_call(jenkins_get_jobs, True)
+        self.cache.add_call(zuul_get_builds, False)
         self.assertEqual(self.cache.cache,
-                         set([("jenkins_source", "get_jobs"),
-                              ("zuul_source", "get_builds")
-                              ]))
+                         {("jenkins_source", "get_jobs"): True,
+                          ("zuul_source", "get_builds"): False})
 
     def test_has_been_called(self):
         """Test has_been_called method."""
         jenkins_get_jobs = self.jenkins.get_jobs
         zuul_get_builds = self.zuul.get_builds
-        self.cache.add_call(jenkins_get_jobs)
-        self.cache.add_call(zuul_get_builds)
+        self.cache.add_call(jenkins_get_jobs, True)
+        self.cache.add_call(zuul_get_builds, True)
         self.assertTrue(self.cache.has_been_called(jenkins_get_jobs))
         self.assertTrue(self.cache.has_been_called(zuul_get_builds))
+
+    def test_status(self):
+        """Test get_status method."""
+        jenkins_get_jobs = self.jenkins.get_jobs
+        zuul_get_builds = self.zuul.get_builds
+        self.cache.add_call(jenkins_get_jobs, True)
+        self.cache.add_call(zuul_get_builds, False)
+        self.assertTrue(self.cache.has_been_called(jenkins_get_jobs))
+        self.assertTrue(self.cache.has_been_called(zuul_get_builds))
+        self.assertTrue(self.cache.get_status(jenkins_get_jobs))
+        self.assertFalse(self.cache.get_status(zuul_get_builds))


### PR DESCRIPTION
Since multiple sources can be used in a single query, the
SourceMethodsStore stores now whether the call to a source method was
successful or not (whether there was any error). If a method was
successfully called, then no other call to the same method of another
source in the same system is done. If there was an error, then other
sources are still checked. Before this change, if two arguments for the
same method were used (e.g. --builds --build-status) and there were
multiple sources defined, the first source would call get_builds, and
then the SourceMethodsStore would cause to skip it and call the second
source, even if the second call is completely unnecessary.
