### PR TITLE
Delay elasticsearch connection until setup call

### DIFF
--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -39,17 +39,23 @@ LOG = logging.getLogger(__name__)
 class ElasticSearchOSP(ServerSource):
     """Used to perform queries in elasticsearch"""
 
-    def __init__(self: object, driver: str = 'elasticsearch',
+    def __init__(self, driver: str = 'elasticsearch',
                  name: str = "elasticsearch", priority: int = 0,
                  enabled: bool = True, **kwargs) -> None:
         super().__init__(name=name, driver=driver, priority=priority,
                          enabled=enabled)
-
+        self.url = kwargs.get('url')
+        self.es_client = None
         if 'elastic_client' in kwargs:
             self.es_client = kwargs.get('elastic_client')
-        else:
+
+    def setup(self):
+        """ Ensure that a connection to the elasticsearch server can be
+        established.
+        """
+        if self.es_client is None:
             try:
-                url_parsed = urlsplit(kwargs.get('url'))
+                url_parsed = urlsplit(self.url)
                 host = f"{url_parsed.scheme}://{url_parsed.hostname}"
                 port = url_parsed.port
             except Exception as exception:
@@ -62,7 +68,7 @@ class ElasticSearchOSP(ServerSource):
     def get_jobs(self: object, **kwargs: Argument) -> list:
         """Get jobs from elasticsearch
 
-            :returns: Job objects queried from elasticserach
+            :returns: Job objects queried from elasticsearch
             :rtype: :class:`AttributeDictValue`
         """
         key_filter = 'job_name'

--- a/tests/e2e/containers/elasticsearch.py
+++ b/tests/e2e/containers/elasticsearch.py
@@ -25,6 +25,7 @@ class ElasticSearchContainer(ComposedContainer):
     def __init__(self, **kwargs):
         super().__init__('tests/e2e/data/images/elasticsearch')
 
+        self._index_name = kwargs.get('index_name', 'logstash_jenkins_jobs')
         self._jenkins_mapping = kwargs.get(
             'jenkins_mapping',
             'tests/e2e/data/images/elasticsearch/jenkins.mapping.json'
@@ -45,12 +46,12 @@ class ElasticSearchContainer(ComposedContainer):
         with open(self._jenkins_mapping, 'r', encoding='utf-8') as mapping:
             # Create the index
             requests.put(
-                f'{self.url}/jenkins'
+                f'{self.url}/{self._index_name}'
             )
 
             # It is a big mapping, increase the number of possible fields
             requests.put(
-                f'{self.url}/jenkins/_settings',
+                f'{self.url}/{self._index_name}/_settings',
                 json={
                     'index.mapping.total_fields.limit': 2000
                 }
@@ -58,6 +59,6 @@ class ElasticSearchContainer(ComposedContainer):
 
             # Load the mapping
             requests.put(
-                f'{self.url}/jenkins/_mapping',
+                f'{self.url}/{self._index_name}/_mapping',
                 json=json.load(mapping)
             )

--- a/tests/e2e/test_elasticsearch.py
+++ b/tests/e2e/test_elasticsearch.py
@@ -27,7 +27,7 @@ class TestElasticSearch(EndToEndTest):
     def test_jobs(self):
         """Checks that jobs are retrieved with the "--jobs" flag.
         """
-        with ElasticSearchContainer():
+        with ElasticSearchContainer(index_name='logstash_jenkins_jobs'):
             sys.argv = [
                 '',
                 '--config', 'tests/e2e/data/configs/elasticsearch.yaml',

--- a/tests/unit/sources/test_source_factory.py
+++ b/tests/unit/sources/test_source_factory.py
@@ -13,7 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from unittest import TestCase, skip
+from unittest import TestCase
 
 from cibyl.sources.elasticsearch.api import ElasticSearchOSP
 from cibyl.sources.jenkins import Jenkins
@@ -34,12 +34,11 @@ class TestSourceFactory(TestCase):
         self.assertEqual(source.driver, "jenkins")
         self.assertEqual(source.url, "url")
 
-    @skip("Until OSPCRE-427 is fixed")
     def test_create_elasticsearch_source(self):
         """Checks that a elasticsearch source is created."""
         source = SourceFactory.create_source("elasticsearch", "elastic_source",
                                              driver="elastic",
-                                             url="http://example.com:8080")
+                                             url="url")
         self.assertTrue(isinstance(source, ElasticSearchOSP))
         self.assertEqual(source.name, "elastic_source")
         self.assertEqual(source.driver, "elastic")


### PR DESCRIPTION
Move the code that checks connection to the elasticsearch instance into
the setup method. This will avoid any message from the elasticsearch
source if it's disabled. This change also updates the e2e elasticsearch
test to use the same index that it's used in get_jobs.

Solves OSPCRE-428
