### PR TITLE
Add filtering by time in elastic tests

### DIFF
--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -466,11 +466,11 @@ one')
                           )
                 continue
 
-            if test_duration_arguments:
-                if not self.match_filter_test_by_duration(
-                       test_duration,
-                       test_duration_arguments):
-                    continue
+            if test_duration_arguments and \
+               not self.match_filter_test_by_duration(
+                   test_duration,
+                   test_duration_arguments):
+                continue
 
             if test_duration:
                 test_duration *= 1000

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -20,7 +20,7 @@ from urllib.parse import urlsplit
 
 from elasticsearch.helpers import scan
 
-from build.lib.cibyl.cli.ranged_argument import RANGE_OPERATORS
+from cibyl.cli.ranged_argument import RANGE_OPERATORS
 from cibyl.cli.argument import Argument
 from cibyl.exceptions.cli import MissingArgument
 from cibyl.exceptions.elasticsearch import ElasticSearchError

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -20,8 +20,8 @@ from urllib.parse import urlsplit
 
 from elasticsearch.helpers import scan
 
-from cibyl.cli.ranged_argument import RANGE_OPERATORS
 from cibyl.cli.argument import Argument
+from cibyl.cli.ranged_argument import RANGE_OPERATORS
 from cibyl.exceptions.cli import MissingArgument
 from cibyl.exceptions.elasticsearch import ElasticSearchError
 from cibyl.models.attribute import AttributeDictValue
@@ -53,8 +53,9 @@ class ElasticSearchOSP(Source):
                 host = f"{url_parsed.scheme}://{url_parsed.hostname}"
                 port = url_parsed.port
             except Exception as exception:
-                raise ElasticSearchError('The URL given is not valid') \
-                    from exception
+                raise ElasticSearchError(
+                    'The URL given is not valid'
+                ) from exception
             self.es_client = ElasticSearchClient(host, port).connect()
 
     @speed_index({'base': 1})
@@ -107,8 +108,9 @@ class ElasticSearchOSP(Source):
                 size=10000
             )]
         except Exception as exception:
-            raise ElasticSearchError("Error getting the results.") \
-                from exception
+            raise ElasticSearchError(
+                "Error getting the results."
+            ) from exception
         return hits
 
     @speed_index({'base': 2})

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -466,23 +466,12 @@ one')
                           )
                 continue
 
-            # If we filter by --test-duration then
-            # we don't accept empty time_duration
-            time_not_match = None
             if test_duration_arguments:
-                # If we don't have time_duration
-                if not test_duration:
+                if not self.match_filter_test_by_duration(
+                       test_duration,
+                       test_duration_arguments):
                     continue
-                # For every condition passed by the user
-                for test_duration_argument in test_duration_arguments:
-                    operator = RANGE_OPERATORS[test_duration_argument.operator]
-                    operand = test_duration_argument.operand
-                    if operator(test_duration, float(operand)):
-                        continue
-                    time_not_match = True
 
-            if time_not_match:
-                continue
             if test_duration:
                 test_duration *= 1000
 
@@ -496,6 +485,30 @@ one')
             )
 
         return job_builds_found
+
+    def match_filter_test_by_duration(self: object,
+                                      test_duration: float,
+                                      test_duration_arguments: list) -> bool:
+        """Match if the duration of a test pass all the
+        conditions provided by the user that are located
+        in the arguments
+
+        :params test_duration: Duration of a job
+        :type node_name: float
+        :params test_duration_arguments: Conditions provided
+        by the user
+        :type list: str
+
+        :returns: Return if match all the conditions or no
+        :rtype: bool
+        """
+        for test_duration_argument in test_duration_arguments:
+            operator = RANGE_OPERATORS[test_duration_argument.operator]
+            operand = test_duration_argument.operand
+            if operator(test_duration, float(operand)):
+                continue
+            return False
+        return True
 
 
 class QueryTemplate():

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -472,6 +472,7 @@ one')
                    test_duration_arguments):
                 continue
 
+            # Duration comes in seconds. Convert to ms:
             if test_duration:
                 test_duration *= 1000
 
@@ -505,9 +506,8 @@ one')
         for test_duration_argument in test_duration_arguments:
             operator = RANGE_OPERATORS[test_duration_argument.operator]
             operand = test_duration_argument.operand
-            if operator(test_duration, float(operand)):
-                continue
-            return False
+            if not operator(test_duration, float(operand)):
+                return False
         return True
 
 


### PR DESCRIPTION
Filter by test_duration using RANGE_OPERATORS to compare the input of the user with the test duration if exists
Added tests related to this change