### PR TITLE
Improve consistency of exceptions formatting

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -18,7 +18,7 @@ import sys
 
 from cibyl.cli.output import OutputStyle
 from cibyl.cli.query import get_query_type
-from cibyl.exceptions import CibylException
+from cibyl.exceptions import CibylException, CibylNotImplementedException
 from cibyl.exceptions.cli import InvalidArgument
 from cibyl.exceptions.config import ConfigurationNotFound
 from cibyl.orchestrator import Orchestrator
@@ -65,7 +65,7 @@ def raw_parsing(arguments):
 
             try:
                 args["output_style"] = OutputStyle.from_key(arg)
-            except NotImplementedError:
+            except CibylNotImplementedException:
                 raise InvalidArgument(f'Unknown format: {arg}')
 
     return args

--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -38,7 +38,7 @@ def raw_parsing(arguments):
     args = {'config_file_path': None, 'help': False,
             "log_file": "cibyl_output.log", "log_mode": "both",
             "logging": logging.INFO, "plugins": [],
-            "debug": False, "output_style": OutputStyle.COLORIZED}
+            "debug": False, "output_style": "colorized"}
     for i, item in enumerate(arguments[1:]):
         if item in ('-c', '--config'):
             args['config_file_path'] = arguments[i + 2]
@@ -61,14 +61,22 @@ def raw_parsing(arguments):
                 plugins.append(argument)
             args["plugins"] = plugins
         elif item in ('-f', '--output-format'):
-            arg = arguments[i + 2]
+            args["output_style"] = arguments[i + 2]
 
-            try:
-                args["output_style"] = OutputStyle.from_key(arg)
-            except CibylNotImplementedException:
-                raise InvalidArgument(f'Unknown format: {arg}')
-
+    if not args['debug']:
+        CibylException.setup_quiet_exceptions()
+    setup_output_format(args)
     return args
+
+
+def setup_output_format(args):
+    """Parse the OutputStyle specified by the user."""
+    user_output_format = args["output_style"]
+    try:
+        args["output_style"] = OutputStyle.from_key(user_output_format)
+    except CibylNotImplementedException:
+        msg = f'Unknown output format: {user_output_format}'
+        raise InvalidArgument(msg) from None
 
 
 def main():
@@ -78,8 +86,6 @@ def main():
     # to run the app parser only once, after we update it with the loaded
     # arguments from the CI models based on the loaded configuration file
     arguments = raw_parsing(sys.argv)
-    if not arguments['debug']:
-        CibylException.setup_quiet_exceptions()
     configure_logging(arguments.get('log_mode'),
                       arguments.get('log_file'),
                       arguments.get('logging'))

--- a/cibyl/cli/output.py
+++ b/cibyl/cli/output.py
@@ -15,6 +15,8 @@
 """
 from enum import Enum
 
+from cibyl.exceptions import CibylNotImplementedException
+
 
 class OutputStyle(Enum):
     """Lists all supported output formats by the CLI.
@@ -36,11 +38,12 @@ class OutputStyle(Enum):
         :type key: Any
         :return: The correspondent style.
         :rtype: :class:`OutputStyle`
-        :raise NotImplementedError: If no style is present for the given key.
+        :raise CibylNotImplementedException: If no style is present for the
+        given key.
         """
         if key == 'text':
             return OutputStyle.TEXT
         elif key == 'colorized':
             return OutputStyle.COLORIZED
         else:
-            raise NotImplementedError(f'Unknown format: {key}')
+            raise CibylNotImplementedException(f'Unknown format: {key}')

--- a/cibyl/exceptions/__init__.py
+++ b/cibyl/exceptions/__init__.py
@@ -38,3 +38,7 @@ class CibylException(Exception):
                 sys.__excepthook__(kind, message, traceback)
 
         sys.excepthook = quiet_hook
+
+
+class CibylNotImplementedException(CibylException, NotImplementedError):
+    """Custom NotImplementedError that inherits the quiet_extensions setup."""

--- a/cibyl/models/ci/printers/__init__.py
+++ b/cibyl/models/ci/printers/__init__.py
@@ -15,6 +15,7 @@
 """
 from abc import ABC, abstractmethod
 
