### PR TITLE
Implementing 'get_projects' on Zuul source

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -38,6 +38,8 @@ def get_query_type(**kwargs):
 
     :param kwargs: The arguments.
     :key tenants: Query targets tenants.
+    :key projects: Query targets projects.
+    :key pipelines: Query targets pipelines.
     :key jobs: Query targets jobs.
     :key builds: Query target builds.
     :return: The lowest query level possible. For example,
@@ -49,6 +51,12 @@ def get_query_type(**kwargs):
 
     if 'tenants' in kwargs:
         result = QueryType.TENANTS
+
+    if 'projects' in kwargs:
+        result = QueryType.PROJECTS
+
+    if 'pipelines' in kwargs:
+        result = QueryType.PIPELINES
 
     if 'jobs' in kwargs:
         result = QueryType.JOBS

--- a/cibyl/models/ci/printers/colored.py
+++ b/cibyl/models/ci/printers/colored.py
@@ -155,12 +155,15 @@ class CIColoredPrinter(CIPrinter):
         result.add(self._palette.blue('Tenant: '), 0)
         result[-1].append(tenant.name)
 
-        if self.query > QueryType.TENANTS:
+        if self.query >= QueryType.PROJECTS:
             print_projects()
+
+        if self.query >= QueryType.JOBS:
             print_jobs()
 
         return result.build()
 
+    @overrides
     def print_project(self, project):
         result = IndentedTextBuilder()
 

--- a/cibyl/sources/source.py
+++ b/cibyl/sources/source.py
@@ -80,6 +80,10 @@ class Source(AttrDict):
         """Setup everything required for the source to become operational."""
         pass
 
+    @abstractmethod
+    def teardown(self):
+        pass
+
 
 def is_source_valid(source: Source, desired_attr: str):
     """Checks if a source can be considered valid to perform a query.

--- a/cibyl/sources/zuul/api.py
+++ b/cibyl/sources/zuul/api.py
@@ -16,6 +16,7 @@
 from abc import ABC, abstractmethod
 
 from cibyl.exceptions.source import SourceException
+from cibyl.utils.io import Closeable
 
 
 class ZuulAPIError(SourceException):
@@ -23,7 +24,7 @@ class ZuulAPIError(SourceException):
     """
 
 
-class ZuulJobAPI(ABC):
+class ZuulJobAPI(Closeable, ABC):
     """Interface which defines the information that can be retrieved from
     Zuul regarding a particular job.
     """
@@ -72,7 +73,7 @@ class ZuulJobAPI(ABC):
         raise NotImplementedError
 
 
-class ZuulProjectAPI(ABC):
+class ZuulProjectAPI(Closeable, ABC):
     def __init__(self, tenant, project):
         self._tenant = tenant
         self._project = project
@@ -91,7 +92,7 @@ class ZuulProjectAPI(ABC):
         raise NotImplementedError
 
 
-class ZuulTenantAPI(ABC):
+class ZuulTenantAPI(Closeable, ABC):
     """Interface which defines the information that can be retrieved from
     Zuul regarding a particular tenant.
     """
@@ -150,7 +151,7 @@ class ZuulTenantAPI(ABC):
         raise NotImplementedError
 
 
-class ZuulAPI(ABC):
+class ZuulAPI(Closeable, ABC):
     """Interface describing the actions that can be taken over Zuul's API.
     """
 

--- a/cibyl/sources/zuul/api.py
+++ b/cibyl/sources/zuul/api.py
@@ -73,7 +73,22 @@ class ZuulJobAPI(ABC):
 
 
 class ZuulProjectAPI(ABC):
-    pass
+    def __init__(self, tenant, project):
+        self._tenant = tenant
+        self._project = project
+
+    @property
+    def tenant(self):
+        return self._tenant
+
+    @property
+    def name(self):
+        return self._project['name']
+
+    @property
+    @abstractmethod
+    def url(self):
+        raise NotImplementedError
 
 
 class ZuulTenantAPI(ABC):
@@ -117,6 +132,10 @@ class ZuulTenantAPI(ABC):
         :rtype: list[dict]
         :raises ZuulAPIError: If the request failed.
         """
+        raise NotImplementedError
+
+    @abstractmethod
+    def projects(self):
         raise NotImplementedError
 
     @abstractmethod

--- a/cibyl/sources/zuul/api.py
+++ b/cibyl/sources/zuul/api.py
@@ -72,6 +72,10 @@ class ZuulJobAPI(ABC):
         raise NotImplementedError
 
 
+class ZuulProjectAPI(ABC):
+    pass
+
+
 class ZuulTenantAPI(ABC):
     """Interface which defines the information that can be retrieved from
     Zuul regarding a particular tenant.

