### PR TITLE
Add ML2 driver type to the spec in jenkins source

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -89,6 +89,13 @@ class Deployment(Model):
                                    description="Whether dvr is used in the "
                                                "deployment")]
         },
+        'ml2_driver': {
+            'attr_type': str,
+            'arguments': [Argument(name='--ml2-driver', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   description="ML2 driver used in the "
+                                               "deployment")]
+        },
         'tls_everywhere': {
             'attr_type': str,
             'arguments': [Argument(name='--tls-everywhere', arg_type=str,
@@ -116,13 +123,15 @@ class Deployment(Model):
                  nodes: Dict[str, Node], services: Dict[str, Service],
                  ip_version: str = None, topology: str = None,
                  network_backend: str = None, storage_backend: str = None,
-                 dvr: str = None, tls_everywhere: str = None):
+                 dvr: str = None, tls_everywhere: str = None,
+                 ml2_driver: str = None):
         super().__init__({'release': release, 'infra_type': infra_type,
                           'nodes': nodes, 'services': services,
                           'ip_version': ip_version, 'topology': topology,
                           'network_backend': network_backend,
                           'storage_backend': storage_backend,
-                          'dvr': dvr, 'tls_everywhere': tls_everywhere})
+                          'dvr': dvr, 'tls_everywhere': tls_everywhere,
+                          'ml2_driver': ml2_driver})
 
     def add_node(self, node: Node):
         """Add a node to the deployment.
@@ -167,6 +176,8 @@ class Deployment(Model):
             self.dvr.value = other.dvr.value
         if not self.tls_everywhere.value:
             self.tls_everywhere.value = other.tls_everywhere.value
+        if not self.ml2_driver.value:
+            self.ml2_driver.value = other.ml2_driver.value
         for node in other.nodes.values():
             self.add_node(node)
         for service in other.services.values():

--- a/cibyl/plugins/openstack/printers/colored.py
+++ b/cibyl/plugins/openstack/printers/colored.py
@@ -62,36 +62,41 @@ class OSColoredPrinter(OSPrinter):
             printer.add(self._palette.blue('Infra type: '), 1)
             printer[-1].append(deployment.infra_type)
 
+        if deployment.topology.value:
+            is_empty_deployment = False
+            printer.add(self._palette.blue('Topology: '), 1)
+            printer[-1].append(deployment.topology)
+
         ip_version = deployment.ip_version.value
         if ip_version and ip_version != "unknown":
             is_empty_deployment = False
             printer.add(self._palette.blue('IP version: '), 1)
             printer[-1].append(deployment.ip_version)
 
-        if deployment.topology.value:
-            is_empty_deployment = False
-            printer.add(self._palette.blue('Topology: '), 1)
-            printer[-1].append(deployment.topology)
-
         if deployment.network_backend.value:
             is_empty_deployment = False
             printer.add(self._palette.blue('Network backend: '), 1)
             printer[-1].append(deployment.network_backend)
-
-        if deployment.storage_backend.value:
-            is_empty_deployment = False
-            printer.add(self._palette.blue('Storage backend: '), 1)
-            printer[-1].append(deployment.storage_backend)
 
         if deployment.dvr.value:
             is_empty_deployment = False
             printer.add(self._palette.blue('DVR: '), 1)
             printer[-1].append(deployment.dvr)
 
+        if deployment.ml2_driver.value:
+            is_empty_deployment = False
+            printer.add(self._palette.blue('ML2 driver: '), 1)
+            printer[-1].append(deployment.ml2_driver)
+
         if deployment.tls_everywhere.value:
             is_empty_deployment = False
             printer.add(self._palette.blue('TLS everywhere: '), 1)
             printer[-1].append(deployment.tls_everywhere)
+
+        if deployment.storage_backend.value:
+            is_empty_deployment = False
+            printer.add(self._palette.blue('Storage backend: '), 1)
+            printer[-1].append(deployment.storage_backend)
 
         if deployment.nodes.values():
             is_empty_deployment = False

--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -581,7 +581,7 @@ accurate results", len(jobs_found))
         :param job: Dictionary representation of a jenkins job
         :type job: dict
         """
-        message = "Unable to find information"
+        message = "N/A"
         for attr in self.deployment_attr:
             if not job.get(attr):
                 job[attr] = message

