### PR TITLE
Simplifying how exceptions are handled at a high-level.

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -23,6 +23,7 @@ from cibyl.exceptions.cli import InvalidArgument
 from cibyl.exceptions.config import ConfigurationNotFound
 from cibyl.orchestrator import Orchestrator
 from cibyl.plugins import extend_models
+from cibyl.utils.colors import Colors
 from cibyl.utils.logger import configure_logging
 
 LOG = logging.getLogger(__name__)
@@ -63,9 +64,8 @@ def raw_parsing(arguments):
         elif item in ('-f', '--output-format'):
             args["output_style"] = arguments[i + 2]
 
-    if not args['debug']:
-        CibylException.setup_quiet_exceptions()
     setup_output_format(args)
+
     return args
 
 
@@ -123,12 +123,18 @@ def run_cibyl():
 
 def main():
     """CLI main entry."""
+    debug = False
+
+    if '--debug' in sys.argv:
+        debug = True
+
     try:
         run_cibyl()
     except CibylException as ex:
-        raise ex
-    except Exception as ex:
-        raise CibylException from ex
+        if debug:
+            raise ex
+
+        print(Colors.red(ex.message))
 
 
 if __name__ == "__main__":

--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -18,7 +18,7 @@ import sys
 
 from cibyl.cli.output import OutputStyle
 from cibyl.cli.query import get_query_type
-from cibyl.exceptions import CibylException, CibylNotImplementedException
+from cibyl.exceptions import CibylException
 from cibyl.exceptions.cli import InvalidArgument
 from cibyl.exceptions.config import ConfigurationNotFound
 from cibyl.orchestrator import Orchestrator
@@ -74,7 +74,7 @@ def setup_output_format(args):
     user_output_format = args["output_style"]
     try:
         args["output_style"] = OutputStyle.from_key(user_output_format)
-    except CibylNotImplementedException:
+    except NotImplementedError:
         msg = f'Unknown output format: {user_output_format}'
         raise InvalidArgument(msg) from None
 

--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -79,7 +79,8 @@ def setup_output_format(args):
         raise InvalidArgument(msg) from None
 
 
-def run_cibyl():
+def main():
+    """CLI main entry."""
     # We parse it from sys.argv instead of argparse parser because we want
     # to run the app parser only once, after we update it with the loaded
     # arguments from the CI models based on the loaded configuration file
@@ -127,11 +128,6 @@ def run_cibyl():
             raise ex
 
         print(Colors.red(ex.message))
-
-
-def main():
-    """CLI main entry."""
-    run_cibyl()
 
 
 if __name__ == "__main__":

--- a/cibyl/cli/output.py
+++ b/cibyl/cli/output.py
@@ -15,8 +15,6 @@
 """
 from enum import Enum
 
-from cibyl.exceptions import CibylNotImplementedException
-
 
 class OutputStyle(Enum):
     """Lists all supported output formats by the CLI.
@@ -38,7 +36,7 @@ class OutputStyle(Enum):
         :type key: Any
         :return: The correspondent style.
         :rtype: :class:`OutputStyle`
-        :raise CibylNotImplementedException: If no style is present for the
+        :raise NotImplementedError: If no style is present for the
         given key.
         """
         if key == 'text':
@@ -46,4 +44,4 @@ class OutputStyle(Enum):
         elif key == 'colorized':
             return OutputStyle.COLORIZED
         else:
-            raise CibylNotImplementedException(f'Unknown format: {key}')
+            raise NotImplementedError(f'Unknown format: {key}')

--- a/cibyl/exceptions/__init__.py
+++ b/cibyl/exceptions/__init__.py
@@ -38,7 +38,3 @@ class CibylException(Exception):
                 sys.__excepthook__(kind, message, traceback)
 
         sys.excepthook = quiet_hook
-
-
-class CibylNotImplementedException(CibylException, NotImplementedError):
-    """Custom NotImplementedError that inherits the quiet_extensions setup."""

--- a/cibyl/exceptions/__init__.py
+++ b/cibyl/exceptions/__init__.py
@@ -13,9 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-import sys
-
-from cibyl.utils.colors import Colors
 
 
 class CibylException(Exception):
@@ -25,5 +22,8 @@ class CibylException(Exception):
 
     def __init__(self, message=''):
         """Constructor.
+
+        :param message: The reason for this error.
+        :type message: str
         """
         self.message = message

--- a/cibyl/exceptions/__init__.py
+++ b/cibyl/exceptions/__init__.py
@@ -20,21 +20,10 @@ from cibyl.utils.colors import Colors
 
 class CibylException(Exception):
     """Parent class for all cibyl exceptions for easier control of the
