### PR TITLE
Fix zuul system failing due to None system attributes.

### DIFF
--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -141,7 +141,7 @@ class System(Model):
         when calling on of their methods
         :rtype: dict
         """
-        pass
+        return {}
 
     def populate(self, instances):
         """Adds all models found on an attribute to this system.

--- a/tests/unit/models/ci/test_system.py
+++ b/tests/unit/models/ci/test_system.py
@@ -59,7 +59,7 @@ class TestSystem(unittest.TestCase):
     def test_export_attributes_to_source(self):
         """Test system export_attributes_to_source method."""
         output = self.system.export_attributes_to_source()
-        self.assertIsNone(output)
+        self.assertEqual({}, output)
 
 
 class TestJobsSystem(unittest.TestCase):


### PR DESCRIPTION
Do not return None if the system has no custom attributes as that will make the zuul system crash on the orchestrator.