+from cibyl.exceptions import CibylNotImplementedException
 from cibyl.output import Printer
 
 
@@ -29,7 +30,7 @@ class CIPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def print_system(self, system):
@@ -38,7 +39,7 @@ class CIPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def print_tenant(self, tenant):
@@ -47,7 +48,7 @@ class CIPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def print_project(self, project):
@@ -56,7 +57,7 @@ class CIPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def print_pipeline(self, pipeline):
@@ -65,7 +66,7 @@ class CIPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def print_job(self, job):
@@ -74,7 +75,7 @@ class CIPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def print_build(self, build):
@@ -83,7 +84,7 @@ class CIPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def print_test(self, test):
@@ -92,4 +93,4 @@ class CIPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException

--- a/cibyl/models/ci/printers/factory.py
+++ b/cibyl/models/ci/printers/factory.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 from cibyl.cli.output import OutputStyle
+from cibyl.exceptions import CibylNotImplementedException
 from cibyl.models.ci.printers.colored import CIColoredPrinter
 from cibyl.models.ci.printers.raw import CIRawPrinter
 
@@ -34,12 +35,13 @@ class CIPrinterFactory:
         :type verbosity: int
         :return: The printer.
         :rtype: :class:`cibyl.models.ci.printers.CIPrinter`
-        :raise NotImplementedError: If there is not printer for the desired
-            style.
+        :raise CibylNotImplementedException: If there is not printer for the
+        desired style.
         """
         if style == OutputStyle.TEXT:
             return CIRawPrinter(query, verbosity)
         elif style == OutputStyle.COLORIZED:
             return CIColoredPrinter(query, verbosity)
         else:
-            raise NotImplementedError(f'Unknown output style: {style}')
+            msg = f'Unknown output style: {style}'
+            raise CibylNotImplementedException(msg)

--- a/cibyl/models/ci/system.py
+++ b/cibyl/models/ci/system.py
@@ -18,6 +18,7 @@ from copy import deepcopy
 from typing import Dict, List, Type
 
 from cibyl.cli.argument import Argument
+from cibyl.exceptions import CibylNotImplementedException
 from cibyl.exceptions.model import NonSupportedModelType
 from cibyl.models.attribute import AttributeDictValue, AttributeListValue
 from cibyl.models.ci.job import Job
@@ -99,7 +100,7 @@ class System(Model):
         depending on the system type so it is left empty and will be overloaded
         by each type.
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     def add_source(self, source):
         """Add a source to the CI system.

--- a/cibyl/models/ci/system_factory.py
+++ b/cibyl/models/ci/system_factory.py
@@ -15,6 +15,7 @@
 """
 from enum import Enum
 
+from cibyl.exceptions import CibylNotImplementedException
 from cibyl.models.ci.system import JobsSystem
 from cibyl.models.ci.zuul.system import ZuulSystem
 from cibyl.utils.dicts import subset
@@ -57,4 +58,5 @@ class SystemFactory:
         if system_type == SystemType.ZUUL:
             return ZuulSystem(name=name, system_type=system_type, **args)
 
-        raise NotImplementedError(f"Unknown system type '{system_type}'")
+        msg = f"Unknown system type '{system_type}'"
+        raise CibylNotImplementedException(msg)

--- a/cibyl/plugins/openstack/printers/__init__.py
+++ b/cibyl/plugins/openstack/printers/__init__.py
@@ -15,6 +15,7 @@
 """
 from abc import ABC, abstractmethod
 
+from cibyl.exceptions import CibylNotImplementedException
 from cibyl.output import Printer
 
 
@@ -29,7 +30,7 @@ class OSPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def print_deployment(self, deployment):
@@ -38,7 +39,7 @@ class OSPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def print_node(self, node):
@@ -47,7 +48,7 @@ class OSPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def print_package(self, package):
@@ -56,7 +57,7 @@ class OSPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def print_service(self, service):
@@ -65,4 +66,4 @@ class OSPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException

