### PR TITLE
Adjust spec output based on verbosity level

### DIFF
--- a/cibyl/plugins/openstack/printers/colored.py
+++ b/cibyl/plugins/openstack/printers/colored.py
@@ -69,19 +69,22 @@ class OSColoredPrinter(OSPrinter):
             printer[-1].append(deployment.network_backend)
 
         if deployment.ml2_driver.value:
-            is_empty_network = False
-            printer.add(self._palette.blue('ML2 driver: '), 2)
-            printer[-1].append(deployment.ml2_driver)
+            if deployment.ml2_driver.value != "N/A" or self.verbosity > 0:
+                is_empty_network = False
+                printer.add(self._palette.blue('ML2 driver: '), 2)
+                printer[-1].append(deployment.ml2_driver)
 
         if deployment.dvr.value:
-            is_empty_network = False
-            printer.add(self._palette.blue('DVR: '), 2)
-            printer[-1].append(deployment.dvr)
+            if deployment.dvr.value != "N/A" or self.verbosity > 0:
+                is_empty_network = False
+                printer.add(self._palette.blue('DVR: '), 2)
+                printer[-1].append(deployment.dvr)
 
         if deployment.tls_everywhere.value:
-            is_empty_network = False
-            printer.add(self._palette.blue('TLS everywhere: '), 2)
-            printer[-1].append(deployment.tls_everywhere)
+            if deployment.tls_everywhere.value != "N/A" or self.verbosity > 0:
+                is_empty_network = False
+                printer.add(self._palette.blue('TLS everywhere: '), 2)
+                printer[-1].append(deployment.tls_everywhere)
 
         if is_empty_network:
             printer.pop()
@@ -100,9 +103,10 @@ class OSColoredPrinter(OSPrinter):
         printer.add(self._palette.blue("Storage: "), 1)
 
         if deployment.storage_backend.value:
-            is_empty_storage = False
-            printer.add(self._palette.blue('Storage backend: '), 2)
-            printer[-1].append(deployment.storage_backend)
+            if deployment.storage_backend.value != "N/A" or self.verbosity > 0:
+                is_empty_storage = False
+                printer.add(self._palette.blue('Storage backend: '), 2)
+                printer[-1].append(deployment.storage_backend)
 
         if is_empty_storage:
             printer.pop()
@@ -121,14 +125,18 @@ class OSColoredPrinter(OSPrinter):
         printer.add(self._palette.blue("Ironic: "), 1)
 
         if deployment.ironic_inspector.value:
-            is_empty_ironic = False
-            printer.add(self._palette.blue('Ironic inspector: '), 2)
-            printer[-1].append(deployment.ironic_inspector)
+            if deployment.ironic_inspector.value != "N/A" or \
+               self.verbosity > 0:
+                is_empty_ironic = False
+                printer.add(self._palette.blue('Ironic inspector: '), 2)
+                printer[-1].append(deployment.ironic_inspector)
 
         if deployment.cleaning_network.value:
-            is_empty_ironic = False
-            printer.add(self._palette.blue('Cleaning network: '), 2)
-            printer[-1].append(deployment.cleaning_network)
+            if deployment.cleaning_network.value != "N/A" or \
+               self.verbosity > 0:
+                is_empty_ironic = False
+                printer.add(self._palette.blue('Cleaning network: '), 2)
+                printer[-1].append(deployment.cleaning_network)
 
         if is_empty_ironic:
             printer.pop()


### PR DESCRIPTION
The challenges with the output of --spec argument are:

* Keep it consistent so it can be used for purposes
  like jobs comparison
* Keep it concise so user gets valuable information

Before this change, the first point of keeping it consistent
and full was fulfilled, but with providing consistent output, it
slowly becomes impossible to also make the spec output valuable,
as users can see in most of the lines "N/A" if the information is
not available. Perhaps this point isn't critical right now,
but it becomes more critical as more properties are being
added to the spec.

This changes tries to deal with it by balancing between consistent
output and valueable output: if user runs simply --spec, only
available information will be displayed. If user runs --spec -v,
then a full spec will be printed.

This way users can have short concise output, but the same time
ask for more than that and also have full output for purposes like
jobs comparison or seeing what full spec is all about.
