### PR TITLE
Adding the project model

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -23,11 +23,13 @@ class QueryType(Enum):
     """No data from host is requested."""
     TENANTS = 1
     """Only retrieve data concerning tenants."""
-    PIPELINES = 2
+    PROJECTS = 2
+    """Retrieve data concerning projects and above."""
+    PIPELINES = 3
     """Retrieve data concerning pipelines and above."""
-    JOBS = 3
+    JOBS = 4
     """Retrieve data concerning jobs and above."""
-    BUILDS = 4
+    BUILDS = 5
     """Retrieve data concerning builds and above."""
 
 

--- a/cibyl/models/ci/pipeline.py
+++ b/cibyl/models/ci/pipeline.py
@@ -54,10 +54,24 @@ class Pipeline(Model):
         return self.name == other.name
 
     def merge(self, other):
+        """Adds the contents of another pipeline into this one.
+
+        :param other: The other pipeline.
+        :type other: :class:`Pipeline`
+        """
         for job in other.jobs.values():
             self.add_job(job)
 
     def add_job(self, job):
+        """Appends, or merges, a new child job into this pipeline.
+
+        If the job already exists in this pipeline, then it is not
+        overwritten. Instead, the two jobs are merged together into a
+        complete job model.
+
+        :param job: The job to be added.
+        :type job: :class:`Job`
+        """
         key = job.name.value
 
         if key in self.jobs:

--- a/cibyl/models/ci/printers/__init__.py
+++ b/cibyl/models/ci/printers/__init__.py
@@ -50,6 +50,15 @@ class CIPrinter(Printer, ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def print_project(self, project):
+        """
+        :param project: The project.
+        :return: Textual representation of the provided model.
+        :rtype: str
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def print_pipeline(self, pipeline):
         """
         :param pipeline: The pipeline.

--- a/cibyl/models/ci/printers/colored.py
+++ b/cibyl/models/ci/printers/colored.py
@@ -163,6 +163,8 @@ class CIColoredPrinter(CIPrinter):
             result[-1].append(self._palette.blue("': "))
             result[-1].append(len(project.pipelines))
 
+        return result.build()
+
     @overrides
     def print_pipeline(self, pipeline):
         result = IndentedTextBuilder()

--- a/cibyl/models/ci/printers/colored.py
+++ b/cibyl/models/ci/printers/colored.py
@@ -131,16 +131,37 @@ class CIColoredPrinter(CIPrinter):
         result.add(self._palette.blue('Tenant: '), 0)
         result[-1].append(tenant.name.value)
 
-        for job in tenant.jobs.values():
-            result.add(self.print_job(job), 1)
+        if self.query > QueryType.TENANTS:
+            for job in tenant.jobs.values():
+                result.add(self.print_job(job), 1)
 
-        if self.query != QueryType.TENANTS:
-            result.add(self._palette.blue("Total jobs found in tenant '"), 1)
-            result[-1].append(tenant.name)
+            result.add(
+                self._palette.blue("Total jobs found in tenant '"), 1
+            )
+
+            result[-1].append(self._palette.underline(tenant.name.value))
             result[-1].append(self._palette.blue("': "))
             result[-1].append(len(tenant.jobs))
 
         return result.build()
+
+    def print_project(self, project):
+        result = IndentedTextBuilder()
+
+        result.add(self._palette.blue('Project: '), 0)
+        result[-1].append(project.name.value)
+
+        if self.query > QueryType.PROJECTS:
+            for pipeline in project.pipelines.values():
+                result.add(self.print_pipeline(pipeline), 1)
+
+            result.add(
+                self._palette.blue("Total pipelines found in project '"), 1
+            )
+
+            result[-1].append(self._palette.underline(project.name.value))
+            result[-1].append(self._palette.blue("': "))
+            result[-1].append(len(project.pipelines))
 
     @overrides
     def print_pipeline(self, pipeline):
@@ -149,12 +170,15 @@ class CIColoredPrinter(CIPrinter):
         result.add(self._palette.blue('Pipeline: '), 0)
         result[-1].append(pipeline.name.value)
 
-        for job in pipeline.jobs.values():
-            result.add(self.print_job(job), 1)
+        if self.query > QueryType.PIPELINES:
+            for job in pipeline.jobs.values():
+                result.add(self.print_job(job), 1)
 
-        if self.query != QueryType.PIPELINES:
-            result.add(self._palette.blue('Total jobs found in pipeline '), 1)
-            result[-1].append(self._palette.underline(pipeline.name))
+            result.add(
+                self._palette.blue('Total jobs found in pipeline '), 1
+            )
+
+            result[-1].append(self._palette.underline(pipeline.name.value))
             result[-1].append(self._palette.blue(': '))
             result[-1].append(len(pipeline.jobs))
 

--- a/cibyl/models/ci/project.py
+++ b/cibyl/models/ci/project.py
@@ -1,0 +1,80 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from cibyl.cli.argument import Argument
+from cibyl.models.attribute import AttributeDictValue
+from cibyl.models.ci.pipeline import Pipeline
+from cibyl.models.model import Model
+
+
+class Project(Model):
+    API = {
+        'name': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'pipelines': {
+            'attr_type': Pipeline,
+            'attribute_value_class': AttributeDictValue,
+            'arguments': [
+                Argument(
+                    name='--pipelines',
+                    arg_type=str, nargs='*',
+                    description='Pipelines belonging to project',
+                    func='get_pipelines'
+                )
+            ]
+        }
+    }
+
+    def __init__(self, name, pipelines=None):
+        # Let IDEs know this model's attributes
+        self.name = None
+        self.pipelines = None
+
+        # Set up the model
+        super().__init__({'name': name, 'pipelines': pipelines})
+
+    def __eq__(self, other):
+        if not isinstance(other, Project):
+            return False
+
+        return self.name == other.name
+
+    def merge(self, other):
+        """
+
+        :param other:
+        :type other: :class:`Project`
+        :return:
+        """
+        for pipeline in other.pipelines.values():
+            self.add_pipeline(pipeline)
+
+    def add_pipeline(self, pipeline):
+        """
+
+        :param pipeline:
+        :type pipeline: :class:`Pipeline`
+        :return:
+        """
+        key = pipeline.name.value
+
+        if key in self.pipelines:
+            # Extract unknown contents of pipeline
+            self.pipelines[key].merge(pipeline)
+        else:
+            # Register brand-new pipeline
+            self.pipelines[key] = pipeline

--- a/cibyl/models/ci/project.py
+++ b/cibyl/models/ci/project.py
@@ -20,6 +20,8 @@ from cibyl.models.model import Model
 
 
 class Project(Model):
+    """Representation of a Zuul project.
+    """
     API = {
         'name': {
             'attr_type': str,
@@ -54,21 +56,23 @@ class Project(Model):
         return self.name == other.name
 
     def merge(self, other):
-        """
+        """Adds the contents of another project into this one.
 
-        :param other:
+        :param other: The other project.
         :type other: :class:`Project`
-        :return:
         """
         for pipeline in other.pipelines.values():
             self.add_pipeline(pipeline)
 
     def add_pipeline(self, pipeline):
-        """
+        """Appends, or merges, a new child pipeline into this project.
 
-        :param pipeline:
+        If the pipeline already exists in this project, then it is not
+        overwritten. Instead, the two pipelines are merged together into a
+        complete pipeline model.
+
+        :param pipeline: The pipeline to be added.
         :type pipeline: :class:`Pipeline`
-        :return:
         """
         key = pipeline.name.value
 

--- a/tests/unit/models/ci/test_pipeline.py
+++ b/tests/unit/models/ci/test_pipeline.py
@@ -24,7 +24,7 @@ class TestPipeline(TestCase):
     """
 
     def test_not_equal_by_type(self):
-        """Checks that if pipeline is compared with something of another
+        """Checks that if a pipeline is compared with something of another
         type, they will not be equal.
         """
         pipeline = Pipeline('pipeline')
@@ -72,7 +72,7 @@ class TestPipeline(TestCase):
 
     def test_merge_job(self):
         """Checks that a job that already exists on the pipeline gets merged
-        instead overwritten.
+        instead of overwritten.
         """
         name = 'job'
 

--- a/tests/unit/models/ci/test_project.py
+++ b/tests/unit/models/ci/test_project.py
@@ -1,0 +1,95 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.models.ci.project import Project
+
+
+class TestProject(TestCase):
+    """Tests for :class:`Project`.
+    """
+
+    def test_not_equal_by_type(self):
+        """Checks that if a project is compared with something of another
+        type, they will not be equal.
+        """
+        project = Project('project')
+        other = Mock()
+
+        self.assertNotEqual(other, project)
+
+    def test_equal_by_name(self):
+        """Checks that two projects are the same if they share the same name.
+        """
+        name = 'project'
+
+        project1 = Project(name)
+        project2 = Project(name)
+
+        self.assertEqual(project2, project1)
+
+    def test_merge_project(self):
+        """Checks that the pipelines from one project is added to the other
+        during a merge.
+        """
+        name1 = 'pipeline1'
+        name2 = 'pipeline2'
+
+        pipeline1 = Mock()
+        pipeline1.name = Mock()
+        pipeline1.name.value = name1
+
+        pipeline2 = Mock()
+        pipeline2.name = Mock()
+        pipeline2.name.value = name2
+
+        project1 = Project('project1', {name1: pipeline1})
+        project2 = Project('project2', {name2: pipeline2})
+
+        project1.merge(project2)
+
+        self.assertEqual(
+            {
+                name1: pipeline1,
+                name2: pipeline2
+            },
+            project1.pipelines.value
+        )
+
+    def test_merge_pipeline(self):
+        """Checks that a pipeline that already exists on the project gets
+        merged instead of overwritten.
+        """
+        name = 'pipeline'
+
+        pipeline = Mock()
+        pipeline.name = Mock()
+        pipeline.name.value = name
+        pipeline.merge = Mock()
+
+        project = Project('project', {name: pipeline})
+
+        project.add_pipeline(pipeline)
+
+        self.assertEqual(
+            {
+                name: pipeline
+            },
+            project.pipelines.value
+        )
+
+        pipeline.merge.assert_called_once_with(pipeline)


### PR DESCRIPTION
Following the Zuul CI hierarchy: `Tenant -> Project -> Pipeline -> Jobs ...`, this pull request adds a model for the Project level. This model is not used anywhere yet, that is the job of future tasks to do.