--- a/cibyl/sources/zuul/models.py
+++ b/cibyl/sources/zuul/models.py
@@ -42,6 +42,9 @@ class ModelBuilder:
 
         return self
 
+    def with_project(self, project):
+        pass
+
     def with_job(self, job):
         """Adds a job to the current model being built. If the job is
         already present on the model, then this is ignored. If the job's

--- a/cibyl/sources/zuul/query.py
+++ b/cibyl/sources/zuul/query.py
@@ -91,7 +91,22 @@ def _get_jobs(zuul, **kwargs):
 
 
 def _get_projects(zuul, **kwargs):
-    return []
+    result = []
+
+    for tenant in _get_tenants(zuul, **kwargs):
+        projects = tenant.projects()
+
+        # Apply projects filters
+        if 'projects' in kwargs:
+            targets = kwargs['projects'].value
+
+            # An empty '--projects' means all of them.
+            if targets:
+                projects.with_name(*targets)
+
+        result += projects.get()
+
+    return result
 
 
 def _get_tenants(zuul, **kwargs):

--- a/cibyl/sources/zuul/query.py
+++ b/cibyl/sources/zuul/query.py
@@ -90,6 +90,10 @@ def _get_jobs(zuul, **kwargs):
     return result
 
 
+def _get_projects(zuul, **kwargs):
+    return []
+
+
 def _get_tenants(zuul, **kwargs):
     """Query for tenants.
 
@@ -163,6 +167,10 @@ def handle_query(api, **kwargs):
     if query == QueryType.TENANTS:
         for tenant in _get_tenants(api, **kwargs):
             model.with_tenant(tenant)
+
+    if query == QueryType.PROJECTS:
+        for project in _get_projects(api, **kwargs):
+            model.with_project(project)
 
     if query == QueryType.JOBS:
         for job in _get_jobs(api, **kwargs):

--- a/cibyl/sources/zuul/query.py
+++ b/cibyl/sources/zuul/query.py
@@ -72,6 +72,8 @@ def _get_jobs(zuul, **kwargs):
     result = []
 
     for tenant in _get_tenants(zuul, **kwargs):
+        # TODO: Fetch jobs in projects
+
         jobs = tenant.jobs()
 
         # Apply jobs filters

--- a/cibyl/sources/zuul/requests.py
+++ b/cibyl/sources/zuul/requests.py
@@ -70,6 +70,16 @@ class TenantsRequest(Request):
         return [TenantResponse(tenant) for tenant in tenants]
 
 
+class ProjectsRequest(Request):
+    def __init__(self, tenant):
+        super().__init__()
+
+        self._tenant = tenant
+
+    def get(self):
+        pass
+
+
 class JobsRequest(Request):
     """High-Level petition focused on retrieval of data related to jobs.
     """
@@ -205,6 +215,38 @@ class TenantResponse:
         :rtype: :class:`JobsRequest`
         """
         return JobsRequest(self._tenant)
+
+
+class ProjectResponse:
+    """Response for :class:`ProjectsRequest`.
+    """
+
+    def __init__(self, tenant, project):
+        """Constructor.
+
+        :param tenant: Low-Level API to access this project's tenant.
+        :type tenant: :class:`cibyl.sources.zuul.api.ZuulTenantAPI`
+        :param project: Low-Level API to access the project's data.
+        :type project: :class:`cibyl.sources.zuul.api.ZuulProjectAPI`
+        """
+        self._tenant = tenant
+        self._project = project
+
+    @property
+    def tenant(self):
+        """
+        :return: API to the project's tenant.
+        :rtype:class:`cibyl.sources.zuul.api.ZuulTenantAPI`
+        """
+        return self._tenant
+
+    @property
+    def name(self):
+        """
+        :return: The project's name.
+        :rtype: str
+        """
+        return self._project.name
 
 
 class JobResponse:

--- a/cibyl/sources/zuul/requests.py
+++ b/cibyl/sources/zuul/requests.py
@@ -216,6 +216,10 @@ class TenantResponse:
         return self._tenant.name
 
     def projects(self):
+        """
+        :return: A request for this tenant's projects.
+        :rtype: :class:`ProjectsRequest`
+        """
         return ProjectsRequest(self._tenant)
 
     def jobs(self):
@@ -244,10 +248,10 @@ class ProjectResponse:
     @property
     def tenant(self):
         """
