### PR TITLE
Add intemediate layer bewtween Source and sources

### DIFF
--- a/cibyl/exceptions/source.py
+++ b/cibyl/exceptions/source.py
@@ -47,3 +47,12 @@ the configuration.\n{sources}"""
 class SourceException(CibylException):
     """Abstract exception to representation any error while querying a
     source."""
+
+
+class MissingArgument(SourceException):
+    """Represents a missing required argument inside a source method call."""
+
+    def __init__(self, message='Missing required argument.'):
+        """Constructor.
+        """
+        super().__init__(message)

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -22,7 +22,6 @@ from elasticsearch.helpers import scan
 
 from cibyl.cli.argument import Argument
 from cibyl.cli.ranged_argument import RANGE_OPERATORS
-from cibyl.exceptions.cli import MissingArgument
 from cibyl.exceptions.elasticsearch import ElasticSearchError
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.build import Build
@@ -30,13 +29,14 @@ from cibyl.models.ci.job import Job
 from cibyl.models.ci.test import Test
 from cibyl.plugins.openstack.deployment import Deployment
 from cibyl.sources.elasticsearch.client import ElasticSearchClient
-from cibyl.sources.source import Source, speed_index
+from cibyl.sources.server import ServerSource
+from cibyl.sources.source import speed_index
 from cibyl.utils.filtering import IP_PATTERN
 
 LOG = logging.getLogger(__name__)
 
 
-class ElasticSearchOSP(Source):
+class ElasticSearchOSP(ServerSource):
     """Used to perform queries in elasticsearch"""
 
     def __init__(self: object, driver: str = 'elasticsearch',
@@ -367,10 +367,8 @@ class ElasticSearchOSP(Source):
             (if any) and the tests
             :rtype: :class:`AttributeDictValue`
         """