-    exceptions' representation."""
+    exceptions' representation.
+    """
+
     def __init__(self, message=''):
-        """Constructor."""
-        super().__init__(*[message])
-
-    @staticmethod
-    def setup_quiet_exceptions():
-        """Sets up quiet exceptions, without tracebacks, if they are
-        of the type CibylException
+        """Constructor.
         """
-
-        def quiet_hook(kind, message, traceback):
-            if CibylException in kind.__bases__:
-                print(Colors.red(f'{message}'))
-            else:
-                sys.__excepthook__(kind, message, traceback)
-
-        sys.excepthook = quiet_hook
+        self.message = message

--- a/cibyl/exceptions/config.py
+++ b/cibyl/exceptions/config.py
@@ -35,7 +35,7 @@ class ConfigurationNotFound(CibylException):
 
     def __init__(self, paths):
         if paths:
-            paths = f" at: {paths}"
+            paths = f" at: '{paths}'"
         else:
             paths = ""
         self.message = f"""Could not find configuration file{paths}.

--- a/cibyl/models/ci/base/system.py
+++ b/cibyl/models/ci/base/system.py
@@ -18,7 +18,6 @@ from copy import deepcopy
 from typing import Dict, List, Type
 
 from cibyl.cli.argument import Argument
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.exceptions.model import NonSupportedModelType
 from cibyl.models.attribute import AttributeDictValue, AttributeListValue
 from cibyl.models.ci.base.job import Job
@@ -98,7 +97,7 @@ class System(Model):
         depending on the system type so it is left empty and will be overloaded
         by each type.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     def add_source(self, source):
         """Add a source to the CI system.

--- a/cibyl/models/ci/system_factory.py
+++ b/cibyl/models/ci/system_factory.py
@@ -15,7 +15,6 @@
 """
 from enum import Enum
 
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.models.ci.base.system import JobsSystem
 from cibyl.models.ci.zuul.system import ZuulSystem
 
@@ -52,4 +51,4 @@ class SystemFactory:
             return ZuulSystem(name=name, system_type=system_type, **kwargs)
 
         msg = f"Unknown system type '{system_type}'"
-        raise CibylNotImplementedException(msg)
+        raise NotImplementedError(msg)

--- a/cibyl/outputs/cli/ci/factory.py
+++ b/cibyl/outputs/cli/ci/factory.py
@@ -14,7 +14,6 @@
 #    under the License.
 """
 from cibyl.cli.output import OutputStyle
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.outputs.cli.ci.colored import CIColoredPrinter
 from cibyl.utils.colors import ClearText
 
@@ -35,7 +34,7 @@ class CIPrinterFactory:
         :type verbosity: int
         :return: The printer.
         :rtype: :class:`cibyl.models.ci.printers.CIPrinter`
-        :raise CibylNotImplementedException: If there is no printer for the
+        :raise NotImplementedError: If there is no printer for the
         desired style.
         """
         if style == OutputStyle.TEXT:
@@ -51,4 +50,4 @@ class CIPrinterFactory:
             )
         else:
             msg = f'Unknown output style: {style}'
-            raise CibylNotImplementedException(msg)
+            raise NotImplementedError(msg)

--- a/cibyl/outputs/cli/ci/printer.py
+++ b/cibyl/outputs/cli/ci/printer.py
@@ -15,7 +15,6 @@
 """
 from abc import ABC, abstractmethod
 
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.outputs.cli.printer import Printer
 
 
@@ -31,4 +30,4 @@ class CIPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError

--- a/cibyl/outputs/cli/ci/systems/printer.py
+++ b/cibyl/outputs/cli/ci/systems/printer.py
@@ -15,7 +15,6 @@
 """
 from abc import ABC, abstractmethod
 
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.outputs.cli.printer import Printer
 
 
@@ -31,4 +30,4 @@ class CISystemPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError

--- a/cibyl/plugins/openstack/printers/__init__.py
+++ b/cibyl/plugins/openstack/printers/__init__.py
@@ -15,7 +15,6 @@
 """
 from abc import ABC, abstractmethod
 
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.outputs.cli.printer import Printer
 
 
@@ -30,7 +29,7 @@ class OSPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def print_deployment(self, deployment):
@@ -39,7 +38,7 @@ class OSPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def print_node(self, node):
@@ -48,7 +47,7 @@ class OSPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def print_package(self, package):
@@ -57,7 +56,7 @@ class OSPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def print_service(self, service):
@@ -66,4 +65,4 @@ class OSPrinter(Printer, ABC):
         :return: Textual representation of the provided model.
         :rtype: str
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError

--- a/cibyl/sources/source_factory.py
+++ b/cibyl/sources/source_factory.py
@@ -16,7 +16,6 @@
 import re
 from enum import Enum
 
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.exceptions.config import NonSupportedSourceKey
 from cibyl.sources.elasticsearch.api import ElasticSearchOSP
 from cibyl.sources.jenkins import Jenkins
