### PR TITLE
Add '--projects' and '--pipelines' filters for builds

### DIFF
--- a/cibyl/models/ci/zuul/job.py
+++ b/cibyl/models/ci/zuul/job.py
@@ -137,6 +137,23 @@ class Job(BaseJob):
         """
         super().__init__(name, url, builds, variants=variants)
 
+    def __eq__(self, other):
+        if not isinstance(other, Job):
+            return False
+
+        if self is other:
+            return True
+
+        if self.builds != other.builds:
+            return False
+
+        if self.variants != other.variants:
+            return False
+
+        return \
+            self.name == other.name and \
+            self.url == other.url
+
     @overrides
     def merge(self, other):
         # Merging with oneself will never end, avoid at all costs.

--- a/cibyl/sources/zuul/query.py
+++ b/cibyl/sources/zuul/query.py
@@ -49,6 +49,20 @@ def _get_builds(zuul, **kwargs):
             if targets:
                 builds.with_uuid(*targets)
 
+        if 'projects' in kwargs:
+            targets = kwargs['projects'].value
+
+            # An empty '--projects' means all of them.
+            if targets:
+                builds.with_project(*targets)
+
+        if 'pipelines' in kwargs:
+            targets = kwargs['pipelines'].value
+
+            # An empty '--pipelines' means all of them.
+            if targets:
+                builds.with_pipeline(*targets)
+
         if 'build_status' in kwargs:
             builds.with_status(*kwargs['build_status'].value)
 

--- a/cibyl/sources/zuul/requests.py
+++ b/cibyl/sources/zuul/requests.py
@@ -297,6 +297,42 @@ class BuildsRequest(Request):
         self._filters.append(test)
         return self
 
+    def with_project(self, *pattern):
+        """Will limit request to builds that belong to a project which
+        follows a certain pattern.
+
+        :param pattern: Regex pattern for the project's name.
+        :type pattern: str
+        :return: The request's instance.
+        :rtype: :class:`BuildsRequest`
+        """
+
+        def test(build):
+            return any(
+                matches_regex(patt, build['project']) for patt in pattern
+            )
+
+        self._filters.append(test)
+        return self
+
+    def with_pipeline(self, *pattern):
+        """Will limit request to builds that where triggered by a pipeline
+        which follows a certain pattern.
+
+        :param pattern: Regex pattern for the pipeline's name.
+        :type pattern: str
+        :return: The request's instance.
+        :rtype: :class:`BuildsRequest`
+        """
+
+        def test(build):
+            return any(
+                matches_regex(patt, build['pipeline']) for patt in pattern
+            )
+
+        self._filters.append(test)
+        return self
+
     def with_last_build_only(self):
         """Will only return the latest build that meets the filters.
 

--- a/tests/unit/models/ci/zuul/test_job.py
+++ b/tests/unit/models/ci/zuul/test_job.py
@@ -25,6 +25,41 @@ class TestJob(TestCase):
     """Tests for :class:`Job`.
     """
 
+    def test_equality_by_type(self):
+        """Checks that two jobs are different if they are of different type.
+        """
+        job = Job('job', 'url')
+        other = Mock()
+
+        self.assertNotEqual(other, job)
+
+    def test_equality_by_reference(self):
+        """Checks that a job is equal to itself.
+        """
+        job = Job('job', 'url')
+        other = job
+
+        self.assertEqual(other, job)
+
+    def test_equality_by_contents(self):
+        """Checks that two jobs are equal if they have the same data.
+        """
+        name = 'job'
+        url = 'url'
+
+        build = Mock()
+        variant = Mock()
+
+        job = Job(name, url)
+        job.add_build(build)
+        job.add_variant(variant)
+
+        other = Job(name, url)
+        other.add_build(build)
+        other.add_variant(variant)
+
+        self.assertEqual(other, job)
+
     def test_has_variants_attribute(self):
         """Checks that a 'variants' attribute is added to the object.
         """
@@ -56,47 +91,46 @@ class TestJob(TestCase):
 
         self.assertIn(variant, job1.variants)
 
-
-class TestVariant(TestCase):
-    """Tests for :class:`Job.Variant`.
-    """
-
-    def test_attributes(self):
-        """Checks that the variant has all its attributes.
+    class TestVariant(TestCase):
+        """Tests for :class:`Job.Variant`.
         """
-        variant = Job.Variant('parent')
 
-        self.assertIsInstance(variant.parent, AttributeValue)
-        self.assertIsInstance(variant.description, AttributeValue)
-        self.assertIsInstance(variant.branches, AttributeListValue)
-        self.assertIsInstance(variant.variables, AttributeDictValue)
+        def test_attributes(self):
+            """Checks that the variant has all its attributes.
+            """
+            variant = Job.Variant('parent')
 
-    def test_equality_by_type(self):
-        """Checks that two objects of different type are not equal.
-        """
-        variant = Job.Variant('parent')
-        other = Mock()
+            self.assertIsInstance(variant.parent, AttributeValue)
+            self.assertIsInstance(variant.description, AttributeValue)
+            self.assertIsInstance(variant.branches, AttributeListValue)
+            self.assertIsInstance(variant.variables, AttributeDictValue)
 
-        self.assertNotEqual(other, variant)
+        def test_equality_by_type(self):
+            """Checks that two objects of different type are not equal.
+            """
+            variant = Job.Variant('parent')
+            other = Mock()
 
-    def test_equality_by_reference(self):
-        """Checks that two objects are equal if they are pointed by the same
-        reference.
-        """
-        variant = Job.Variant('parent')
-        other = variant
+            self.assertNotEqual(other, variant)
 
-        self.assertEqual(other, variant)
+        def test_equality_by_reference(self):
+            """Checks that two objects are equal if they are pointed by the same
+            reference.
+            """
+            variant = Job.Variant('parent')
+            other = variant
 
-    def test_equality_by_content(self):
-        """Checks that two objects are equal if they have the same contents.
-        """
-        parent = 'parent'
-        description = 'description'
-        branches = ['branch1', 'branch2']
-        variables = {'var1': 'val1'}
+            self.assertEqual(other, variant)
 
-        variant1 = Job.Variant(parent, description, branches, variables)
-        variant2 = Job.Variant(parent, description, branches, variables)
+        def test_equality_by_content(self):
+            """Checks that two objects are equal if they have the same contents.
+            """
+            parent = 'parent'
+            description = 'description'
+            branches = ['branch1', 'branch2']
+            variables = {'var1': 'val1'}
 
-        self.assertEqual(variant2, variant1)
+            variant1 = Job.Variant(parent, description, branches, variables)
+            variant2 = Job.Variant(parent, description, branches, variables)
+
+            self.assertEqual(variant2, variant1)


### PR DESCRIPTION
For a query like the following:
`cibyl --tenants --projects projectA --pipelines pipelineA --jobs --builds`
only builds triggered by 'pipelineA' on project 'projectA' will be displayed on the output, both on project and job view.