### PR TITLE
Support jobs_scope argument for jenkins and elasticsearch

### DIFF
--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -134,6 +134,16 @@ class System(Model):
         """
         return self.queried.value
 
+    def export_attributes_to_source(self):
+        """Prepare system-level attributes that should be passed to the
+        sources.
+
+        :returns: Dictionary of attributes that should be passed to the sources
+        when calling on of their methods
+        :rtype: dict
+        """
+        pass
+
     def populate(self, instances):
         """Adds all models found on an attribute to this system.
 
@@ -175,7 +185,7 @@ class JobsSystem(System):
                  sources: List = None,
                  enabled: bool = True,
                  jobs: Dict[str, Job] = None,
-                 jobs_scope: str = "*"):
+                 jobs_scope: str = None):
         # Let IDEs know this class's attributes
         self.jobs = None
         self.jobs_scope = None
@@ -191,6 +201,16 @@ class JobsSystem(System):
             jobs=jobs
         )
 
+    def export_attributes_to_source(self):
+        """Prepare system-level attributes that should be passed to the
+        sources.
+
+        :returns: Dictionary of attributes that should be passed to the sources
+        when calling on of their methods
+        :rtype: dict
+        """
+        return {'jobs_scope': self.jobs_scope}
+
     def add_toplevel_model(self, model: Job):
         """Adds a top-level model to the system.
 
@@ -200,7 +220,8 @@ class JobsSystem(System):
         self.add_job(model)
 
     def add_job(self, job: Job):
-        """Adds a job to the CI system.
+        """Adds a job to the CI system. The job will only be added if it's
+        consistent with the jobs_scope attribute of the system.
 
         :param job: Job to add.
         :type job: :class:`Job`

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -134,13 +134,19 @@ def filter_jobs(jobs_found: List[Dict], **kwargs):
     checks_to_apply = [is_job]
 
     jobs_arg = kwargs.get('jobs')
-    if jobs_arg:
+    if jobs_arg and jobs_arg.value:
         pattern = re.compile("|".join(jobs_arg.value))
         checks_to_apply.append(partial(satisfy_regex_match, pattern=pattern,
                                        field_to_check="name"))
 
+    jobs_scope_arg = kwargs.get('jobs_scope')
+    if jobs_scope_arg and jobs_scope_arg.value:
+        pattern = re.compile(jobs_scope_arg.value)
+        checks_to_apply.append(partial(satisfy_regex_match, pattern=pattern,
+                                       field_to_check="name"))
+
     job_urls = kwargs.get('job_url')
-    if job_urls:
+    if job_urls and job_urls.value:
         checks_to_apply.append(partial(satisfy_exact_match,
                                        user_input=job_urls,
                                        field_to_check="url"))

--- a/cibyl/utils/source_methods_store.py
+++ b/cibyl/utils/source_methods_store.py
@@ -22,7 +22,7 @@ class SourceMethodsStore:
     and --build-status or --jobs and --jobs-url).
     """
     def __init__(self):
