### PR TITLE
Fix bug filtering by status with running build

### DIFF
--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -90,6 +90,8 @@ def satisfy_case_insensitive_match(model: Dict[str, str], user_input: Argument,
     :returns: Whether the model satisfies user input
     :rtype: bool
     """
+    if model[field_to_check] is None:
+        return False
     lowercase_input = [status.lower() for status in user_input.value]
     return model[field_to_check].lower() in lowercase_input
 

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -2185,6 +2185,26 @@ class TestFilters(TestCase):
                      'result': 'success'}]
         self.assertEqual(builds_filtered, expected)
 
+    def test_filter_builds_build_status_running_build(self):
+        """Test that filter builds filters the builds given the user input.
+        This tests simulates the case when a build is running, which sets the
+        result field to None."""
+        response = [{'_class': 'org..job.WorkflowRun', 'number': 3,
+                     'result': 'SUCCESS'},
+                    {'_class': 'org..job.WorkflowRun', 'number': 4,
+                     'result': None},
+                    {'_class': 'org..job.WorkflowRun', 'number': 5,
+                     'result': 'success'}]
+        build_status = Mock()
+        build_status.value = ["success"]
+        builds_filtered = filter_builds(response,
+                                        build_status=build_status)
+        expected = [{'_class': 'org..job.WorkflowRun', 'number': "3",
+                     'result': 'SUCCESS'},
+                    {'_class': 'org..job.WorkflowRun', 'number': "5",
+                     'result': 'success'}]
+        self.assertEqual(builds_filtered, expected)
+
     def test_filter_nodes(self):
         """Test that filter_nodes filters nodes according to user input."""
         job = {'nodes': {'node1': Node('node1', 'test',


### PR DESCRIPTION
If we query for builds with a running job in Jenkins, the result field
is set to None, which would crash the filtering code. This change
provides a simple fix to filter out such builds.
