### PR TITLE
Support passing job name to --spec argument

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -58,7 +58,7 @@ def get_query_type(**kwargs):
     if 'pipelines' in kwargs:
         result = QueryType.PIPELINES
 
-    if 'jobs' in kwargs:
+    if 'jobs' in kwargs or 'spec' in kwargs:
         result = QueryType.JOBS
 
     if 'builds' in kwargs:

--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -34,7 +34,7 @@ class Deployment(Model):
                                    func='get_deployment', nargs='*',
                                    description="Deployment release version"),
                           Argument(name='--spec', arg_type=str,
-                                   func='get_deployment', nargs=0,
+                                   func='get_deployment', nargs='*',
                                    description="Print complete openstack"
                                    " deployment")]
         },


### PR DESCRIPTION
Support calling --spec job_name without any reference to the --jobs
argument. This should perform the same checks, i.e. only one job
requested and raise an error if more than one match the request.
