### PR TITLE
Add build options to query.py

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -60,7 +60,8 @@ def get_query_type(**kwargs):
     if 'pipelines' in kwargs:
         result = QueryType.PIPELINES
 
-    if 'jobs' in kwargs or 'spec' in kwargs:
+    job_args = subset(kwargs, ["jobs", "variants", "job_url"])
+    if job_args:
         result = QueryType.JOBS
 
     build_args = subset(kwargs, ["builds", "last_build", "build_status"])

--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -15,6 +15,8 @@
 """
 from enum import IntEnum
 
+from cibyl.utils.dicts import subset
+
 
 class QueryType(IntEnum):
     """Defines the hierarchy level at which a query is meant to be performed.
@@ -61,7 +63,8 @@ def get_query_type(**kwargs):
     if 'jobs' in kwargs or 'spec' in kwargs:
         result = QueryType.JOBS
 
-    if 'builds' in kwargs:
+    build_args = subset(kwargs, ["builds", "last_build", "build_status"])
+    if build_args:
         result = QueryType.BUILDS
 
     return result

--- a/tests/unit/cli/test_query.py
+++ b/tests/unit/cli/test_query.py
@@ -78,3 +78,37 @@ class TestGetQueryType(TestCase):
         }
 
         self.assertEqual(QueryType.BUILDS, get_query_type(**args))
+
+    def test_get_last_builds(self):
+        """Checks that "Builds" is returned for "--last-builds".
+        """
+        args = {
+            'last_build': None
+        }
+
+        self.assertEqual(QueryType.BUILDS, get_query_type(**args))
+
+    def test_get_build_status(self):
+        """Checks that "Builds" is returned for "--build-status".
+        """
+        args = {
+            'build_status': None
+        }
+
+        self.assertEqual(QueryType.BUILDS, get_query_type(**args))
+
+    def test_get_job_url(self):
+        """Checks that "Jobs" is returned for "--job-url"."""
+        args = {
+            'job_url': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_variants(self):
+        """Checks that "Jobs" is returned for "--variants"."""
+        args = {
+            'variants': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))


### PR DESCRIPTION
The query module was ignoring build argurments like --build-status and
--last-build so running a command like cibyl --last-build would not
show the builds even if the source was recovering them.