--- a/cibyl/sources/source_factory.py
+++ b/cibyl/sources/source_factory.py
@@ -16,6 +16,7 @@
 import re
 from enum import Enum
 
+from cibyl.exceptions import CibylNotImplementedException
 from cibyl.exceptions.config import NonSupportedSourceKey
 from cibyl.sources.elasticsearch.api import ElasticSearchOSP
 from cibyl.sources.jenkins import Jenkins
@@ -72,4 +73,5 @@ class SourceFactory:
             if re_result:
                 raise NonSupportedSourceKey(source_type, re_result.group(1))
 
-        raise NotImplementedError(f"Unknown source type '{source_type}'")
+        msg = f"Unknown source type '{source_type}'"
+        raise CibylNotImplementedException(msg)

--- a/cibyl/sources/zuul/api.py
+++ b/cibyl/sources/zuul/api.py
@@ -15,6 +15,7 @@
 """
 from abc import ABC, abstractmethod
 
+from cibyl.exceptions import CibylNotImplementedException
 from cibyl.exceptions.source import SourceException
 from cibyl.sources.zuul.providers import JobsProvider, PipelinesProvider
 from cibyl.utils.io import Closeable
@@ -66,7 +67,7 @@ class ZuulJobAPI(Closeable, ABC):
         :return: URL where this job can be consulted at.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def builds(self):
@@ -75,7 +76,7 @@ class ZuulJobAPI(Closeable, ABC):
         :rtype: list[dict]
         :raises ZuulAPIError: If the request failed.
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
 
 class ZuulPipelineAPI(Closeable, JobsProvider, ABC):
@@ -119,7 +120,7 @@ class ZuulPipelineAPI(Closeable, JobsProvider, ABC):
         :rtype: list[:class:`ZuulJobAPI`]
         :raises ZuulAPIError: If the request failed.
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
 
 class ZuulProjectAPI(Closeable, PipelinesProvider, ABC):
@@ -163,7 +164,7 @@ class ZuulProjectAPI(Closeable, PipelinesProvider, ABC):
         :return: URL where this project can be consulted at.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def pipelines(self):
@@ -172,7 +173,7 @@ class ZuulProjectAPI(Closeable, PipelinesProvider, ABC):
         :rtype: list[:class:`ZuulPipelineAPI`]
         :raises ZuulAPIError: If the request failed.
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
 
 class ZuulTenantAPI(Closeable, JobsProvider, ABC):
@@ -206,7 +207,7 @@ class ZuulTenantAPI(Closeable, JobsProvider, ABC):
         :rtype: list[dict]
         :raises ZuulAPIError: If the request failed.
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def buildsets(self):
@@ -216,7 +217,7 @@ class ZuulTenantAPI(Closeable, JobsProvider, ABC):
         :rtype: list[dict]
         :raises ZuulAPIError: If the request failed.
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def projects(self):
@@ -227,7 +228,7 @@ class ZuulTenantAPI(Closeable, JobsProvider, ABC):
         :rtype: list[:class:`ZuulProjectAPI`]
         :raises ZuulAPIError: If the request failed.
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def jobs(self):
@@ -238,7 +239,7 @@ class ZuulTenantAPI(Closeable, JobsProvider, ABC):
         :rtype: list[:class:`ZuulJobAPI`]
         :raises ZuulAPIError: If the request failed.
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
 
 class ZuulAPI(Closeable, ABC):
@@ -254,7 +255,7 @@ class ZuulAPI(Closeable, ABC):
         :rtype: dict
         :raises ZuulAPIError: If the request failed.
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def tenants(self):
@@ -265,4 +266,4 @@ class ZuulAPI(Closeable, ABC):
         :rtype: list[:class:`ZuulTenantAPI`]
         :raises ZuulAPIError: If the request failed.
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException

--- a/cibyl/sources/zuul/providers.py
+++ b/cibyl/sources/zuul/providers.py
@@ -15,6 +15,8 @@
 """
 from abc import ABC, abstractmethod
 
