### PR TITLE
Remove openstack as default plugin

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -22,7 +22,7 @@ from cibyl.exceptions import CibylException
 from cibyl.exceptions.cli import InvalidArgument
 from cibyl.exceptions.config import ConfigurationNotFound
 from cibyl.orchestrator import Orchestrator
-from cibyl.plugins import DEFAULT_PLUGIN, extend_models
+from cibyl.plugins import extend_models
 from cibyl.utils.logger import configure_logging
 
 LOG = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ def raw_parsing(arguments):
     """
     args = {'config_file_path': None, 'help': False,
             "log_file": "cibyl_output.log", "log_mode": "both",
-            "logging": logging.INFO, "plugins": [DEFAULT_PLUGIN],
+            "logging": logging.INFO, "plugins": [],
             "debug": False, "output_style": OutputStyle.COLORIZED}
     for i, item in enumerate(arguments[1:]):
         if item in ('-c', '--config'):
@@ -95,9 +95,12 @@ def main():
 
     orchestrator.create_ci_environments()
 
+    plugins = arguments.get('plugins')
+    if not plugins:
+        # if user has not specified any plugins, read them from configuration
+        plugins = orchestrator.config.data.get('plugins', [])
     # add plugins after the environments are created, since the environment
     # might modify some of the models APIs
-    plugins = arguments.get('plugins')
     if plugins:
         for plugin in plugins:
             extend_models(plugin)

--- a/cibyl/plugins/__init__.py
+++ b/cibyl/plugins/__init__.py
@@ -20,10 +20,6 @@ from cibyl.models.ci.environment import Environment
 
 LOG = logging.getLogger(__name__)
 
-# TODO(abregman): Remove in the future and rely solely on
-#                 CLI or configuration
-DEFAULT_PLUGIN = 'openstack'
-
 
 def extend_models(plugin_name):
     try:

--- a/tests/intr/cli/test_openstack_plugin.py
+++ b/tests/intr/cli/test_openstack_plugin.py
@@ -103,3 +103,21 @@ class TestOpenstackCLI(TestCase):
 
             main()
         self.assertIn('deployment', Job.API)
+
+    def test_openstack_cli_zuul_system_plugin_configuration(self):
+        """Test that the Deployment model is added to the Job when a Zuul
+        system is present in the configuration and openstack plugin is added
+        through the configuration.
+        """
+        with NamedTemporaryFile() as config_file:
+            config_file.write(b"environments:\n")
+            config_file.write(b"  env:\n")
+            config_file.write(b"    system:\n")
+            config_file.write(b"      system_type: zuul\n")
+            config_file.write(b"plugins:\n")
+            config_file.write(b"  - openstack\n")
+            config_file.seek(0)
+            sys.argv = ['-h', '--config', config_file.name]
+
+            main()
+        self.assertIn('deployment', Job.API)

--- a/tests/unit/cli/test_raw_parsing.py
+++ b/tests/unit/cli/test_raw_parsing.py
@@ -1,0 +1,82 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import logging
+from unittest import TestCase
+
+from cibyl.cli.main import raw_parsing
+from cibyl.cli.output import OutputStyle
+
+
+class TestRawParsing(TestCase):
+    """Test raw_parsing from main."""
+
+    def test_parser_plugin_argument(self):
+        """Tests parser plugin argument."""
+        parse_args = ['cibyl', '--plugin', 'openstack', 'unknown']
+        args = raw_parsing(parse_args)
+        self.assertEqual(args['plugins'], ['openstack', 'unknown'])
+
+    def test_parser_debug_argument(self):
+        """Tests parser debug argument."""
+        parse_args = ['cibyl', '--debug']
+        args = raw_parsing(parse_args)
+        self.assertTrue(args['debug'])
+        self.assertEqual(args['logging'], logging.DEBUG)
+
+    def test_parser_config_argument(self):
+        """Tests parser config argument."""
+        parse_args = ['cibyl', '--config', '/some/path']
+        args = raw_parsing(parse_args)
+        self.assertEqual(args['config_file_path'], '/some/path')
+
+    def test_parser_help_argument(self):
+        """Tests parser help argument."""
+        parse_args = ['cibyl', '--help']
+        args = raw_parsing(parse_args)
+        self.assertTrue(args['help'])
+
+    def test_parser_log_file_argument(self):
+        """Tests parser log_file argument."""
+        parse_args = ['cibyl', '--log-file', '/some/path']
+        args = raw_parsing(parse_args)
+        self.assertEqual(args['log_file'], '/some/path')
+
+    def test_parser_log_mode_argument(self):
+        """Tests parser log_mode argument."""
+        parse_args = ['cibyl', '--log-mode', 'terminal']
+        args = raw_parsing(parse_args)
+        self.assertEqual(args['log_mode'], 'terminal')
+
+    def test_parser_output_format_argument(self):
+        """Tests parser output format argument."""
+        parse_args = ['cibyl', '--output-format', 'text']
+        args = raw_parsing(parse_args)
+        self.assertEqual(args['output_style'], OutputStyle.from_key('text'))
+
+    def test_parser_all_arguments(self):
+        """Tests that all arguments are parsed."""
+        parse_args = ['cibyl', '-c', 'path', '-h', '--log-file', 'log',
+                      '--log-mode', 'terminal', '-d', '-p', 'plugin1',
+                      'plugin2', '-f', 'text']
+        args = raw_parsing(parse_args)
+        self.assertEqual(args['config_file_path'], 'path')
+        self.assertTrue(args['help'])
+        self.assertEqual(args['log_file'], 'log')
+        self.assertEqual(args['log_mode'], 'terminal')
+        self.assertTrue(args['debug'])
+        self.assertEqual(args['logging'], logging.DEBUG)
+        self.assertEqual(args['plugins'], ['plugin1', 'plugin2'])
+        self.assertEqual(args['output_style'], OutputStyle.from_key('text'))

--- a/tests/unit/plugins/test_plugin.py
+++ b/tests/unit/plugins/test_plugin.py
@@ -16,7 +16,7 @@
 from unittest import TestCase
 
 from cibyl.exceptions.plugin import MissingPlugin
-from cibyl.plugins import DEFAULT_PLUGIN, extend_models
+from cibyl.plugins import extend_models
 
 
 class TestPlugin(TestCase):
@@ -24,7 +24,7 @@ class TestPlugin(TestCase):
 
     def test_extend_models(self):
         """Test extend_models method"""
-        self.assertIsNone(extend_models(DEFAULT_PLUGIN))
+        self.assertIsNone(extend_models("openstack"))
 
     def test_missing_plugin(self):
         """Test extend_models method with a non-existing plugin."""


### PR DESCRIPTION
Plugins can no be specified either through configuration file or through
cli arguments. CLI takes precedence and there is no default plugin.
