### PR TITLE
Improve check for plugin section in jobs

### DIFF
--- a/cibyl/outputs/cli/ci/system/common/jobs.py
+++ b/cibyl/outputs/cli/ci/system/common/jobs.py
@@ -33,7 +33,18 @@ def has_plugin_section(job):
         False if not.
     :rtype: bool
     """
-    return job.plugin_attributes
+    if not job.plugin_attributes:
+        return False
+    has_plugin_attribute = False
+    for plugin_attribute in job.plugin_attributes:
+        # Plugins install some attributes as part of the model
+        attribute = getattr(job, plugin_attribute)
+
+        # Check if the attribute is populated
+        if not attribute.value:
+            continue
+        has_plugin_attribute = True
+    return has_plugin_attribute
 
 
 def get_plugin_section(printer, job):
@@ -57,11 +68,11 @@ def get_plugin_section(printer, job):
 
     text = IndentedTextBuilder()
 
-    for plugin in job.plugin_attributes:
-        # Plugins are installed as part of the model
-        attribute = getattr(job, plugin)
+    for plugin_attribute in job.plugin_attributes:
+        # Plugins install some attributes as part of the model
+        attribute = getattr(job, plugin_attribute)
 
-        # Check if the plugin is installed
+        # Check if the attribute is populated
         if not attribute.value:
             continue
 

--- a/tests/intr/output/__init__.py
+++ b/tests/intr/output/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/intr/output/test_output_colored_openstack.py
+++ b/tests/intr/output/test_output_colored_openstack.py
@@ -1,0 +1,104 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest.mock import Mock
+
+from cibyl.cli.query import QueryType
+from cibyl.models.ci.base.job import Job
+from cibyl.models.ci.base.system import JobsSystem
+from cibyl.models.ci.zuul.pipeline import Pipeline
+from cibyl.models.ci.zuul.project import Project
+from cibyl.models.ci.zuul.system import ZuulSystem
+from cibyl.models.ci.zuul.tenant import Tenant
+from cibyl.outputs.cli.ci.system.impls.jobs import colored
+from cibyl.outputs.cli.ci.system.impls.zuul import colored as zuul_colored
+from tests.utils import (OpenstackPluginWithJobSystem,
+                         OpenstackPluginWithZuulSystem)
+
+
+class TestOutputJobsSystemWithOpenstackPlugin(OpenstackPluginWithJobSystem):
+    """Test publisher output with openstack plugin."""
+
+    def test_empty_openstack_attributes(self):
+        system = JobsSystem("test-system", "test")
+        for i in range(3):
+            job_name = f"job-name-{i}"
+            system.add_job(Job(name=job_name))
+        system.register_query()
+
+        palette = Mock()
+        palette.blue = Mock()
+        palette.blue.side_effect = lambda text: text
+
+        printer = colored.ColoredJobsSystemPrinter(palette=palette,
+                                                   query=QueryType.JOBS)
+        output = printer.print_system(system)
+        # check that output is five lines long(system line, one line per job
+        # and the line for total number of jobs)
+        self.assertEqual(5, len(output.split("\n")))
+        expected = "System: test-system"
+        for i in range(3):
+            expected += f"\n  Job: job-name-{i}"
+        expected += "\n  Total jobs found in query: 3"
+        self.assertEqual(output, expected)
+
+
+class TestOutputZuulSystemWithOpenstackPlugin(OpenstackPluginWithZuulSystem):
+    """Test publisher output with openstack plugin."""
+
+    def test_empty_openstack_attributes(self):
+        system = ZuulSystem("test-system", "test")
+        jobs = {}
+        for i in range(3):
+            job_name = f"job-name-{i}"
+            jobs[job_name] = Job(name=job_name)
+        pipeline = Pipeline(name="pipeline", jobs=jobs)
+        project = Project("project", url="url",
+                          pipelines={'pipeline': pipeline})
+        tenant = Tenant("tenant", projects={'project': project})
+        system.add_toplevel_model(tenant)
+        system.register_query()
+
+        palette = Mock()
+        palette.blue = Mock()
+        palette.blue.side_effect = lambda text: text
+        palette.underline = Mock()
+        palette.underline.side_effect = lambda text: text
+
+        printer = zuul_colored.ColoredZuulSystemPrinter(palette=palette,
+                                                        query=QueryType.JOBS)
+        output = printer.print_system(system)
+        print("")
+        print(output)
+        # check that output is five lines long(system line, one line per job
+        # and the line for total number of jobs)
+        self.assertEqual(12, len(output.split("\n")))
+        expected = "System: test-system\n"
+        expected += "  Tenant: tenant\n"
+        expected += "    Projects: \n"
+        expected += "      Project: project\n"
+        expected += "        Pipeline: pipeline"
+        for i in range(3):
+            expected += f"\n          Job: job-name-{i}"
+        expected += "\n          Total jobs found in query for pipeline"
+        expected += " 'pipeline': 3\n"
+        expected += "        Total pipelines found in query for project"
+        expected += " 'project': 1\n"
+        expected += "    Total projects found in query for tenant"
+        expected += " 'tenant': 1\n"
+        expected += "  Total tenants found in query: 1"
+        print("")
+        print(expected)
+        self.assertEqual(output, expected)

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -19,6 +19,7 @@ from unittest import TestCase
 from cibyl.models.ci.base.job import Job
 from cibyl.models.ci.base.system import JobsSystem, System
 from cibyl.models.ci.zuul.job import Job as ZuulJob
+from cibyl.models.ci.zuul.system import ZuulSystem
 from cibyl.plugins import enable_plugins
 
 
@@ -55,6 +56,16 @@ class JobSystemAPI(TestCase):
         System.API = deepcopy(JobsSystem.API)
 
 
+class ZuulSystemAPI(TestCase):
+    """Setup a test class that applies the ZuulSystemAPI."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup the API of system using that of ZuulSystem."""
+        super().setUpClass()
+        System.API = deepcopy(ZuulSystem.API)
+
+
 class OpenstackPluginWithJobSystem(JobSystemAPI):
     """Setup a test class to test environments with a JobsSystem and Openstack
     plugin."""
@@ -62,6 +73,24 @@ class OpenstackPluginWithJobSystem(JobSystemAPI):
     @classmethod
     def setUpClass(cls):
         """Setup the API of system using that of JobsSystem and apply the
+        openstack plugin."""
+        super().setUpClass()
+        enable_plugins(["openstack"])
+
+    @classmethod
+    def tearDownClass(cls):
+        """Restore the original APIs of Job and System to avoid interferring
+        with other systems."""
+        super().tearDownClass()
+
+
+class OpenstackPluginWithZuulSystem(ZuulSystemAPI):
+    """Setup a test class to test environments with a ZuulSystem and Openstack
+    plugin."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup the API of system using that of ZuulSystem and apply the
         openstack plugin."""
         super().setUpClass()
         enable_plugins(["openstack"])


### PR DESCRIPTION
Before adding a plugin section to the output, check whether there are
any attributes added by a plugin and whether those attributes are
populated. Otherwise, the section will produce an empty string that
would mess with the output formatting.
