### PR TITLE
Fix issues in run_query due to many args and envs

### DIFF
--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -233,9 +233,9 @@ class Orchestrator:
                                 **system_args)
                         except SourceException as exception:
                             source_methods_store.add_call(source_method, False)
-                            LOG.error("Error in %s. %s",
-                                      source_info, exception,
-                                      exc_info=debug)
+                            LOG.error("Error in %s with system %s. %s",
+                                      source_info, system.name.value,
+                                      exception, exc_info=debug)
                             continue
                         source_methods_store.add_call(source_method, True)
                         end_time = time.time()

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -660,7 +660,8 @@ accurate results", len(jobs_found))
                                          url=artifact_url,
                                          raw_response=True)
             artifact = yaml.safe_load(artifact)
-            nodes = artifact['provision']['topology'].get('nodes', {})
+            provision = artifact.get('provision', {})
+            nodes = provision.get('topology', {}).get('nodes', {})
             topology = []
             for node_path, amount in nodes.items():
                 node = os.path.split(node_path)[1]

--- a/tests/intr/test_orchestrator.py
+++ b/tests/intr/test_orchestrator.py
@@ -1,0 +1,72 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import logging
+import os
+import sys
+from tempfile import NamedTemporaryFile
+from unittest import TestCase
+from unittest.mock import patch
+
+from cibyl.cli.main import main
+from cibyl.exceptions.jenkins import JenkinsError
+from cibyl.sources.jenkins import Jenkins
+from cibyl.utils.source_methods_store import SourceMethodsStore
+
+
+class TestOrchestrator(TestCase):
+    """Test the Orchestrator class."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._original_stdout = sys.stdout
+        # silence stdout and logging to avoid cluttering
+        logging.disable(logging.CRITICAL)
+        sys.stdout = open(os.devnull, 'w', encoding='utf-8')
+
+    @classmethod
+    def tearDownClass(cls):
+        sys.stdout.close()
+        sys.stdout = cls._original_stdout
+
+    @patch('cibyl.orchestrator.source_information_from_method',
+           return_value="")
+    @patch.object(SourceMethodsStore, '_method_information_tuple')
+    @patch.object(Jenkins, 'get_jobs', side_effect=JenkinsError)
+    @patch.object(Jenkins, 'get_deployment', side_effect=JenkinsError)
+    def test_args_level(self, jenkins_deployment, jenkins_jobs, store_mock,
+                        _):
+        """Test that the args level is updated properly in run_query."""
+        store_mock.side_effect = [("jenkins", "get_deployment"),
+                                  ("jenkins", "get_deployment"),
+                                  ("jenkins", "get_jobs"),
+                                  ("jenkins", "get_jobs"),
+                                  ("jenkins", "get_jobs")]
+        with NamedTemporaryFile() as config_file:
+            config_file.write(b"environments:\n")
+            config_file.write(b"  env:\n")
+            config_file.write(b"    system:\n")
+            config_file.write(b"      system_type: jenkins\n")
+            config_file.write(b"      sources:\n")
+            config_file.write(b"        jenkins:\n")
+            config_file.write(b"          driver: jenkins\n")
+            config_file.write(b"          url: url\n")
+            config_file.seek(0)
+            sys.argv = ['', '-p', 'openstack', '--config', config_file.name,
+                        '--jobs', 'DFG-compute', '--spec']
+
+            main()
+        jenkins_deployment.assert_called_once()
+        jenkins_jobs.assert_not_called()

--- a/tests/unit/sources/zuul/test_zuuld_git_api.py
+++ b/tests/unit/sources/zuul/test_zuuld_git_api.py
@@ -60,6 +60,6 @@ class TestZuulGitAPI(TestCase):
     def test_zuuld_repos_with_parse_file(self):
         data = ZuulLocal(self.valid)
         yaml_file = os.path.join(self.path, "zuul.d",
-                                 "ansible-galaxy.yaml")
+                                 "ansible.yaml")
         yaml_data = data._parse_file(yaml_file)
-        self.assertIn('job', yaml_data[0].keys())
+        self.assertIn('project-template', yaml_data[0].keys())


### PR DESCRIPTION
Revert a recent change that swapped the order of the systems and
arguments loops in run_query method of the Orchestrator. The argument
loop must be the outermost one. Otherwise different systems might
perform different queries if, for example, one of the systems does not
have any source that supports the argument with the highest level. This
change also updates the last_level variable, to ensure that queries like
cibyl --spec --jobs do not query for jobs, since --spec is the argument
with the highest level, and --jobs acts simply as a filter.

Solves OSPCRE-472
