### PR TITLE
Raise exception if configuration file is empty

### DIFF
--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -58,6 +58,12 @@ class Config(UserDict):
         :raises YAMLError: If the file could not be parsed.
         """
         self.data = yaml.parse(file)
+        if self.data is None:
+            # if the configuration file is empty, yaml.parse will return None,
+            # we assign an empty dictionary to always return the same type and
+            # raise an exception
+            self.data = {}
+            raise ConfigurationNotFound(f"Configuration file {file} is empty.")
 
 
 class ConfigFactory:

--- a/tests/intr/cli/test_config.py
+++ b/tests/intr/cli/test_config.py
@@ -1,0 +1,38 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+import sys
+from tempfile import NamedTemporaryFile
+from unittest import TestCase
+
+from cibyl.cli.main import main
+from cibyl.exceptions.config import ConfigurationNotFound
+
+
+class TestConfig(TestCase):
+    """Test that configuration is read properly when calling cibyl."""
+
+    def test_empty_config(self):
+        """Test that an exception is raised when calling cibyl with an empty
+        configuration.
+        """
+        with NamedTemporaryFile() as config_file:
+            sys.argv = [
+                '',
+                '--config', config_file.name
+            ]
+
+            self.assertRaises(ConfigurationNotFound, main)

--- a/tests/intr/cli/test_openstack_plugin.py
+++ b/tests/intr/cli/test_openstack_plugin.py
@@ -35,10 +35,11 @@ class TestOpenstackCLI(TestCase):
         cls._original_stdout = sys.stdout
         # silence stdout and logging to avoid cluttering
         logging.disable(logging.CRITICAL)
-        sys.stdout = open(os.devnull, 'w')
+        sys.stdout = open(os.devnull, 'w', encoding='utf-8')
 
     @classmethod
     def tearDownClass(cls):
+        sys.stdout.close()
         sys.stdout = cls._original_stdout
 
     def setUp(self):


### PR DESCRIPTION
Yaml returns None when parsing an empty file. This is checked after
loading the configuration and an exception is raised. This exception
follows the same behaviour as the case of no configuration file, if the
user passed the -h option, the help is displayed, if not, the exception
is raised. Adds also a few test to avoid regressions.
