### PR TITLE
Add exception for non-supported source type

### DIFF
--- a/cibyl/exceptions/config.py
+++ b/cibyl/exceptions/config.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 from cibyl.exceptions import CibylException
+from cibyl.utils.colors import Colors
 
 CONFIG_DOCS_URL = "https://cibyl.readthedocs.io/en/latest/configuration.html"
 CHECK_DOCS_MSG = f"Check the documentation at {CONFIG_DOCS_URL} \
@@ -81,5 +82,16 @@ class NonSupportedSystemKey(CibylException):
     def __init__(self, source_type, key):
         self.message = f"""The following key in "{source_type}" system type \
 is not supported: {key}\n\n{CHECK_DOCS_MSG}"""
+
+        super().__init__(self.message)
+
+
+class NonSupportedSourceType(CibylException):
+    """Configuration source type is not supported."""
+
+    def __init__(self, source_type, source_types):
+        types = Colors.blue("\n  ".join([t.value for t in source_types]))
+        self.message = f"""The source type "{source_type}" isn't supported.
+Use one of the following source types:\n  {types}"""
 
         super().__init__(self.message)

--- a/cibyl/sources/source_factory.py
+++ b/cibyl/sources/source_factory.py
@@ -16,7 +16,8 @@
 import re
 from enum import Enum
 
-from cibyl.exceptions.config import NonSupportedSourceKey
+from cibyl.exceptions.config import (NonSupportedSourceKey,
+                                     NonSupportedSourceType)
 from cibyl.sources.elasticsearch.api import ElasticSearchOSP
 from cibyl.sources.jenkins import Jenkins
 from cibyl.sources.jenkins_job_builder import JenkinsJobBuilder
@@ -79,5 +80,4 @@ class SourceFactory:
             if re_result:
                 raise NonSupportedSourceKey(source_type, re_result.group(1))
 
-        msg = f"Unknown source type '{source_type}'"
-        raise NotImplementedError(msg)
+        raise NonSupportedSourceType(source_type, SourceType)

--- a/tests/unit/sources/test_source_factory.py
+++ b/tests/unit/sources/test_source_factory.py
@@ -15,6 +15,7 @@
 """
 from unittest import TestCase
 
+from cibyl.exceptions.config import NonSupportedSourceType
 from cibyl.sources.elasticsearch.api import ElasticSearchOSP
 from cibyl.sources.jenkins import Jenkins
 from cibyl.sources.jenkins_job_builder import JenkinsJobBuilder
@@ -64,6 +65,6 @@ class TestSourceFactory(TestCase):
 
     def test_create_unknown_source(self):
         """Checks that an exception is raise if the source type is unknown."""
-        self.assertRaises(NotImplementedError,
+        self.assertRaises(NonSupportedSourceType,
                           SourceFactory.create_source,
                           "unknown", "zuul_source")


### PR DESCRIPTION
Using non-supported source type throws an internal
exception.

This change adds a custom exception that points out
the source type used isn't supported. In addition,
it lists the supported source types so the user knows
which source type he/she can use.
