### PR TITLE
Set granular exception for source misconfiguration

### DIFF
--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -21,13 +21,12 @@ import rfc3987
 
 from cibyl.cli.interactions import ask_yes_no_question
 from cibyl.exceptions.cli import AbortedByUserError
-from cibyl.exceptions.config import ConfigurationNotFound
+from cibyl.exceptions.config import ConfigurationNotFound, EmptyConfiguration
 from cibyl.utils import yaml
 from cibyl.utils.files import get_first_available_file, is_file_available
 from cibyl.utils.net import DownloadError, download_file
 
 LOG = logging.getLogger(__name__)
-CONFIG_DOCS_URL = "https://cibyl.readthedocs.io/en/latest/configuration.html"
 
 
 def _ask_user_for_overwrite():
@@ -64,10 +63,7 @@ class Config(UserDict):
             # we assign an empty dictionary to always return the same type and
             # raise an exception
             self.data = {}
-            msg = f"Configuration file {file} is empty.\n"
-            msg += f"Check the documentation at {CONFIG_DOCS_URL} for more "
-            msg += "details about the configuration syntax."
-            raise ConfigurationNotFound(msg)
+            raise EmptyConfiguration(file)
 
 
 class ConfigFactory:
@@ -122,10 +118,7 @@ class ConfigFactory:
         :raise ConfigurationNotFound: If the file does not exist.
         """
         if not is_file_available(file):
-            msg = f"Could not find configuration file at: {file}.\n"
-            msg += f"Check the documentation at {CONFIG_DOCS_URL} for more "
-            msg += "details about the configuration syntax."
-            raise ConfigurationNotFound(msg)
+            raise ConfigurationNotFound(file)
 
         config = Config()
         config.load(file)
@@ -145,11 +138,7 @@ class ConfigFactory:
         file = get_first_available_file(paths)
 
         if not file:
-            msg = f"Could not find configuration file at: {paths}.\n"
-            msg += f"Check the documentation at {CONFIG_DOCS_URL} for more "
-            msg += "details about the configuration syntax."
-
-            raise ConfigurationNotFound(msg)
+            raise ConfigurationNotFound(paths)
 
         return ConfigFactory.from_file(file)
 
@@ -206,10 +195,7 @@ class ConfigFactory:
         try:
             download_file(url, dest)
         except DownloadError as ex:
-            msg = f"Configuration could not be retrieved from: {url}.\n"
-            msg += f"Check the documentation at {CONFIG_DOCS_URL} for more "
-            msg += "details about the configuration syntax."
-            raise ConfigurationNotFound(msg) from ex
+            raise ConfigurationNotFound(url) from ex
 
         LOG.info('Download completed successfully.')
 

--- a/cibyl/exceptions/config.py
+++ b/cibyl/exceptions/config.py
@@ -15,6 +15,8 @@
 """
 from cibyl.exceptions import CibylException
 
+CONFIG_DOCS_URL = "https://cibyl.readthedocs.io/en/latest/configuration.html"
+
 
 class InvalidConfiguration(CibylException):
     """Invalid configuration exception"""
@@ -34,3 +36,37 @@ environments:
 
 class ConfigurationNotFound(CibylException):
     """Configuration file not found exception"""
+
+    def __init__(self, paths):
+        if paths:
+            paths = f" at: {paths}"
+        else:
+            paths = ""
+        self.message = f"""Could not find configuration file{paths}.\n
+Check the documentation at {CONFIG_DOCS_URL} for more information"""
+
+        super().__init__(self.message)
+
+
+class EmptyConfiguration(CibylException):
+    """Configuration file is empty exception."""
+
+    def __init__(self, file):
+        self.message = f"""Configuration file {file} is empty.\n
+Check the documentation at {CONFIG_DOCS_URL} for more \
+details about the configuration syntax."""
+
+        super().__init__(self.message)
+
+
+class InvalidSourceConfiguration(CibylException):
+    """Invalid source configuration exception."""
+
+    def __init__(self, source_name, source_data):
+        self.message = f"""Invalid source configuration.
+
+{source_name}: {source_data}
+
+Check the documentation at {CONFIG_DOCS_URL} for more information"""
+
+        super().__init__(self.message)

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -18,10 +18,10 @@ import operator
 import time
 from copy import deepcopy
 