@@ -74,4 +73,4 @@ class SourceFactory:
                 raise NonSupportedSourceKey(source_type, re_result.group(1))
 
         msg = f"Unknown source type '{source_type}'"
-        raise CibylNotImplementedException(msg)
+        raise NotImplementedError(msg)

--- a/cibyl/sources/zuul/api.py
+++ b/cibyl/sources/zuul/api.py
@@ -15,7 +15,6 @@
 """
 from abc import ABC, abstractmethod
 
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.exceptions.source import SourceException
 from cibyl.sources.zuul.providers import JobsProvider, PipelinesProvider
 from cibyl.utils.io import Closeable
@@ -67,7 +66,7 @@ class ZuulJobAPI(Closeable, ABC):
         :return: URL where this job can be consulted at.
         :rtype: str
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def variants(self):
@@ -76,7 +75,7 @@ class ZuulJobAPI(Closeable, ABC):
         :rtype: list[dict]
         :raises ZuulAPIError: If the request failed.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def builds(self):
@@ -85,7 +84,7 @@ class ZuulJobAPI(Closeable, ABC):
         :rtype: list[dict]
         :raises ZuulAPIError: If the request failed.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
 
 class ZuulPipelineAPI(Closeable, JobsProvider, ABC):
@@ -129,7 +128,7 @@ class ZuulPipelineAPI(Closeable, JobsProvider, ABC):
         :rtype: list[:class:`ZuulJobAPI`]
         :raises ZuulAPIError: If the request failed.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
 
 class ZuulProjectAPI(Closeable, PipelinesProvider, ABC):
@@ -173,7 +172,7 @@ class ZuulProjectAPI(Closeable, PipelinesProvider, ABC):
         :return: URL where this project can be consulted at.
         :rtype: str
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def pipelines(self):
@@ -182,7 +181,7 @@ class ZuulProjectAPI(Closeable, PipelinesProvider, ABC):
         :rtype: list[:class:`ZuulPipelineAPI`]
         :raises ZuulAPIError: If the request failed.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
 
 class ZuulTenantAPI(Closeable, JobsProvider, ABC):
@@ -216,7 +215,7 @@ class ZuulTenantAPI(Closeable, JobsProvider, ABC):
         :rtype: list[dict]
         :raises ZuulAPIError: If the request failed.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def buildsets(self):
@@ -226,7 +225,7 @@ class ZuulTenantAPI(Closeable, JobsProvider, ABC):
         :rtype: list[dict]
         :raises ZuulAPIError: If the request failed.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def projects(self):
@@ -237,7 +236,7 @@ class ZuulTenantAPI(Closeable, JobsProvider, ABC):
         :rtype: list[:class:`ZuulProjectAPI`]
         :raises ZuulAPIError: If the request failed.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def jobs(self):
@@ -248,7 +247,7 @@ class ZuulTenantAPI(Closeable, JobsProvider, ABC):
         :rtype: list[:class:`ZuulJobAPI`]
         :raises ZuulAPIError: If the request failed.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
 
 class ZuulAPI(Closeable, ABC):
@@ -264,7 +263,7 @@ class ZuulAPI(Closeable, ABC):
         :rtype: dict
         :raises ZuulAPIError: If the request failed.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def tenants(self):
@@ -275,4 +274,4 @@ class ZuulAPI(Closeable, ABC):
         :rtype: list[:class:`ZuulTenantAPI`]
         :raises ZuulAPIError: If the request failed.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError

--- a/cibyl/sources/zuul/providers.py
+++ b/cibyl/sources/zuul/providers.py
@@ -15,8 +15,6 @@
 """
 from abc import ABC, abstractmethod
 
-from cibyl.exceptions import CibylNotImplementedException
-
 
 class PipelinesProvider(ABC):
     """Represents an entity capable of retrieving information on pipelines.
@@ -29,7 +27,7 @@ class PipelinesProvider(ABC):
         :return: Name of the provider.
         :rtype: str
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def pipelines(self):
@@ -37,7 +35,7 @@ class PipelinesProvider(ABC):
         :return: The pipelines from this entity.
         :rtype: :class:`cibyl.sources.zuul.api.ZuulPipelineAPI`
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
 
 class JobsProvider(ABC):
@@ -51,7 +49,7 @@ class JobsProvider(ABC):
         :return: Name of the provider.
         :rtype: str
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     @abstractmethod
     def jobs(self):
@@ -59,4 +57,4 @@ class JobsProvider(ABC):
         :return: The pipelines from this entity.
         :rtype: :class:`cibyl.sources.zuul.api.ZuulJobAPI`
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError

--- a/cibyl/sources/zuul/query.py
+++ b/cibyl/sources/zuul/query.py
@@ -19,7 +19,6 @@ License:
 import logging
 
 from cibyl.cli.query import QueryType, get_query_type
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.zuul.tenant import Tenant
 from cibyl.sources.zuul.models import ModelBuilder
@@ -291,7 +290,7 @@ def handle_query(zuul, **kwargs):
     handler = handlers.get(query)
 
     if not handler:
-        raise CibylNotImplementedException(f'Unsupported query: {query}')
+        raise NotImplementedError(f'Unsupported query: {query}')
 
     model = handler(zuul, **kwargs)
 

--- a/cibyl/utils/io.py
+++ b/cibyl/utils/io.py
@@ -15,8 +15,6 @@
 """
 from abc import ABC, abstractmethod
 
