### PR TITLE
Parse all arguments instead of ignoring non-supported args

### DIFF
--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -100,15 +100,13 @@ class Parser:
         :param arguments: Arguments to parse
         :type arguments: list
         """
-        # First item is the namespace of the parsed known arguments (we ignore
-        # the arguments we are not familiar with)
-        known_arguments = self.argument_parser.parse_known_args(arguments)[0]
+        arguments = vars(self.argument_parser.parse_args(arguments))
         # Keep only the used arguments
-        self.ci_args = {arg_name: arg_value for arg_name, arg_value in vars(
-            known_arguments).items() if isinstance(arg_value, Argument)}
-        self.app_args = {arg_name: arg_value for arg_name, arg_value in vars(
-            known_arguments).items() if arg_value is not None and not
-            isinstance(arg_value, Argument)}
+        self.ci_args = {arg_name: arg_value for arg_name, arg_value in
+                        arguments.items() if isinstance(arg_value, Argument)}
+        self.app_args = {arg_name: arg_value for arg_name, arg_value in
+                         arguments.items() if arg_value is not None and not
+                         isinstance(arg_value, Argument)}
 
     def get_group(self, group_name: str):
         """Returns the argument parser group based on a given group_name

--- a/tests/unit/cli/test_parser.py
+++ b/tests/unit/cli/test_parser.py
@@ -53,7 +53,7 @@ class TestParser(TestCase):
 
     def test_parser_parse_args(self):
         """Testing parser extend method"""
-        self.parser.parse()
+        self.parser.parse({})
         self.assertEqual(self.parser.app_args, {'debug': False,
                                                 'plugin': 'openstack',
                                                 'output_style': 'colorized',

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -195,8 +195,7 @@ class TestOrchestrator(TestCase):
         self.orchestrator.create_ci_environments()
         for env in self.orchestrator.environments:
             self.orchestrator.extend_parser(attributes=env.API)
-        self.orchestrator.parser.parse(["--jobs", "--builds", "--tenants"])
-        self.assertFalse("tenants" in self.orchestrator.parser.ci_args)
+        self.orchestrator.parser.parse(["--jobs", "--builds"])
         self.assertTrue("jobs" in self.orchestrator.parser.ci_args)
         self.assertTrue("builds" in self.orchestrator.parser.ci_args)
         self.assertEqual(self.orchestrator.parser.ci_args["jobs"].level, 2)


### PR DESCRIPTION
Using parse_known_args led to a situation where non-known
arguments were simply ignored. This made commands like the
following completely valid:

cibyl --jobs --non-existing-arguments

This change switches to parsing all arguments hence causing
the app to fail if a known argument was used.

Also, removed tenants argument from a test which tests a
jenkins system configuration.