-        :return: API to the project's tenant.
-        :rtype:class:`cibyl.sources.zuul.api.ZuulTenantAPI`
+        :return: Response to this project's tenant.
+        :rtype: :class:`TenantResponse`
         """
-        return self._tenant
+        return TenantResponse(self._tenant)
 
     @property
     def name(self):
@@ -276,10 +280,10 @@ class JobResponse:
     @property
     def tenant(self):
         """
-        :return: API to the job's tenant.
-        :rtype:class:`cibyl.sources.zuul.api.ZuulTenantAPI`
+        :return: Response to this job's tenant.
+        :rtype: :class:`TenantResponse`
         """
-        return self._tenant
+        return TenantResponse(self._tenant)
 
     @property
     def name(self):
@@ -323,10 +327,10 @@ class BuildResponse:
     @property
     def job(self):
         """
-        :return: API to the build's job.
-        :rtype: :class:`cibyl.sources.zuul.api.ZuulJobAPI`
+        :return: Response for this build's job.
+        :rtype: :class:`JobResponse`
         """
-        return self._job
+        return JobResponse(self._job.tenant, self._job)
 
     @property
     def data(self):

--- a/cibyl/sources/zuul/requests.py
+++ b/cibyl/sources/zuul/requests.py
@@ -76,8 +76,14 @@ class ProjectsRequest(Request):
 
         self._tenant = tenant
 
+    def with_name(self, *name):
+        self._filters.append(lambda project: project.name in name)
+        return self
+
     def get(self):
-        pass
+        projects = apply_filters(self._tenant.projects(), *self._filters)
+
+        return [ProjectResponse(self._tenant, project) for project in projects]
 
 
 class JobsRequest(Request):
@@ -208,6 +214,9 @@ class TenantResponse:
         :rtype: str
         """
         return self._tenant.name
+
+    def projects(self):
+        return ProjectsRequest(self._tenant)
 
     def jobs(self):
         """

--- a/cibyl/sources/zuul/source.py
+++ b/cibyl/sources/zuul/source.py
@@ -144,7 +144,7 @@ class Zuul(Source):
 
     @speed_index({'base': 2})
     def get_projects(self, **kwargs):
-        pass
+        return self.get_tenants(**kwargs)
 
     @speed_index({'base': 2})
     def get_jobs(self, **kwargs):

--- a/cibyl/sources/zuul/source.py
+++ b/cibyl/sources/zuul/source.py
@@ -123,6 +123,10 @@ class Zuul(Source):
     def setup(self):
         pass
 
+    @overrides
+    def teardown(self):
+        self._api.close()
+
     @speed_index({'base': 1})
     def get_tenants(self, **kwargs):
         """Retrieves tenants present on the host.

--- a/cibyl/sources/zuul/source.py
+++ b/cibyl/sources/zuul/source.py
@@ -39,17 +39,17 @@ class Zuul(Source):
             ['tenant_1', 'tenant_2']
         """
 
-    def __init__(self, api, name, driver, url, fallbacks=None, **kwargs):
+    def __init__(self, name, driver, url, cert=None, fallbacks=None, **kwargs):
         """Constructor.
 
-        :param api: Medium of communication with host.
-        :type api: :class:`cibyl.sources.zuul.api.ZuulAPI`
         :param name: Name of the source.
         :type name: str
         :param driver: Driver used by the source.
         :type driver: str
         :param url: Address where the host is located.
         :type url: str
+        :param cert: See :meth:`ZuulRESTClient.from_url`
+        :type cert: str or None
         :param fallbacks: Default search terms to be used for missing query
             arguments.
         :type fallbacks: :class:`Zuul.Fallbacks` or None
@@ -64,9 +64,9 @@ class Zuul(Source):
         if url.endswith('/'):
             url = url[:-1]  # Removes last character of string
 
-        super().__init__(name, driver, url=url, **kwargs)
+        super().__init__(name, driver, url=url, cert=cert, **kwargs)
 
-        self._api = api
+        self._api = None
         self._fallbacks = fallbacks
 
     @staticmethod