+import cibyl.exceptions.config as conf_exc
 from cibyl.cli.parser import Parser
 from cibyl.cli.validator import Validator
 from cibyl.config import Config, ConfigFactory
-from cibyl.exceptions.config import InvalidConfiguration
 from cibyl.exceptions.source import (NoSupportedSourcesFound, NoValidSources,
                                      SourceException)
 from cibyl.models.ci.environment import Environment
@@ -77,6 +77,16 @@ class Orchestrator:
         """Loads the configuration of the application."""
         self.config = ConfigFactory.from_path(path)
 
+    def get_source(self, source_name, source_data):
+        try:
+            return SourceFactory.create_source(
+                    source_data.get('driver'),
+                    source_name,
+                    **source_data)
+        except AttributeError as exception:
+            raise conf_exc.InvalidSourceConfiguration(
+                source_name, source_data) from exception
+
     def create_ci_environments(self) -> None:
         """Creates CI environment entities based on loaded configuration."""
         try:
@@ -94,12 +104,7 @@ class Orchestrator:
 
                     for source_name, source_data in sources_dict.items():
                         sources.append(
-                            SourceFactory.create_source(
-                                source_data.get('driver'),
-                                source_name,
-                                **source_data
-                            )
-                        )
+                            self.get_source(source_name, source_data))
 
                     environment.add_system(
                         name=system_name,
@@ -110,7 +115,7 @@ class Orchestrator:
                 self.environments.append(environment)
             self.set_system_api()
         except AttributeError as exception:
-            raise InvalidConfiguration from exception
+            raise conf_exc.InvalidConfiguration from exception
 
     def set_system_api(self):
         """Modify the System API depending on the type of systems present in

--- a/tests/intr/cli/test_config.py
+++ b/tests/intr/cli/test_config.py
@@ -19,7 +19,7 @@ from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
 from cibyl.cli.main import main
-from cibyl.exceptions.config import ConfigurationNotFound
+from cibyl.exceptions.config import EmptyConfiguration
 
 
 class TestConfig(TestCase):
@@ -35,4 +35,4 @@ class TestConfig(TestCase):
                 '--config', config_file.name
             ]
 
-            self.assertRaises(ConfigurationNotFound, main)
+            self.assertRaises(EmptyConfiguration, main)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,7 +22,7 @@ import yaml
 import cibyl.config
 from cibyl.config import Config, ConfigFactory
 from cibyl.exceptions.cli import AbortedByUserError
-from cibyl.exceptions.config import ConfigurationNotFound
+from cibyl.exceptions.config import ConfigurationNotFound, EmptyConfiguration
 from cibyl.utils.net import DownloadError
 from cibyl.utils.yaml import encrypted_constructor, get_loader
 
@@ -35,7 +35,7 @@ class TestConfig(TestCase):
         """Test that parsing and empty configuration file raises and error."""
         with NamedTemporaryFile() as config_file:
             config = Config()
-            self.assertRaises(ConfigurationNotFound, config.load,
+            self.assertRaises(EmptyConfiguration, config.load,
                               config_file.name)
 
     def test_contents_are_loaded(self):


### PR DESCRIPTION
Before this change, if user made a mistake in the sources section
in the configuration file, it would throw a generic exception
about invalid configuration. With this change applied, the user
will now see the invalid source configuration and also the link
to the documentation will be provided for more details.

In addition, consolidated the ConfigurationNotFound exceptions
into one generic exception, and created a separate exception
for empty file.
