### PR TITLE
Printing URL of projects when verbosity is above > 0

### DIFF
--- a/cibyl/models/ci/printers/colored.py
+++ b/cibyl/models/ci/printers/colored.py
@@ -170,6 +170,9 @@ class CIColoredPrinter(CIPrinter):
         result.add(self._palette.blue('Project: '), 0)
         result[-1].append(project.name)
 
+        if self.verbosity > 0:
+            result.add(f"URL: {project.url}", 1)
+
         if self.query > QueryType.PROJECTS:
             for pipeline in project.pipelines.values():
                 result.add(self.print_pipeline(pipeline), 1)

--- a/cibyl/models/ci/project.py
+++ b/cibyl/models/ci/project.py
@@ -27,6 +27,10 @@ class Project(Model):
             'attr_type': str,
             'arguments': []
         },
+        'url': {
+            'attr_type': str,
+            'arguments': []
+        },
         'pipelines': {
             'attr_type': Pipeline,
             'attribute_value_class': AttributeDictValue,
@@ -41,19 +45,20 @@ class Project(Model):
         }
     }
 
-    def __init__(self, name, pipelines=None):
+    def __init__(self, name, url, pipelines=None):
         # Let IDEs know this model's attributes
         self.name = None
+        self.url = None
         self.pipelines = None
 
         # Set up the model
-        super().__init__({'name': name, 'pipelines': pipelines})
+        super().__init__({'name': name, 'url': url, 'pipelines': pipelines})
 
     def __eq__(self, other):
         if not isinstance(other, Project):
             return False
 
-        return self.name == other.name
+        return self.name == other.name and self.url == other.url
 
     def merge(self, other):
         """Adds the contents of another project into this one.

--- a/cibyl/sources/zuul/models.py
+++ b/cibyl/sources/zuul/models.py
@@ -53,7 +53,7 @@ class ModelBuilder:
         :return: The builder's instance.
         :rtype: :class:`ModelBuilder`
         """
-        model = Project(project.name)
+        model = Project(project.name, project.url)
 
         # Register the project's tenant
         self.with_tenant(project.tenant)

--- a/cibyl/sources/zuul/requests.py
+++ b/cibyl/sources/zuul/requests.py
@@ -281,6 +281,14 @@ class ProjectResponse:
         """
         return self._project.name
 
+    @property
+    def url(self):
+        """
+        :return: The project's URL.
+        :rtype: str
+        """
+        return self._project.url
+
 
 class JobResponse:
     """Response for a :class:`JobsRequest`.

--- a/tests/e2e/test_zuul.py
+++ b/tests/e2e/test_zuul.py
@@ -109,6 +109,30 @@ class TestZuul(EndToEndTest):
             self.output
         )
 
+    def test_get_project_url(self):
+        """Checks that "-v" will print a project's URL.
+        """
+        sys.argv = [
+            '',
+            '--config', 'tests/e2e/data/configs/zuul.yaml',
+            '-f', 'text',
+            '--tenants', 'example-tenant',
+            '--projects', 'test1',
+            '-v'
+        ]
+
+        main()
+
+        self.assertIn(
+            "Project: test1",
+            self.output
+        )
+
+        self.assertIn(
+            "URL: http://localhost:9000/t/example-tenant/project/test1",
+            self.output
+        )
+
     def test_no_jobs_on_tenant_query(self):
         """Checks that no 'Jobs found in tenant...' string is printed for a
         '--tenants' query.

--- a/tests/intr/sources/zuul/test_query.py
+++ b/tests/intr/sources/zuul/test_query.py
@@ -103,9 +103,11 @@ class TestHandleQuery(TestCase):
         """
         project1 = Mock()
         project1.name = 'project1'
+        project1.url = 'url1'
 
         project2 = Mock()
         project2.name = 'project2'
+        project2.url = 'url2'
 
         tenant = Mock()
         tenant.name = 'tenant'
@@ -126,8 +128,8 @@ class TestHandleQuery(TestCase):
                 tenant.name: Tenant(
                     tenant.name,
                     projects={
-                        project1.name: Project(project1.name),
-                        project2.name: Project(project2.name)
+                        project1.name: Project(project1.name, project1.url),
+                        project2.name: Project(project2.name, project2.url)
                     }
                 )
             },
@@ -139,9 +141,11 @@ class TestHandleQuery(TestCase):
         """
         project1 = Mock()
         project1.name = 'project1'
+        project1.url = 'url1'
 
         project2 = Mock()
         project2.name = 'project2'
+        project2.url = 'url2'
 
         tenant = Mock()
         tenant.name = 'tenant'
@@ -162,7 +166,7 @@ class TestHandleQuery(TestCase):
                 tenant.name: Tenant(
                     tenant.name,
                     projects={
-                        project1.name: Project(project1.name)
+                        project1.name: Project(project1.name, project1.url)
                     }
                 )
             },

--- a/tests/unit/models/ci/test_project.py
+++ b/tests/unit/models/ci/test_project.py
@@ -27,18 +27,20 @@ class TestProject(TestCase):
         """Checks that if a project is compared with something of another
         type, they will not be equal.
         """
-        project = Project('project')
+        project = Project('project', 'url')
         other = Mock()
 
         self.assertNotEqual(other, project)
 
-    def test_equal_by_name(self):
-        """Checks that two projects are the same if they share the same name.
+    def test_equal_by_content(self):
+        """Checks that two projects are the same if they share the same
+        contents.
         """
         name = 'project'
+        url = 'url'
 
-        project1 = Project(name)
-        project2 = Project(name)
+        project1 = Project(name, url)
+        project2 = Project(name, url)
 
         self.assertEqual(project2, project1)
 
@@ -57,8 +59,8 @@ class TestProject(TestCase):
         pipeline2.name = Mock()
         pipeline2.name.value = name2
 
-        project1 = Project('project1', {name1: pipeline1})
-        project2 = Project('project2', {name2: pipeline2})
+        project1 = Project('project1', 'url1', {name1: pipeline1})
+        project2 = Project('project2', 'url2', {name2: pipeline2})
 
         project1.merge(project2)
 
@@ -81,7 +83,7 @@ class TestProject(TestCase):
         pipeline.name.value = name
         pipeline.merge = Mock()
 
-        project = Project('project', {name: pipeline})
+        project = Project('project', 'url', {name: pipeline})
 
         project.add_pipeline(pipeline)
 


### PR DESCRIPTION
On this request:
- Adding URL attribute to Project.
- Making ModelBuilder pass the URL to the model.
- Make printer print the URL of projects when '-v' is passed.
- Updating tests accordingly.