-        if not kwargs.get('builds') and not kwargs.get('last_build'):
-            raise MissingArgument('Please specify some builds (--builds) \
-to get the tests from. Or use (--last-build) to get the tests from the last \
-one')
+        self.check_builds_for_test(**kwargs)
+
         job_builds_found = self.get_builds(**kwargs)
         query_body = {
             "query": {

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -27,7 +27,6 @@ import urllib3
 import yaml
 
 from cibyl.cli.argument import Argument
-from cibyl.exceptions.cli import MissingArgument
 from cibyl.exceptions.jenkins import JenkinsError
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.build import Build
@@ -39,7 +38,8 @@ from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.package import Package
 from cibyl.plugins.openstack.service import Service
 from cibyl.plugins.openstack.utils import translate_topology_string
-from cibyl.sources.source import Source, safe_request_generic, speed_index
+from cibyl.sources.server import ServerSource
+from cibyl.sources.source import safe_request_generic, speed_index
 from cibyl.utils.dicts import subset
 from cibyl.utils.filtering import (DEPLOYMENT_PATTERN, DVR_PATTERN_NAME,
                                    IP_PATTERN, NETWORK_BACKEND_PATTERN,
@@ -212,7 +212,7 @@ def filter_tests(tests_found: List[Dict], **kwargs):
 
 
 # pylint: disable=no-member
-class Jenkins(Source):
+class Jenkins(ServerSource):
     """A class representation of Jenkins client."""
 
     jobs_query = "?tree=jobs[name,url]"
@@ -407,10 +407,7 @@ try reducing verbosity for quicker query")
             :rtype: :class:`AttributeDictValue`
         """
 
-        if not kwargs.get('builds') and not kwargs.get('last_build'):
-            raise MissingArgument('Please specify some builds (--builds) \
-to get the tests from. Or use (--last-build) to get the tests from the last \
-one')
+        self.check_builds_for_test(**kwargs)
 
         jobs_found = self.get_builds(**kwargs)
 

--- a/cibyl/sources/server.py
+++ b/cibyl/sources/server.py
@@ -1,0 +1,35 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import logging
+
+from cibyl.exceptions.source import MissingArgument
+from cibyl.sources.source import Source
+
+LOG = logging.getLogger(__name__)
+
+
+class ServerSource(Source):
+    """A class representation of a source that must connect to a server
+    instance."""
+
+    # pylint: disable=too-many-arguments
+    def check_builds_for_test(self, **kwargs):
+        """Ensure that some build information is passed when requesting
+        tests."""
+        if not kwargs.get('builds') and not kwargs.get('last_build'):
+            raise MissingArgument('Please specify some builds (--builds) \
+to get the tests from. Or use (--last-build) to get the tests from the last \
+one')

--- a/cibyl/sources/zuul/source.py
+++ b/cibyl/sources/zuul/source.py
@@ -18,13 +18,14 @@ from typing import List, MutableMapping
 
 from overrides import overrides
 
-from cibyl.sources.source import Source, speed_index
+from cibyl.sources.server import ServerSource
+from cibyl.sources.source import speed_index
 from cibyl.sources.zuul.apis.rest import ZuulRESTClient
 from cibyl.sources.zuul.query import handle_query
 from cibyl.utils.dicts import subset
 
 
-class Zuul(Source):
+class Zuul(ServerSource):
     """Source implementation for a Zuul host.
     """
 
@@ -64,7 +65,7 @@ class Zuul(Source):
         if url.endswith('/'):
             url = url[:-1]  # Removes last character of string
 
-        super().__init__(name, driver, url=url, **kwargs)
+        super().__init__(name=name, driver=driver, url=url, **kwargs)
 
         self._api = api
         self._fallbacks = fallbacks

--- a/tests/unit/sources/elasticsearch/test_api.py
+++ b/tests/unit/sources/elasticsearch/test_api.py
@@ -19,7 +19,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 from cibyl.cli.argument import Argument
-from cibyl.exceptions.cli import MissingArgument
+from cibyl.exceptions.source import MissingArgument
 from cibyl.sources.elasticsearch.api import ElasticSearchOSP, QueryTemplate
 
 
@@ -144,8 +144,8 @@ class TestElasticsearchOSP(TestCase):
 
     @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
     def test_get_deployment(self: object, mock_query_hits: object) -> None:
-        """Tests that the internal logic from :meth:`ElasticSearchOSP.get_deployment`
-            is correct.
+        """Tests that the internal logic from
+        :meth:`ElasticSearchOSP.get_deployment` is correct.
         """
         mock_query_hits.return_value = self.build_hits
 
@@ -155,8 +155,8 @@ class TestElasticsearchOSP(TestCase):
         # We need to mock the Argument kwargs passed. In this case
         # ip_address
         ip_address_kwargs = MagicMock()
-        ip_adress_value = PropertyMock(return_value=[])
-        type(ip_address_kwargs).value = ip_adress_value
+        ip_address_value = PropertyMock(return_value=[])
+        type(ip_address_kwargs).value = ip_address_value
 
         jobs = self.es_api.get_deployment(jobs=jobs_argument,
                                           ip_version=ip_address_kwargs)
@@ -178,8 +178,8 @@ class TestElasticsearchOSP(TestCase):
         # We need to mock the Argument kwargs passed. In this case
         # ip_address
         ip_address_kwargs = MagicMock()
-        ip_adress_value = PropertyMock(return_value=['4'])
-        type(ip_address_kwargs).value = ip_adress_value
+        ip_address_value = PropertyMock(return_value=['4'])
+        type(ip_address_kwargs).value = ip_address_value
 
         builds = self.es_api.get_deployment(jobs=jobs_argument,
                                             ip_version=ip_address_kwargs)

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -22,6 +22,7 @@ import yaml
 
 from cibyl.cli.argument import Argument
 from cibyl.exceptions.jenkins import JenkinsError
+from cibyl.exceptions.source import MissingArgument, SourceException
 from cibyl.plugins import extend_models
 from cibyl.plugins.openstack.container import Container
 from cibyl.plugins.openstack.node import Node
@@ -738,6 +739,16 @@ class TestJenkinsSource(TestCase):
 
         tests_found = job.builds.value['1'].tests
         self.assertEqual(len(tests_found), 0)
+
+    def test_get_tests_no_builds_info(self):
+        """Test that calling get_test without build informantion raises an
+        exception."""
+        self.assertRaises(MissingArgument, self.jenkins.get_tests)
+
+    def test_get_tests_no_builds_info_general_exception(self):
+        """Test that calling get_test without build informantion raises an
+        exception."""
+        self.assertRaises(SourceException, self.jenkins.get_tests)
 
     @patch("requests.get")
     def test_send_request(self, patched_get):

--- a/tests/unit/sources/test_source_factory.py
+++ b/tests/unit/sources/test_source_factory.py
@@ -1,0 +1,69 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase, skip
+
+from cibyl.sources.elasticsearch.api import ElasticSearchOSP
+from cibyl.sources.jenkins import Jenkins
+from cibyl.sources.jenkins_job_builder import JenkinsJobBuilder
+from cibyl.sources.source_factory import SourceFactory
+from cibyl.sources.zuul.source import Zuul
+
+
+class TestSourceFactory(TestCase):
+    """Test for the SourceFactory class."""
+
+    def test_create_jenkins_source(self):
+        """Checks that a jenkins source is created."""
+        source = SourceFactory.create_source("jenkins", "jenkins_source",
+                                             driver="jenkins", url="url")
+        self.assertTrue(isinstance(source, Jenkins))
+        self.assertEqual(source.name, "jenkins_source")
+        self.assertEqual(source.driver, "jenkins")
+        self.assertEqual(source.url, "url")
+
+    @skip("Until OSPCRE-427 is fixed")
+    def test_create_elasticsearch_source(self):
+        """Checks that a elasticsearch source is created."""
+        source = SourceFactory.create_source("elasticsearch", "elastic_source",
+                                             driver="elastic",
+                                             url="http://example.com:8080")
+        self.assertTrue(isinstance(source, ElasticSearchOSP))
+        self.assertEqual(source.name, "elastic_source")
+        self.assertEqual(source.driver, "elastic")
+        self.assertEqual(source.url, "url")
+
+    def test_create_jenkins_job_builder_source(self):
+        """Checks that a jenkins_job_builder source is created."""
+        source = SourceFactory.create_source("jenkins_job_builder",
+                                             "jjb_source",
+                                             driver="jjb")
+        self.assertTrue(isinstance(source, JenkinsJobBuilder))
+        self.assertEqual(source.name, "jjb_source")
+        self.assertEqual(source.driver, "jjb")
+
+    def test_create_zuul_source(self):
+        """Checks that a zuul source is created."""
+        source = SourceFactory.create_source("zuul", "zuul_source",
+                                             driver="zuul", url="url")
+        self.assertTrue(isinstance(source, Zuul))
+        self.assertEqual(source.name, "zuul_source")
+        self.assertEqual(source.driver, "zuul")
+        self.assertEqual(source.url, "url")
+
+    def test_create_unknown_source(self):
+        """Checks that an exception is raise if the source type is unknown."""
+        self.assertRaises(NotImplementedError, SourceFactory.create_source,
+                          "unknown", "zuul_source")


### PR DESCRIPTION
This changes introduces a new class ServerSource which inherits from
Source and from which the Jenkins, ElasticSearch and Zuul sources will
inherit. At the moment, this class will only contain a method to check
that the required arguments are provided to get_tests, but in the future
it might include additional shared functionality between the three
sources.

The class is named ServerSource because the main characteristic that the three
sources share is that they all talk to a server instance. However it can be
changed if better alternatives are suggested.
