### PR TITLE
Support --test-result and --test-duration in Jenkins

### DIFF
--- a/cibyl/cli/ranged_argument.py
+++ b/cibyl/cli/ranged_argument.py
@@ -17,7 +17,7 @@ import operator
 import re
 from collections import namedtuple
 
-EXPRESSION_PATTERN = re.compile(r"([<>=!]*)(\d)+")
+EXPRESSION_PATTERN = re.compile(r"([<>=!]*)(\d+)")
 
 Range = namedtuple('Range', 'operator operand')
 

--- a/cibyl/models/ci/build.py
+++ b/cibyl/models/ci/build.py
@@ -32,7 +32,7 @@ class Build(Model):
         'status': {
             'attr_type': str,
             'arguments': [Argument(name='--build-status', arg_type=str,
-                                   func='get_builds',
+                                   func='get_builds', nargs='*',
                                    description="Build status")]
         },
         'duration': {

--- a/cibyl/models/ci/test.py
+++ b/cibyl/models/ci/test.py
@@ -35,8 +35,9 @@ class Test(Model):
         'duration': {
             'attr_type': int,
             'arguments': [Argument(name='--test-duration', arg_type=str,
-                                   func='get_tests',
-                                   description="Test duration")]
+                                   func='get_tests', nargs='*',
+                                   ranged=True,
+                                   description="Test duration (in seconds)")]
         },
         'class_name': {
             'attr_type': int,

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -93,6 +93,28 @@ def satisfy_case_insensitive_match(model: Dict[str, str], user_input: Argument,
     return model[field_to_check].lower() in lowercase_input
 
 
+def satisfy_range_match(model: Dict[str, str], user_input: Argument,
+                        field_to_check: str):
+    """Check whether model should be included according to the user input. The
+    model should be added if the information provided in field_to_check
+    (the model name or url for example) is consistent with the range defined
+    in the user_input values.
+
+    :param model: model information obtained from jenkins
+    :type model: str
+    :param user_input: input argument specified by the user
+    :type model_urls: :class:`.Argument`
+    :param field_to_check: Job field to perform the check
+    :param field_to_check: str
+    :returns: Whether the model satisfies user input
+    :rtype: bool
+    """
+    model_value = float(model[field_to_check])
+    results = [RANGE_OPERATORS[operator](float(model_value), float(user_value))
+               for operator, user_value in user_input.value]
+    return all(results)
+
+
 def filter_topology(model: Dict[str, str], operator: str, value: str,
                     component: str):
     """Check whether model should be included according to the user input. The

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -98,14 +98,16 @@ Arguments Matrix
    * - --test-result
      - | Test result (default: all)
        | success, failed, skipped
-     - |:black_square_button:|
+     - |:ballot_box_with_check:|
      - |:black_square_button:|
      - |:ballot_box_with_check:|
      - |:x:|
      - |:x:|
    * - --test-duration
-     - | Test duration (default: all)
-     - |:black_square_button:|
+     - | Test duration (in seconds,
+       | default: all)
+       | (Can be also range: ">=3")
+     - |:ballot_box_with_check:|
      - |:black_square_button:|
      - |:black_square_button:|
      - |:x:|

--- a/tests/unit/cli/test_ranged_argument.py
+++ b/tests/unit/cli/test_ranged_argument.py
@@ -36,6 +36,8 @@ class TestRange(TestCase):
         self.assertTrue(is_valid_regex(matched_str, ">>", "4"))
         matched_str = EXPRESSION_PATTERN.search("!=4")
         self.assertTrue(is_valid_regex(matched_str, "!=", "4"))
+        matched_str = EXPRESSION_PATTERN.search("<=45")
+        self.assertTrue(is_valid_regex(matched_str, "<=", "45"))
 
     def test_Range(self):
         """Test that Range namedtuple works as intended."""


### PR DESCRIPTION
The Jenkins source can now filter tests by result (case-insensitive
check) and by duration (range check) and by test names (specified in the
--tests argument).