-from cibyl.exceptions import CibylNotImplementedException
-
 
 class Closeable(ABC):
     """Interface meant to release the resources hold by the object.
@@ -26,4 +24,4 @@ class Closeable(ABC):
     def close(self):
         """Releases any resources associated to this object.
         """
-        raise CibylNotImplementedException
+        raise NotImplementedError

--- a/tests/e2e/containers/__init__.py
+++ b/tests/e2e/containers/__init__.py
@@ -19,8 +19,6 @@ import requests
 from testcontainers.compose import DockerCompose
 from testcontainers.core.waiting_utils import wait_container_is_ready
 
-from cibyl.exceptions import CibylNotImplementedException
-
 
 @wait_container_is_ready()
 def wait_for(url):
@@ -45,7 +43,7 @@ class ComposedContainer(ABC):
 
     @abstractmethod
     def _wait_until_ready(self):
-        raise CibylNotImplementedException
+        raise NotImplementedError
 
     def start(self):
         self._container.start()

--- a/tests/intr/cli/test_config.py
+++ b/tests/intr/cli/test_config.py
@@ -32,7 +32,8 @@ class TestConfig(TestCase):
         with NamedTemporaryFile() as config_file:
             sys.argv = [
                 '',
-                '--config', config_file.name
+                '--config', config_file.name,
+                '--debug'
             ]
 
             self.assertRaises(EmptyConfiguration, main)

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -19,7 +19,6 @@ from unittest.mock import Mock
 import cibyl
 from cibyl.cli.main import raw_parsing
 from cibyl.cli.output import OutputStyle
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.exceptions.cli import InvalidArgument
 
 
@@ -67,7 +66,7 @@ class TestRawParsing(TestCase):
         """
 
         def raise_error(_):
-            raise CibylNotImplementedException
+            raise NotImplementedError
 
         output = 'invalid'
 

--- a/tests/unit/outputs/cli/ci/test_factory.py
+++ b/tests/unit/outputs/cli/ci/test_factory.py
@@ -17,7 +17,6 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from cibyl.cli.output import OutputStyle
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.outputs.cli.ci.factory import CIPrinterFactory
 from cibyl.utils.colors import ClearText, DefaultPalette
 
@@ -29,7 +28,7 @@ class TestCIPrinterFactory(TestCase):
 
         factory = CIPrinterFactory()
 
-        with self.assertRaises(CibylNotImplementedException):
+        with self.assertRaises(NotImplementedError):
             factory.from_style(-1, query, verbosity)
 
     def test_returns_clear_text_printer(self):

--- a/tests/unit/sources/test_source_factory.py
+++ b/tests/unit/sources/test_source_factory.py
@@ -15,7 +15,6 @@
 """
 from unittest import TestCase
 
-from cibyl.exceptions import CibylNotImplementedException
 from cibyl.sources.elasticsearch.api import ElasticSearchOSP
 from cibyl.sources.jenkins import Jenkins
 from cibyl.sources.jenkins_job_builder import JenkinsJobBuilder
@@ -65,6 +64,6 @@ class TestSourceFactory(TestCase):
 
     def test_create_unknown_source(self):
         """Checks that an exception is raise if the source type is unknown."""
-        self.assertRaises(CibylNotImplementedException,
+        self.assertRaises(NotImplementedError,
                           SourceFactory.create_source,
                           "unknown", "zuul_source")


### PR DESCRIPTION
Regarding exceptions, I do not want to have to redefine all standard errors for Cibyl to handle properly. I believe that instead of creating new types, we should have better handles that do the job for us. I have been experimenting a little bit with the current solution that we have, based on 'sys.excepthook', and I have not been able to have errors go through that handle. So, here I am providing a new solution that avoids that hook and is much simpler to extend and understand. Right now, the idea is for it to do the same as before, we can extend this moving forward with more conditions that we want to apply.

On this pull request:
- Removed the 'sys.excepthook' handler.
- Simply wrap the 'main' function on a try/except.
- Only print the stack trace of CibylException if '--debug' is given.
- Removed CibylNotImplementedError and go back to the standard NotImplementedError.