### PR TITLE
Add exception for missing required arg in source

### DIFF
--- a/cibyl/exceptions/config.py
+++ b/cibyl/exceptions/config.py
@@ -95,3 +95,14 @@ class NonSupportedSourceType(CibylException):
 Use one of the following source types:\n  {types}"""
 
         super().__init__(self.message)
+
+
+class MissingSourceKey(CibylException):
+    """Configuration section is incomplete and missing a key."""
+
+    def __init__(self, source_type, key):
+        colored_key = Colors.blue(key)
+        self.message = f"""The following key in "{source_type}" source type \
+is missing and required for the source to become operational: {colored_key}."""
+
+        super().__init__(self.message)

--- a/cibyl/sources/source_factory.py
+++ b/cibyl/sources/source_factory.py
@@ -16,7 +16,7 @@
 import re
 from enum import Enum
 
-from cibyl.exceptions.config import (NonSupportedSourceKey,
+from cibyl.exceptions.config import (MissingSourceKey, NonSupportedSourceKey,
                                      NonSupportedSourceType)
 from cibyl.sources.elasticsearch.api import ElasticSearchOSP
 from cibyl.sources.jenkins import Jenkins
@@ -75,9 +75,15 @@ class SourceFactory:
             if source_type == SourceType.ZUUL_D:
                 return ZuulD(name=name, **kwargs)
         except TypeError as ex:
-            re_result = re.search(r'unexpected keyword argument (.*)',
-                                  ex.args[0])
-            if re_result:
-                raise NonSupportedSourceKey(source_type, re_result.group(1))
+            re_unexpected_arg = re.search(r'unexpected keyword argument (.*)',
+                                          ex.args[0])
+            if re_unexpected_arg:
+                raise NonSupportedSourceKey(
+                    source_type, re_unexpected_arg.group(1))
+            re_missing_arg = re.search(r'required positional argument: (.*)',
+                                       ex.args[0])
+            if re_missing_arg:
+                raise MissingSourceKey(source_type, re_missing_arg.group(1))
+            raise
 
         raise NonSupportedSourceType(source_type, SourceType)


### PR DESCRIPTION
This change adds a custom exception for a case where the
user didn't specify a required argument in the source configuration
section.

For example:

````
sources:
  zuul_api:
    driver: zuul
```

Will print the following:

"The following key in "zuul" source type is missing and required
for the source to become operational: 'url'.""