-        self.cache = dict()
+        self.cache = {}
 
     def _method_information_tuple(self, source_method):
         """Obtain a tuple representation in the format (source_name,

--- a/tests/unit/models/ci/test_system.py
+++ b/tests/unit/models/ci/test_system.py
@@ -56,6 +56,11 @@ class TestSystem(unittest.TestCase):
         msg_str = f"System type should be test_type, not {type_name}"
         self.assertEqual(type_name, "test_type", msg=msg_str)
 
+    def test_export_attributes_to_source(self):
+        """Test system export_attributes_to_source method."""
+        output = self.system.export_attributes_to_source()
+        self.assertIsNone(output)
+
 
 class TestJobsSystem(unittest.TestCase):
     """Test the JobsSystem class."""
@@ -63,7 +68,8 @@ class TestJobsSystem(unittest.TestCase):
     def setUp(self):
         self.name = "test"
         self.system_type = "test_type"
-        self.system = JobsSystem(self.name, self.system_type)
+        self.system = JobsSystem(self.name, self.system_type,
+                                 jobs_scope="phase1")
         self.other_system = JobsSystem(self.name, self.system_type)
 
     def test_add_job(self):
@@ -87,3 +93,9 @@ class TestJobsSystem(unittest.TestCase):
         self.assertFalse(self.system.is_queried())
         self.system.register_query()
         self.assertTrue(self.system.is_queried())
+
+    def test_export_attributes_to_source(self):
+        """Test system export_attributes_to_source method."""
+        output = self.system.export_attributes_to_source()
+        self.assertEqual(1, len(output))
+        self.assertEqual(output['jobs_scope'].value, 'phase1')

--- a/tests/unit/sources/elasticsearch/test_api.py
+++ b/tests/unit/sources/elasticsearch/test_api.py
@@ -143,6 +143,22 @@ class TestElasticsearchOSP(TestCase):
         self.assertEqual(jobs['test'].url.value, "http://domain.tld/test")
 
     @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
+    def test_get_jobs_jobs_scope(self: object, mock_query_hits: object):
+        """Tests that the internal logic from :meth:`ElasticSearchOSP.get_jobs`
+            is correct using jobs_scope argument.
+        """
+        mock_query_hits.return_value = self.job_hits
+
+        jobs_argument = Mock()
+        jobs_argument.value = 'test4'
+        jobs = self.es_api.get_jobs(jobs_scope=jobs_argument)
+
+        self.assertEqual(len(jobs), 1)
+        self.assertTrue('test4' in jobs)
+        self.assertEqual(jobs['test4'].name.value, 'test4')
+        self.assertEqual(jobs['test4'].url.value, "http://domain.tld/test4")
+
+    @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
     def test_get_deployment(self: object, mock_query_hits: object) -> None:
         """Tests that the internal logic from
         :meth:`ElasticSearchOSP.get_deployment` is correct.
@@ -306,6 +322,16 @@ class TestElasticsearchOSP(TestCase):
             len(tests['test'].builds['2'].tests),
             0
         )
+
+    @patch('cibyl.sources.elasticsearch.api.ElasticSearchClient')
+    def test_setup(self, mock_client):
+        """Test setup method of ElasticSearchOSP"""
+        es_api = ElasticSearchOSP(elastic_client=None,
+                                  url="https://example.com:9200")
+        client = mock_client.return_value
+        client.connect.side_effect = None
+        es_api.setup()
+        mock_client.assert_called_with("https://example.com", 9200)
 
 
 class TestQueryTemplate(TestCase):

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -1938,6 +1938,31 @@ class TestFilters(TestCase):
                     ]
         self.assertEqual(jobs_filtered, expected)
 
+    def test_filter_jobs_scope(self):
+        """
+            Test that filter_jobs filters the jobs given the user input.
+        """
+        response = [{'_class': 'org..job.WorkflowRun',
+                     'name': "ansible", 'url': 'url1',
+                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
+                    {'_class': 'org..job.WorkflowRun',
+                     'name': "test_jobs", 'url': 'url2',
+                     'lastBuild': {'number': 2, 'result': "FAILURE"}},
+                    {'_class': 'org..job.WorkflowRun',
+                     'name': "ans2", 'url': 'url3',
+                     'lastBuild': {'number': 0, 'result': "FAILURE"}}]
+        args = Mock()
+        args.value = "ans"
+        jobs_filtered = filter_jobs(response, jobs_scope=args)
+        expected = [{'_class': 'org..job.WorkflowRun',
+                     'name': "ansible", 'url': 'url1',
+                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
+                    {'_class': 'org..job.WorkflowRun',
+                     'name': "ans2", 'url': 'url3',
+                     'lastBuild': {'number': 0, 'result': "FAILURE"}},
+                    ]
+        self.assertEqual(jobs_filtered, expected)
+
     def test_filter_jobs_class(self):
         """
             Test that filter_jobs filters the jobs given the job _class.


### PR DESCRIPTION
This change adds the jobs_scope attribute to use with jenkins and
elasticsearch sources. The attribute is part of the system
configuration, so it introduces a new method of System to export system
attributes that might be relevant for sources. This change also modifies
the run_query main loop to create a new SourceStoreMethod per system,
since the assumption that sources will have unique names is not
correct.