--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -393,9 +393,7 @@ accurate results", len(jobs_found))
                 tls = overcloud.get("tls", {})
                 job["tls_everywhere"] = str(tls.get("everywhere", ""))
             if "ml2_driver" in kwargs or spec:
-                job["ml2_driver"] = ""
-                if network.get("ovn"):
-                    job["ml2_driver"] = "ovn"
+                job["ml2_driver"] = "ovn"
                 if network.get("ovs"):
                     job["ml2_driver"] = "ovs"
 

--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -112,7 +112,7 @@ class Jenkins:
     deployment_attr = ["topology", "release",
                        "network_backend", "storage_backend",
                        "infra_type", "dvr", "ip_version",
-                       "tls_everywhere"]
+                       "tls_everywhere", "ml2_driver"]
 
     def add_job_info_from_name(self, job:  Dict[str, str], **kwargs):
         """Add information to the job by using regex on the job name. Check if
@@ -306,6 +306,7 @@ accurate results", len(jobs_found))
                                     nodes=job.get("nodes", {}),
                                     services=job.get("services", {}),
                                     ip_version=job.get("ip_version", ""),
+                                    ml2_driver=job.get("ml2_driver", ""),
                                     topology=topology,
                                     network_backend=network_backend,
                                     storage_backend=storage_backend,
@@ -391,6 +392,12 @@ accurate results", len(jobs_found))
             if "tls_everywhere" in kwargs or spec:
                 tls = overcloud.get("tls", {})
                 job["tls_everywhere"] = str(tls.get("everywhere", ""))
+            if "ml2_driver" in kwargs or spec:
+                job["ml2_driver"] = ""
+                if network.get("ovn"):
+                    job["ml2_driver"] = "ovn"
+                if network.get("ovs"):
+                    job["ml2_driver"] = "ovs"
 
         except JenkinsError:
             LOG.debug("Found no artifact %s for job %s", artifact_path,

--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -444,6 +444,10 @@ accurate results", len(jobs_found))
                           job_name)
 
         if self.job_missing_deployment_info(job):
+            if spec:
+                LOG.warning("Some logs are missing for job %s, information "
+                            "will be retrieved from the job name, but will "
+                            "be incomplete", job_name)
             LOG.debug("Resorting to get deployment information from job name"
                       " for job %s", job_name)
             self.add_job_info_from_name(job, **kwargs)

--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -91,8 +91,16 @@ Arguments Matrix
      - |:black_square_button:|
      - |:black_square_button:|
    * - --dvr
-     - | Does the deployment uses
+     - | Does the deployment use
        | Distributed Virtual Router
+     - |:ballot_box_with_check:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+   * - --ml2-driver
+     - | Which ml2 driver does
+       | the deployment use
      - |:ballot_box_with_check:|
      - |:black_square_button:|
      - |:black_square_button:|

--- a/tests/unit/plugins/openstack/sources/test_jenkins.py
+++ b/tests/unit/plugins/openstack/sources/test_jenkins.py
@@ -20,7 +20,6 @@ from unittest.mock import Mock, call
 import yaml
 
 from cibyl.cli.argument import Argument
-from cibyl.cli.main import enable_plugins
 from cibyl.exceptions.jenkins import JenkinsError
 from cibyl.plugins.openstack.container import Container
 from cibyl.plugins.openstack.node import Node
@@ -53,7 +52,7 @@ def get_yaml_from_topology_string(topology):
 
 
 def get_yaml_overcloud(ip, release, storage_backend, network_backend, dvr,
-                       tls_everywhere, infra_type):
+                       tls_everywhere, infra_type, ml2_driver=None):
     """Provide a yaml representation for the paremeters obtained from an
     infrared overcloud-install.yml file.
 
