### PR TITLE
Logging Improvements

### DIFF
--- a/cibyl/models/ci/printers/colored.py
+++ b/cibyl/models/ci/printers/colored.py
@@ -232,10 +232,6 @@ class CIColoredPrinter(CIPrinter):
 
             # Check if the plugin is installed
             if not attribute.value:
-                LOG.debug(
-                    'Could not retrieve value for %s on %s.',
-                    plugin, job.name.value
-                )
                 continue
 
             if isinstance(attribute, AttributeValue):

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -47,8 +47,10 @@ def source_information_from_method(source_method):
     :rtype: str
     """
     source = source_method.__self__
-    info_str = f"source {source.name} of type {source.driver} using method "
-    return info_str+f"{source_method.__name__}"
+    info_str = f"source {source.name} of type {source.driver}"
+    if LOG.getEffectiveLevel() <= logging.DEBUG:
+        info_str += f" using method {source_method.__name__}"
+    return info_str
 
 
 class Orchestrator:
@@ -239,9 +241,9 @@ class Orchestrator:
                             continue
                         source_methods_store.add_call(source_method, True)
                         end_time = time.time()
-                        LOG.debug("Took %.2fs to query system %s using %s",
-                                  end_time-start_time, system.name.value,
-                                  source_info)
+                        LOG.info("Took %.2fs to query system %s using %s",
+                                 end_time-start_time, system.name.value,
+                                 source_info)
                         system.populate(model_instances_dict)
                         system.register_query()
                         # if one source has provided the information, there is

--- a/cibyl/sources/elasticsearch/client.py
+++ b/cibyl/sources/elasticsearch/client.py
@@ -50,6 +50,6 @@ class ElasticSearchClient:
         if not es_client.ping():
             raise ElasticSearchError(f"Error connecting to "
                                      f"Elasticsearch: {self.address}")
-        LOG.info(f"Connection established successfully with elasticsearch"
-                 f" instance: {self.address}")
+        LOG.debug(f"Connection established successfully with elasticsearch"
+                  f" instance: {self.address}")
         return es_client

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -184,7 +184,7 @@ class TestOrchestrator(TestCase):
         """Test that the source_information_from_method methods provides the
         correct representation of the source."""
         source = Source(name="source", driver="driver")
-        expected = "source source of type driver using method setup"
+        expected = "source source of type driver"
         output = source_information_from_method(source.setup)
         self.assertEqual(expected, output)
 


### PR DESCRIPTION
* Don't log elsaticsearch connection established on INFO level
  as that displays to the user every time he/she runs a query.
  Show it only on debug level
* Remove "Could not retrieve value" logging as it logs too many
  lines, even for simple queries such as "cibyl --jobs". In addition,
  it's not very useful information for developer or a user
* Show always from where a certain information got pulled and how
  much time it took. Show which method was used only if debugging
  is on as it's not something that is useful for most users.
