### PR TITLE
Move env validation between parse and run_query

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -113,6 +113,9 @@ def main():
     # configuration and extended based on it the parser with arguments
     # from the CI models
     orchestrator.parser.parse()
+
+    orchestrator.validate_environments()
+    orchestrator.setup_sources()
     orchestrator.run_query()
     orchestrator.publisher.publish(
         environments=orchestrator.environments,

--- a/cibyl/cli/validator.py
+++ b/cibyl/cli/validator.py
@@ -97,6 +97,10 @@ class Validator:
         user_sources = self.ci_args.get("sources")
         if user_sources:
             user_sources_names = set(user_sources.value)
+            unused_sources = system_sources-user_sources_names
+            for source in system.sources:
+                if source.name in unused_sources:
+                    source.disable()
             if not user_sources_names & system_sources:
                 return False
 
@@ -227,4 +231,4 @@ class Validator:
                        for source in system.sources]
             raise NoValidSources(sources=sources)
 
-        return user_envs, user_systems
+        return user_envs

--- a/cibyl/sources/source.py
+++ b/cibyl/sources/source.py
@@ -85,6 +85,10 @@ class Source(AttrDict):
         """Release any resources allocated during setup."""
         pass
 
+    def disable(self):
+        """Set source as disabled."""
+        self.enabled = False
+
 
 def is_source_valid(source: Source, desired_attr: str):
     """Checks if a source can be considered valid to perform a query.

--- a/tests/unit/cli/test_validator.py
+++ b/tests/unit/cli/test_validator.py
@@ -23,6 +23,14 @@ from cibyl.exceptions.source import NoValidSources
 from cibyl.orchestrator import Orchestrator
 
 
+def get_all_systems(envs):
+    """Extract all systems from environments to a flat list."""
+    systems = []
+    for env in envs:
+        systems.extend(env.systems)
+    return systems
+
+
 class TestValidator(TestCase):
     """Testing Validator class"""
 
@@ -44,6 +52,10 @@ class TestValidator(TestCase):
                         'system_type': 'zuul',
                         'sources': {
                             'zuul': {
+                                'driver': 'zuul',
+                                'url': ''
+                                },
+                            'zuul2': {
                                 'driver': 'zuul',
                                 'url': ''
                                 }
@@ -84,7 +96,8 @@ class TestValidator(TestCase):
         validator = Validator(self.ci_args)
         original_envs = self.orchestrator.environments
 
-        envs, systems = validator.validate_environments(original_envs)
+        envs = validator.validate_environments(original_envs)
+        systems = get_all_systems(envs)
         self.assertEqual(1, len(envs))
         self.assertEqual(2, len(systems))
         self.assertEqual("system3", systems[0].name.value)
@@ -104,7 +117,8 @@ class TestValidator(TestCase):
         validator = Validator(self.ci_args)
         original_envs = self.orchestrator.environments
 
-        envs, systems = validator.validate_environments(original_envs)
+        envs = validator.validate_environments(original_envs)
+        systems = get_all_systems(envs)
         self.assertEqual(1, len(envs))
         self.assertEqual(1, len(systems))
         self.assertEqual("system3", systems[0].name.value)
@@ -122,7 +136,8 @@ class TestValidator(TestCase):
         validator = Validator(self.ci_args)
         original_envs = self.orchestrator.environments
 
-        envs, systems = validator.validate_environments(original_envs)
+        envs = validator.validate_environments(original_envs)
+        systems = get_all_systems(envs)
         self.assertEqual(1, len(envs))
         self.assertEqual(1, len(systems))
         self.assertEqual("system3", systems[0].name.value)
@@ -183,12 +198,18 @@ class TestValidator(TestCase):
 
         validator = Validator(self.ci_args)
         original_envs = self.orchestrator.environments
-        envs, systems = validator.validate_environments(original_envs)
+        envs = validator.validate_environments(original_envs)
+        systems = get_all_systems(envs)
         self.assertEqual(1, len(envs))
         self.assertEqual(1, len(systems))
         self.assertEqual("system1", systems[0].name.value)
         self.assertEqual("zuul", systems[0].system_type.value)
         self.assertEqual("env1", envs[0].name.value)
+        system = systems[0]
+        self.assertEqual(2, len(system.sources.value))
+        # test that only the selected source is enabled
+        self.assertTrue(system.sources[0].enabled)
+        self.assertFalse(system.sources[1].enabled)
 
     def test_validator_validate_no_sources(self):
         """Test Validator validate_environments with no sources."""
@@ -225,7 +246,8 @@ class TestValidator(TestCase):
 
         original_envs = self.orchestrator.environments
         validator = Validator(self.ci_args)
-        envs, systems = validator.validate_environments(original_envs)
+        envs = validator.validate_environments(original_envs)
+        systems = get_all_systems(envs)
         self.assertEqual(1, len(envs))
         self.assertEqual(2, len(systems))
         self.assertEqual("env", envs[0].name.value)


### PR DESCRIPTION
Instead of running the environment validation inside the run_query
method, move it to a separate method that is called after parsing the
user input. After filtering the environment, a new method setup_sources
is called that will call the setup method of all the enabled sources.
Also as part of this change, if the user specifies sources using the
--source argument, any source that is not selected will be disabled and
its setup will not be called.
