### PR TITLE
Avoid overwriting config file when running e2e tests.

### DIFF
--- a/tests/e2e/test_config.py
+++ b/tests/e2e/test_config.py
@@ -20,12 +20,14 @@ from unittest.mock import Mock
 from cibyl.cli.main import main
 from tests.e2e.containers.httpd import HTTPDContainer
 from tests.e2e.fixtures import EndToEndTest
+from tests.utils.decorators import min_test_level
 
 
 class TestConfig(EndToEndTest):
     """Test for configuration loading.
     """
 
+    @min_test_level(1)
     def test_config_on_url(self):
         """Checks that a configuration file can be downloaded from a host.
         """

--- a/tests/utils/decorators.py
+++ b/tests/utils/decorators.py
@@ -1,0 +1,36 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import os
+from unittest import skipIf
+
+
+def min_test_level(level):
+    """Skips this test unless the 'TEST_LEVEL' environmental variable is
+    equal or greater than the provided level.
+    """
+
+    def wrapper(func):
+        @skipIf(
+            int(os.getenv('TEST_LEVEL', 0)) < level,
+            "Minimum test level not met. Increase 'TEST_LEVEL' to include "
+            "this."
+        )
+        def test(*args, **kwargs):
+            func(*args, **kwargs)
+
+        return test
+
+    return wrapper

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ commands =
 [testenv:e2e]
 passenv =
     DOCKER_HOST
+    TEST_LEVEL = 0
 deps =
     -r {toxinidir}/requirements.txt
     -r {toxinidir}/tests/e2e/requirements.txt


### PR DESCRIPTION
If you run: `tox -e e2e` then you will notice that one test in there overwrites the configuration file stored on: `~/.config/cibyl.yaml`. That is annoying, but the test is trying out that very behavior.

What I have done instead is to disable the test unless explicitly indicated otherwise. Now, the previous command will ignore the problematic test. If you desire to have it run, execute: `TEST_LEVEL=1 tox -e e2e`.

This will also allow us to create test layers, where we can enable/disable those that are more dangerous.  