### PR TITLE
Adding a log entry when an argument has been omitted on a zuul query.

### DIFF
--- a/cibyl/sources/zuul/query.py
+++ b/cibyl/sources/zuul/query.py
@@ -272,6 +272,35 @@ def _handle_jobs_query(zuul, **kwargs):
     return model
 
 
+def log_query_conditions(**kwargs):
+    """Logs any special conditions the query is going to take against the
+    arguments. Some of these are, for example, adding an argument that has
+    been omitted by the user.
+
+    :param kwargs: The arguments to check.
+    """
+    if 'tenants' not in kwargs:
+        LOG.info(
+            "Omitted argument '--tenants', "
+            "loading defaults from configuration file."
+        )
+
+    if 'projects' not in kwargs:
+        LOG.info(
+            "Omitted argument '--projects' implicitly added to query."
+        )
+
+    if 'pipelines' not in kwargs:
+        LOG.info(
+            "Omitted argument '--pipelines' implicitly added to query."
+        )
+
+    if 'jobs' not in kwargs:
+        LOG.info(
+            "Omitted argument '--jobs' implicitly added to query."
+        )
+
+
 def handle_query(zuul, **kwargs):
     """Generates and performs a query on a Zuul host based on the given
     arguments.
@@ -313,6 +342,8 @@ def handle_query(zuul, **kwargs):
 
     if not handler:
         raise NotImplementedError(f'Unsupported query: {query}')
+
+    log_query_conditions(**kwargs)
 
     model = handler(zuul, **kwargs)
 

--- a/tests/e2e/test_zuul.py
+++ b/tests/e2e/test_zuul.py
@@ -19,9 +19,10 @@ from cibyl.cli.main import main
 from cibyl.utils.strings import IndentedTextBuilder
 from tests.e2e.containers.zuul import OpenDevZuulContainer
 from tests.e2e.fixtures import EndToEndTest
+from tests.utils.assertions import ExtraAssertions
 
 
-class TestZuul(EndToEndTest):
+class TestZuul(EndToEndTest, ExtraAssertions):
     """Tests queries regarding the Zuul source.
     """
 
@@ -305,3 +306,39 @@ class TestZuul(EndToEndTest):
         self.assertIn('Tenant: example-tenant', self.output)
         self.assertIn('Tenant: example-tenant-2', self.output)
         self.assertIn('Total tenants found in query: 2', self.output)
+
+    def test_implicit_arguments_are_logged(self):
+        """Checks that a log entry is added for each argument that is
+        implicitly added to the query, such as '--tenants' or '--projects'.
+        """
+
+        sys.argv = [
+            '',
+            '--config', 'tests/e2e/data/configs/zuul/with-tenants.yaml',
+            '-f', 'text',
+            '--builds'
+        ]
+
+        with self.assertLogs(level='INFO') as log:
+            main()
+
+            self.assertContains(
+                "Omitted argument '--tenants', "
+                "loading defaults from configuration file",
+                log.output
+            )
+
+            self.assertContains(
+                "Omitted argument '--projects' implicitly added to query",
+                log.output
+            )
+
+            self.assertContains(
+                "Omitted argument '--pipelines' implicitly added to query",
+                log.output
+            )
+
+            self.assertContains(
+                "Omitted argument '--jobs' implicitly added to query",
+                log.output
+            )

--- a/tests/utils/assertions.py
+++ b/tests/utils/assertions.py
@@ -1,0 +1,24 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+
+class ExtraAssertions(TestCase):
+    def assertAny(self, iterable, msg=...):
+        self.assertTrue(any(iterable), msg)
+
+    def assertContains(self, member, iterable, msg=...):
+        self.assertAny((member in entry for entry in iterable), msg)


### PR DESCRIPTION
If I have the following query: `cibyl --builds` it will be equal to: `cibyl --tenants --projects --pipelines --jobs --builds`

I have added log entries indicating that those arguments have been added implicitly.