### PR TITLE
Fixing some problems to allow for querying of projects

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -13,10 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from enum import Enum
+from enum import IntEnum
 
 
-class QueryType(Enum):
+class QueryType(IntEnum):
     """Defines the hierarchy level at which a query is meant to be performed.
     """
     NONE = 0

--- a/cibyl/models/ci/printers/colored.py
+++ b/cibyl/models/ci/printers/colored.py
@@ -126,18 +126,6 @@ class CIColoredPrinter(CIPrinter):
 
     @overrides
     def print_tenant(self, tenant):
-        def print_jobs():
-            for job in tenant.jobs.values():
-                result.add(self.print_job(job), 1)
-
-            result.add(
-                self._palette.blue("Total jobs found in tenant '"), 1
-            )
-
-            result[-1].append(self._palette.underline(tenant.name))
-            result[-1].append(self._palette.blue("': "))
-            result[-1].append(len(tenant.jobs))
-
         def print_projects():
             for project in tenant.projects.values():
                 result.add(self.print_project(project), 1)
@@ -150,14 +138,26 @@ class CIColoredPrinter(CIPrinter):
             result[-1].append(self._palette.blue("': "))
             result[-1].append(len(tenant.projects))
 
+        def print_jobs():
+            for job in tenant.jobs.values():
+                result.add(self.print_job(job), 1)
+
+            result.add(
+                self._palette.blue("Total jobs found in tenant '"), 1
+            )
+
+            result[-1].append(self._palette.underline(tenant.name))
+            result[-1].append(self._palette.blue("': "))
+            result[-1].append(len(tenant.jobs))
+
         result = IndentedTextBuilder()
 
         result.add(self._palette.blue('Tenant: '), 0)
         result[-1].append(tenant.name)
 
         if self.query > QueryType.TENANTS:
-            print_jobs()
             print_projects()
+            print_jobs()
 
         return result.build()
 

--- a/cibyl/models/ci/tenant.py
+++ b/cibyl/models/ci/tenant.py
@@ -28,18 +28,6 @@ class Tenant(Model):
             'attr_type': str,
             'arguments': []
         },
-        'jobs': {
-            'attr_type': Job,
-            'attribute_value_class': AttributeDictValue,
-            'arguments': [
-                Argument(
-                    name='--jobs',
-                    arg_type=str, nargs='*',
-                    description='Jobs belonging to tenant',
-                    func='get_jobs'
-                )
-            ]
-        },
         'projects': {
             'attr_type': Project,
             'attribute_value_class': AttributeDictValue,
@@ -51,26 +39,38 @@ class Tenant(Model):
                     func='get_projects'
                 )
             ]
+        },
+        'jobs': {
+            'attr_type': Job,
+            'attribute_value_class': AttributeDictValue,
+            'arguments': [
+                Argument(
+                    name='--jobs',
+                    arg_type=str, nargs='*',
+                    description='Jobs belonging to tenant',
+                    func='get_jobs'
+                )
+            ]
         }
     }
 
-    def __init__(self, name, jobs=None, projects=None):
+    def __init__(self, name, projects=None, jobs=None):
         # Let IDEs know this model's attributes
         self.name = None
-        self.jobs = None
         self.projects = None
+        self.jobs = None
 
         # Set up the model
-        super().__init__({'name': name, 'jobs': jobs, 'projects': projects})
+        super().__init__({'name': name, 'projects': projects, 'jobs': jobs})
 
     def __eq__(self, other):
         if not isinstance(other, Tenant):
             return False
 
-        if self.jobs != other.jobs:
+        if self.projects != other.projects:
             return False
 
-        if self.projects != other.projects:
+        if self.jobs != other.jobs:
             return False
 
         return self.name == other.name
@@ -81,30 +81,11 @@ class Tenant(Model):
         :param other: The other tenant.
         :type other: :class:`Tenant`
         """
-        for job in other.jobs.values():
-            self.add_job(job)
-
         for project in other.projects.values():
             self.add_project(project)
 
-    def add_job(self, job):
-        """Appends, or merges, a new child job into this tenant.
-
-        If the job already exists in this tenant, then it is not
-        overwritten. Instead, the two jobs are merged together into a
-        complete job model.
-
-        :param job: The job to be added.
-        :type job: :class:`Job`
-        """
-        key = job.name.value
-
-        if key in self.jobs:
-            # Extract unknown contents of job
-            self.jobs[key].merge(job)
-        else:
-            # Register brand-new job
-            self.jobs[key] = job
+        for job in other.jobs.values():
+            self.add_job(job)
 
     def add_project(self, project):
         """Appends, or merges, a new child project into this tenant.