@@ -81,6 +80,12 @@ def get_yaml_overcloud(ip, release, storage_backend, network_backend, dvr,
         storage = {"backend": storage_backend}
         overcloud["storage"] = storage
     network = {"backend": network_backend, "protocol": ip, "dvr": dvr}
+    if ml2_driver == "ovn":
+        network["ovn"] = True
+        network["ovs"] = False
+    elif ml2_driver == "ovs":
+        network["ovs"] = True
+        network["ovn"] = False
     overcloud["network"] = network
     if tls_everywhere != "":
         tls = {"everywhere": tls_everywhere}
@@ -88,11 +93,12 @@ def get_yaml_overcloud(ip, release, storage_backend, network_backend, dvr,
     return yaml.dump({"install": overcloud})
 
 
+
+
 class TestJenkinsSourceOpenstackPlugin(OpenstackPluginWithJobSystem):
     """Tests for :class:`Jenkins` with openstack plugin."""
 
     def setUp(self):
-        enable_plugins(['openstack'])
         self.jenkins = Jenkins("url", "user", "token")
 
     def test_get_deployment(self):
@@ -779,6 +785,68 @@ tripleo_ironic_conductor.service loaded    active     running
             self.assertEqual(deployment.topology.value, topology)
             self.assertEqual(deployment.dvr.value, dvr)
 
+    def test_get_deployment_filter_ml2_driver(self):
+        """ Test that get_deployment filters properly according to the value of
+        the ml2_driver.
+        """
+        job_names = ['test_17.3_ipv4_job', 'test_16_ipv6_job', 'test_job']
+        ip_versions = ['4', '6', 'unknown']
+        releases = ['17.3', '16', '']
+        dvr_status = ['True', 'True', '']
+        topologies = ["compute:2,controller:3", "compute:1,controller:2",
+                      "compute:2,controller:2"]
+
+        response = {'jobs': [{'_class': 'folder'}]}
+        logs_url = 'href="link">Browse logs'
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastCompletedBuild': {'description':
+                                                            logs_url}})
+        artifacts = [
+                get_yaml_from_topology_string(topologies[0]),
+                get_yaml_overcloud(ip_versions[0], releases[0],
+                                   "ceph", "geneve", dvr_status[0], False, "",
+                                   ml2_driver="ovn"),
+                get_yaml_from_topology_string(topologies[1]),
+                get_yaml_overcloud(ip_versions[1], releases[1],
+                                   "ceph", "geneve", dvr_status[1],
+                                   False, "", ml2_driver="ovs"),
+                get_yaml_from_topology_string(topologies[2]),
+                get_yaml_overcloud(ip_versions[2], releases[2],
+                                   "ceph", "geneve", dvr_status[2],
+                                   False, "")]
+        # one call to get_packages_node and get_containers_node per node, plus
+        # one to get_services
+
+        self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
+
+        args = {
+            "topology": Argument("topology", str, "", value=[]),
+            "release": Argument("release", str, "", value=[]),
+            "infra_type": Argument("infra_type", str, "", value=[]),
+            "nodes": Argument("nodes", str, "", value=[]),
+            "ip_version": Argument("ip_version", str, "", value=[]),
+            "dvr": Argument("dvr", str, "", value=[]),
+            "ml2_driver": Argument("ml2_driver", str, "", value=["ovn"]),
+            "tls_everywhere": Argument("tls_everywhere", str, "", value=[]),
+            "network_backend": Argument("network_backend", str, "", value=[]),
+            "storage_backend": Argument("storage_backend", str, "", value=[])
+        }
+        jobs = self.jenkins.get_deployment(**args)
+        self.assertEqual(len(jobs), 1)
+        job_name = "test_17.3_ipv4_job"
+        job = jobs[job_name]
+        deployment = job.deployment.value
+        self.assertEqual(job.name.value, job_name)
+        self.assertEqual(job.url.value, "url")
+        self.assertEqual(len(job.builds.value), 0)
+        self.assertEqual(deployment.release.value, releases[0])
+        self.assertEqual(deployment.ip_version.value, ip_versions[0])
+        self.assertEqual(deployment.topology.value, topologies[0])
+        self.assertEqual(deployment.dvr.value, dvr_status[0])
+        self.assertEqual(deployment.ml2_driver.value, "ovn")
+
     def test_get_deployment_filter_tls(self):
         """Test that get_deployment filters by tls_everywhere."""
         job_names = ['test_17.3_ipv4_job_2comp_1cont_tls',
@@ -1249,7 +1317,7 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(topologies[0]),
                 get_yaml_overcloud(ip_versions[0], releases[0],
                                    "ceph", "geneve", False,
-                                   False, "path/to/ovb")]
+                                   False, "path/to/ovb", ml2_driver="ovn")]
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -1269,6 +1337,7 @@ tripleo_ironic_conductor.service loaded    active     running
             self.assertEqual(deployment.storage_backend.value, "ceph")
             self.assertEqual(deployment.network_backend.value, "geneve")
             self.assertEqual(deployment.dvr.value, "False")