+from cibyl.exceptions import CibylNotImplementedException
+
 
 class PipelinesProvider(ABC):
     """Represents an entity capable of retrieving information on pipelines.
@@ -27,7 +29,7 @@ class PipelinesProvider(ABC):
         :return: Name of the provider.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def pipelines(self):
@@ -35,7 +37,7 @@ class PipelinesProvider(ABC):
         :return: The pipelines from this entity.
         :rtype: :class:`cibyl.sources.zuul.api.ZuulPipelineAPI`
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
 
 class JobsProvider(ABC):
@@ -49,7 +51,7 @@ class JobsProvider(ABC):
         :return: Name of the provider.
         :rtype: str
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     @abstractmethod
     def jobs(self):
@@ -57,4 +59,4 @@ class JobsProvider(ABC):
         :return: The pipelines from this entity.
         :rtype: :class:`cibyl.sources.zuul.api.ZuulJobAPI`
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException

--- a/cibyl/utils/io.py
+++ b/cibyl/utils/io.py
@@ -15,6 +15,8 @@
 """
 from abc import ABC, abstractmethod
 
+from cibyl.exceptions import CibylNotImplementedException
+
 
 class Closeable(ABC):
     """Interface meant to release the resources hold by the object.
@@ -24,4 +26,4 @@ class Closeable(ABC):
     def close(self):
         """Releases any resources associated to this object.
         """
-        raise NotImplementedError
+        raise CibylNotImplementedException

--- a/tests/e2e/containers/__init__.py
+++ b/tests/e2e/containers/__init__.py
@@ -19,6 +19,8 @@ import requests
 from testcontainers.compose import DockerCompose
 from testcontainers.core.waiting_utils import wait_container_is_ready
 
+from cibyl.exceptions import CibylNotImplementedException
+
 
 @wait_container_is_ready()
 def wait_for(url):
@@ -43,7 +45,7 @@ class ComposedContainer(ABC):
 
     @abstractmethod
     def _wait_until_ready(self):
-        raise NotImplementedError
+        raise CibylNotImplementedException
 
     def start(self):
         self._container.start()

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -19,6 +19,7 @@ from unittest.mock import Mock
 import cibyl
 from cibyl.cli.main import raw_parsing
 from cibyl.cli.output import OutputStyle
+from cibyl.exceptions import CibylNotImplementedException
 from cibyl.exceptions.cli import InvalidArgument
 
 
@@ -66,7 +67,7 @@ class TestRawParsing(TestCase):
         """
 
         def raise_error(_):
-            raise NotImplementedError
+            raise CibylNotImplementedException
 
         output = 'invalid'
 

--- a/tests/unit/sources/test_source_factory.py
+++ b/tests/unit/sources/test_source_factory.py
@@ -15,6 +15,7 @@
 """
 from unittest import TestCase
 
+from cibyl.exceptions import CibylNotImplementedException
 from cibyl.sources.elasticsearch.api import ElasticSearchOSP
 from cibyl.sources.jenkins import Jenkins
 from cibyl.sources.jenkins_job_builder import JenkinsJobBuilder
@@ -64,5 +65,6 @@ class TestSourceFactory(TestCase):
 
     def test_create_unknown_source(self):
         """Checks that an exception is raise if the source type is unknown."""
-        self.assertRaises(NotImplementedError, SourceFactory.create_source,
+        self.assertRaises(CibylNotImplementedException,
+                          SourceFactory.create_source,
                           "unknown", "zuul_source")


### PR DESCRIPTION
This PR addresses two issues:
- Replace NotImplementedError with custom exception
Some parts of the code were raising NotImplementedError, which was showing the
full traceback to the user.

- Move parse output style after setup cibyl exceptions
Similarly, running cibyl -f invented_format was also showing the traceback,
since it was raised before setting up the quiet exceptions.

The PR touches many files, but most are simple search and replace changes.