@@ -124,3 +105,22 @@ class Tenant(Model):
         else:
             # Register brand-new project
             self.projects[key] = project
+
+    def add_job(self, job):
+        """Appends, or merges, a new child job into this tenant.
+
+        If the job already exists in this tenant, then it is not
+        overwritten. Instead, the two jobs are merged together into a
+        complete job model.
+
+        :param job: The job to be added.
+        :type job: :class:`Job`
+        """
+        key = job.name.value
+
+        if key in self.jobs:
+            # Extract unknown contents of job
+            self.jobs[key].merge(job)
+        else:
+            # Register brand-new job
+            self.jobs[key] = job

--- a/cibyl/sources/zuul/source.py
+++ b/cibyl/sources/zuul/source.py
@@ -143,6 +143,10 @@ class Zuul(Source):
         )
 
     @speed_index({'base': 2})
+    def get_projects(self, **kwargs):
+        pass
+
+    @speed_index({'base': 2})
     def get_jobs(self, **kwargs):
         """Retrieves jobs present on the host.
 

--- a/tests/e2e/test_zuul.py
+++ b/tests/e2e/test_zuul.py
@@ -65,6 +65,21 @@ class TestZuul(EndToEndTest):
         self.assertIn('Tenant: example-tenant', self.output)
         self.assertIn('Total tenants found in query: 1', self.output)
 
+    def test_get_projects(self):
+        """Checks that projects are retrieved with the "--projects" flag.
+        """
+        sys.argv = [
+            '',
+            '--config', 'tests/e2e/data/configs/zuul.yaml',
+            '-f', 'text',
+            '-vv',
+            '--projects'
+        ]
+
+        main()
+
+        self.assertIn('Total projects found in query: 2', self.output)
+
     def test_no_jobs_on_tenant_query(self):
         """Checks that no 'Jobs found in tenant...' string is printed for a
         '--tenants' query.

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -198,5 +198,5 @@ class TestOrchestrator(TestCase):
         self.assertTrue("jobs" in self.orchestrator.parser.ci_args)
         self.assertTrue("builds" in self.orchestrator.parser.ci_args)
         self.assertEqual(self.orchestrator.parser.ci_args["tenants"].level, 2)
-        self.assertEqual(self.orchestrator.parser.ci_args["jobs"].level, 3)
-        self.assertEqual(self.orchestrator.parser.ci_args["builds"].level, 4)
+        self.assertEqual(self.orchestrator.parser.ci_args["jobs"].level, 5)
+        self.assertEqual(self.orchestrator.parser.ci_args["builds"].level, 6)

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -65,12 +65,12 @@ class TestOrchestrator(TestCase):
                             'jenkins': {
                                 'driver': 'jenkins',
                                 'url': ''
-                                },
+                            },
                             'jenkins2': {
                                 'driver': 'jenkins',
                                 'url': ''
-                                }
-                            }}}}}
+                            }
+                        }}}}}
 
     def test_orchestrator_config(self):
         """Testing Orchestrator config attribute and method"""
@@ -193,10 +193,15 @@ class TestOrchestrator(TestCase):
         self.orchestrator.create_ci_environments()
         for env in self.orchestrator.environments:
             self.orchestrator.extend_parser(attributes=env.API)
-        self.orchestrator.parser.parse(["--jobs", "--builds", "--tenants"])
+        self.orchestrator.parser.parse([
+            "--jobs", "--builds", "--tenants", "--projects", "--pipelines"
+        ])
         self.assertTrue("tenants" in self.orchestrator.parser.ci_args)
         self.assertTrue("jobs" in self.orchestrator.parser.ci_args)
         self.assertTrue("builds" in self.orchestrator.parser.ci_args)
         self.assertEqual(self.orchestrator.parser.ci_args["tenants"].level, 2)
+        self.assertEqual(self.orchestrator.parser.ci_args["projects"].level, 3)
+        self.assertEqual(
+            self.orchestrator.parser.ci_args["pipelines"].level, 4)
         self.assertEqual(self.orchestrator.parser.ci_args["jobs"].level, 5)
         self.assertEqual(self.orchestrator.parser.ci_args["builds"].level, 6)


### PR DESCRIPTION
These problems are:
- Allowing QueryType to be compared by making it a IntEnum.
- Reversing a previous commit that made jobs be a higher level than projects. The help page does not make sense under that change.
- Adding 'get_projects' to Zuul source.
- Adding a e2e test case to check that 'get_projects' is reached.
- Fixing a unit test by increasing the level of jobs.