@@ -92,9 +92,6 @@ class Zuul(Source):
         :return: The instance.
         """
 
-        def new_api():
-            return ZuulRESTClient.from_url(url, cert)
-
         def new_fallbacks_from(*args):
             """
             :param args: Arguments to generate fallbacks for.
@@ -114,14 +111,13 @@ class Zuul(Source):
         kwargs.setdefault('name', 'zuul-ci')
         kwargs.setdefault('driver', 'zuul')
 
-        api = new_api()
         fallbacks = new_fallbacks_from('tenants')
 
-        return Zuul(api=api, url=url, fallbacks=fallbacks, **kwargs)
+        return Zuul(url=url, cert=cert, fallbacks=fallbacks, **kwargs)
 
     @overrides
     def setup(self):
-        pass
+        self._api = ZuulRESTClient.from_url(self.url, self.cert)
 
     @overrides
     def teardown(self):

--- a/cibyl/utils/io.py
+++ b/cibyl/utils/io.py
@@ -1,0 +1,22 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from abc import ABC, abstractmethod
+
+
+class Closeable(ABC):
+    @abstractmethod
+    def close(self):
+        raise NotImplementedError

--- a/tests/e2e/test_zuul.py
+++ b/tests/e2e/test_zuul.py
@@ -73,12 +73,41 @@ class TestZuul(EndToEndTest):
             '--config', 'tests/e2e/data/configs/zuul.yaml',
             '-f', 'text',
             '-vv',
+            '--tenants', 'example-tenant',
             '--projects'
         ]
 
         main()
 
-        self.assertIn('Total projects found in query: 2', self.output)
+        self.assertIn(
+            "Total projects found in tenant 'example-tenant': 4",
+            self.output
+        )
+
+    def test_get_projects_by_name(self):
+        """Checks that projects are retrieved with the "--projects name1
+        name2" flag.
+        """
+        sys.argv = [
+            '',
+            '--config', 'tests/e2e/data/configs/zuul.yaml',
+            '-f', 'text',
+            '-vv',
+            '--tenants', 'example-tenant',
+            '--projects', 'test1'
+        ]
+
+        main()
+
+        self.assertIn(
+            "Project: test1",
+            self.output
+        )
+
+        self.assertIn(
+            "Total projects found in tenant 'example-tenant': 1",
+            self.output
+        )
 
     def test_no_jobs_on_tenant_query(self):
         """Checks that no 'Jobs found in tenant...' string is printed for a
@@ -90,6 +119,26 @@ class TestZuul(EndToEndTest):
             '-f', 'text',
             '-vv',
             '--tenants', 'example-tenant'
+        ]
+
+        main()
+
+        self.assertNotIn(
+            "Total jobs found in tenant 'example-tenant':",
+            self.output
+        )
+
+    def test_no_jobs_on_projects_query(self):
+        """Checks that no 'Jobs found in tenant...' string is printed for a
+        '--projects' query.
+        """
+        sys.argv = [
+            '',
+            '--config', 'tests/e2e/data/configs/zuul.yaml',
+            '-f', 'text',
+            '-vv',
+            '--tenants', 'example-tenant',
+            '--projects'
         ]
 
         main()

--- a/tests/intr/sources/zuul/test_query.py
+++ b/tests/intr/sources/zuul/test_query.py
@@ -109,6 +109,8 @@ class TestHandleQuery(TestCase):
 
         tenant = Mock()
         tenant.name = 'tenant'
+        tenant.projects = Mock()
+        tenant.projects.return_value = [project1, project2]
 
         api = Mock()
         api.tenants = Mock()
@@ -143,6 +145,8 @@ class TestHandleQuery(TestCase):
 
         tenant = Mock()
         tenant.name = 'tenant'
+        tenant.projects = Mock()
+        tenant.projects.return_value = [project1, project2]
 
         api = Mock()
         api.tenants = Mock()

--- a/tests/intr/sources/zuul/test_query.py
+++ b/tests/intr/sources/zuul/test_query.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock
 
 from cibyl.models.ci.build import Build
 from cibyl.models.ci.job import Job
+from cibyl.models.ci.project import Project
 from cibyl.models.ci.tenant import Tenant
 from cibyl.sources.zuul.query import handle_query
 
@@ -93,6 +94,73 @@ class TestHandleQuery(TestCase):
         self.assertEqual(
             {
                 tenant1.name: Tenant(tenant1.name)
+            },
+            result.value
+        )
+
+    def test_get_all_projects(self):
+        """Checks the '--projects' option.
+        """
+        project1 = Mock()
+        project1.name = 'project1'
+
+        project2 = Mock()
+        project2.name = 'project2'
+
+        tenant = Mock()
+        tenant.name = 'tenant'
+
+        api = Mock()
+        api.tenants = Mock()
+        api.tenants.return_value = [tenant]
+
+        in_projects = Mock()
+        in_projects.value = None
+
+        result = handle_query(api, projects=in_projects)
+
+        self.assertEqual(
+            {
+                tenant.name: Tenant(
+                    tenant.name,
+                    projects={
+                        project1.name: Project(project1.name),
+                        project2.name: Project(project2.name)
+                    }
+                )
+            },
+            result.value
+        )
+
+    def test_get_projects_by_name(self):
+        """Checks the '--projects name1 name2' option.
+        """
+        project1 = Mock()
+        project1.name = 'project1'
+
+        project2 = Mock()
+        project2.name = 'project2'
+
+        tenant = Mock()
+        tenant.name = 'tenant'
+
+        api = Mock()
+        api.tenants = Mock()
+        api.tenants.return_value = [tenant]
+
+        in_projects = Mock()
+        in_projects.value = [project1.name]
+
+        result = handle_query(api, projects=in_projects)
+
+        self.assertEqual(
+            {
+                tenant.name: Tenant(
+                    tenant.name,
+                    projects={
+                        project1.name: Project(project1.name)
+                    }
+                )
             },
             result.value
         )

--- a/tests/unit/cli/test_query.py
+++ b/tests/unit/cli/test_query.py
@@ -39,6 +39,24 @@ class TestGetQueryType(TestCase):
 
         self.assertEqual(QueryType.TENANTS, get_query_type(**args))
 
+    def test_get_projects(self):
+        """Checks that "Projects" is returned for "--projects".
+        """
+        args = {
+            'projects': None
+        }
+
+        self.assertEqual(QueryType.PROJECTS, get_query_type(**args))
+
+    def test_get_pipelines(self):
+        """Checks that "Pipelines" is returned for "--pipelines".
+        """
+        args = {
+            'pipelines': None
+        }
+
+        self.assertEqual(QueryType.PIPELINES, get_query_type(**args))
+
     def test_get_jobs(self):
         """Checks that "Jobs" is returned for "--jobs", winning over
         "--tenants".