+            self.assertEqual(deployment.ml2_driver.value, "ovn")
             self.assertEqual(deployment.tls_everywhere.value, "False")
             self.assertEqual(deployment.infra_type.value, "ovb")
             for component in topology.split(","):

--- a/tests/unit/plugins/openstack/sources/test_jenkins.py
+++ b/tests/unit/plugins/openstack/sources/test_jenkins.py
@@ -93,8 +93,6 @@ def get_yaml_overcloud(ip, release, storage_backend, network_backend, dvr,
     return yaml.dump({"install": overcloud})
 
 
-
-
 class TestJenkinsSourceOpenstackPlugin(OpenstackPluginWithJobSystem):
     """Tests for :class:`Jenkins` with openstack plugin."""
 
@@ -807,11 +805,11 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(topologies[0]),
                 get_yaml_overcloud(ip_versions[0], releases[0],
                                    "ceph", "geneve", dvr_status[0], False, "",
-                                   ml2_driver="ovn"),
+                                   ml2_driver="ovs"),
                 get_yaml_from_topology_string(topologies[1]),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", dvr_status[1],
-                                   False, "", ml2_driver="ovs"),
+                                   False, "", ml2_driver="ovn"),
                 get_yaml_from_topology_string(topologies[2]),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", dvr_status[2],
@@ -828,7 +826,7 @@ tripleo_ironic_conductor.service loaded    active     running
             "nodes": Argument("nodes", str, "", value=[]),
             "ip_version": Argument("ip_version", str, "", value=[]),
             "dvr": Argument("dvr", str, "", value=[]),
-            "ml2_driver": Argument("ml2_driver", str, "", value=["ovn"]),
+            "ml2_driver": Argument("ml2_driver", str, "", value=["ovs"]),
             "tls_everywhere": Argument("tls_everywhere", str, "", value=[]),
             "network_backend": Argument("network_backend", str, "", value=[]),
             "storage_backend": Argument("storage_backend", str, "", value=[])
@@ -845,7 +843,7 @@ tripleo_ironic_conductor.service loaded    active     running
         self.assertEqual(deployment.ip_version.value, ip_versions[0])
         self.assertEqual(deployment.topology.value, topologies[0])
         self.assertEqual(deployment.dvr.value, dvr_status[0])
-        self.assertEqual(deployment.ml2_driver.value, "ovn")
+        self.assertEqual(deployment.ml2_driver.value, "ovs")
 
     def test_get_deployment_filter_tls(self):
         """Test that get_deployment filters by tls_everywhere."""

--- a/tests/unit/plugins/openstack/sources/test_jenkins.py
+++ b/tests/unit/plugins/openstack/sources/test_jenkins.py
@@ -1373,7 +1373,7 @@ tripleo_ironic_conductor.service loaded    active     running
         jobs = self.jenkins.get_deployment(spec=spec)
         self.assertEqual(len(jobs), 1)
         job_name = "test_17.3_ipv4_job"
-        missing_info = "Unable to find information"
+        missing_info = "N/A"
         job = jobs[job_name]
         deployment = job.deployment.value
         self.assertEqual(job.name.value, job_name)
@@ -1413,7 +1413,7 @@ tripleo_ironic_conductor.service loaded    active     running
         spec = Argument("spec", str, "", value=[job_name])
         jobs = self.jenkins.get_deployment(spec=spec)
         self.assertEqual(len(jobs), 1)
-        missing_info = "Unable to find information"
+        missing_info = "N/A"
         job = jobs[job_name]
         deployment = job.deployment.value
         self.assertEqual(job.name.value, job_name)

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -732,8 +732,6 @@ class TestJenkinsSource(TestCase):
         )
 
 
-
-
 class TestFilters(TestCase):
     """Tests for filter functions in jenkins source module."""
     def test_filter_jobs(self):

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -732,6 +732,8 @@ class TestJenkinsSource(TestCase):
         )
 
 
+
+
 class TestFilters(TestCase):
     """Tests for filter functions in jenkins source module."""
     def test_filter_jobs(self):

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ commands =
     coverage erase
     coverage run -a -m unittest discover tests/unit
     coverage run -a -m unittest discover tests/intr
-    coverage report --fail-under=90
+    coverage report -m --fail-under=90
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
Support querying by ml2 driver type in get_deployment and add it to the
spec option.