--- a/tests/unit/sources/zuul/test_models.py
+++ b/tests/unit/sources/zuul/test_models.py
@@ -54,6 +54,29 @@ class TestModelBuilder(TestCase):
 
         self.assertNotRaises(lambda: builder.with_tenant(tenant), Exception)
 
+    def test_with_project_of_unknown_tenant(self):
+        """Checks that a new tenant is generated if a project belonging to
+        an unknown one is added.
+        """
+        tenant = Mock()
+        tenant.name = 'tenant'
+
+        project = Mock()
+        project.tenant = tenant
+
+        builder = ModelBuilder()
+        builder.with_project(project)
+
+        result = builder.assemble()
+
+        self.assertIn(project.tenant.name, result.keys())
+
+        result_tenant = result[tenant.name]
+        result_project = result_tenant.projects[project.name]
+
+        self.assertEqual(tenant.name, result_tenant.name.value)
+        self.assertEqual(project.name, result_project.name.value)
+
     def test_with_job_of_unknown_tenant(self):
         """Checks that a new tenant is generated if a job belonging to an
         unknown one is added.

--- a/tests/unit/utils/test_source_metdhods_store.py
+++ b/tests/unit/utils/test_source_metdhods_store.py
@@ -26,7 +26,7 @@ class TestSourceMethodsStore(TestCase):
     def setUp(self):
         self.cache = SourceMethodsStore()
         self.jenkins = Jenkins(url="", name="jenkins_source")
-        self.zuul = Zuul(api=None, name="zuul_source", driver="zuul", url="")
+        self.zuul = Zuul(name="zuul_source", driver="zuul", url="")
 
     def test_add_call(self):
         """Test add_call method."""


### PR DESCRIPTION
On this request:
- Implement 'get_projects' function on Zuul and everything below it.
- Added a 'teardown' method for sources, not yet called.
- Creating and destroying HTTP API on setup and teardown of Zuul.
- Added e2e tests for '--projects'.
- Extended ModelBuilder with projects.
- Adding 'Closeable' interface to allow for objects to free their resources.