### PR TITLE
Ensure that system constructor arguments are set

### DIFF
--- a/cibyl/models/ci/base/system.py
+++ b/cibyl/models/ci/base/system.py
@@ -70,7 +70,8 @@ class System(Model):
                  system_type: str,
                  top_level_model: Type[Model],
                  sources: List = None,
-                 enabled: bool = True):
+                 enabled: bool = True,
+                 **kwargs):
         # Let IDEs know this class's attributes
         self.name = None
         self.system_type = None
@@ -85,7 +86,8 @@ class System(Model):
                 'system_type': system_type,
                 'sources': sources,
                 'enabled': enabled,
-                'queried': False
+                'queried': False,
+                **kwargs
             }
         )
 
@@ -180,7 +182,11 @@ class JobsSystem(System):
                  enabled: bool = True,
                  jobs: Dict[str, Job] = None,
                  jobs_scope: str = None):
+        # Let IDEs know this class's attributes
         self.jobs = jobs
+        # jobs_scope does not need to go through the Model __init__ since it's
+        # not in the API. As a result, it's value is stored in a simple string
+        # and not in an Argument object
         self.jobs_scope = jobs_scope
 
         # Set up model
@@ -190,6 +196,7 @@ class JobsSystem(System):
             top_level_model=Job,
             sources=sources,
             enabled=enabled,
+            jobs=jobs  # pass jobs to parent init so it's not overriden
         )
 
     def export_attributes_to_source(self):

--- a/cibyl/models/ci/zuul/system.py
+++ b/cibyl/models/ci/zuul/system.py
@@ -46,6 +46,7 @@ class ZuulSystem(System):
                  sources=None,
                  enabled=True,
                  tenants=None):
+        # Let IDEs know this class's attributes
         self.tenants = tenants
 
         # Set up model
@@ -55,6 +56,8 @@ class ZuulSystem(System):
             top_level_model=Tenant,
             sources=sources,
             enabled=enabled,
+            # pass tenants to parent init so it's not overriden
+            tenants=tenants
         )
 
     def add_toplevel_model(self, model):

--- a/tests/unit/models/ci/base/test_system.py
+++ b/tests/unit/models/ci/base/test_system.py
@@ -99,3 +99,8 @@ class TestJobsSystem(unittest.TestCase):
         output = self.system.export_attributes_to_source()
         self.assertEqual(1, len(output))
         self.assertEqual(output['jobs_scope'], 'phase1')
+
+    def test_system_jobs_constructor(self):
+        jobs = {'test_job': Job("test_job")}
+        system = JobsSystem("test", "test", jobs=jobs)
+        self.assertEqual(1, len(system.jobs.value))

--- a/tests/unit/models/ci/zuul/test_system.py
+++ b/tests/unit/models/ci/zuul/test_system.py
@@ -1,0 +1,29 @@
+"""
+# Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+# pylint: disable=no-member
+import unittest
+
+from cibyl.models.ci.zuul.system import ZuulSystem
+from cibyl.models.ci.zuul.tenant import Tenant
+
+
+class TestZuulSystem(unittest.TestCase):
+    """Test the ZuulSystem class."""
+
+    def test_system_tenants_constructor(self):
+        tenants = {'tenant': Tenant("tenant")}
+        system = ZuulSystem("test", "test", tenants=tenants)
+        self.assertEqual(1, len(system.tenants.value))

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -18,7 +18,8 @@ from unittest.mock import Mock, patch
 
 import cibyl.orchestrator
 from cibyl.config import Config
-from cibyl.exceptions.config import InvalidConfiguration
+from cibyl.exceptions.config import (CHECK_DOCS_MSG, InvalidConfiguration,
+                                     NonSupportedSystemKey)
 from cibyl.exceptions.source import NoValidSources
 from cibyl.orchestrator import Orchestrator, source_information_from_method
 from cibyl.sources.source import Source
@@ -242,3 +243,33 @@ class TestOrchestrator(TestCase):
         self.orchestrator.create_ci_environments()
         self.orchestrator.setup_sources()
         patched_setup.assert_called_once_with()
+
+    def test_not_supported_system_key_jobs_system(self):
+        """Test that a NonSupportedSystemKey is raised if the configuration
+        contains invalid parameters for a jobs system."""
+        config = {
+            'environments': {
+                'env1': {
+                    'system1': {
+                        'system_type': 'jenkins',
+                        'tenants': 'tenant'}}}}
+        self.orchestrator.config.data = config
+        msg = "The following key in jenkins system type is not supported:"
+        msg += f" tenants\n\n{CHECK_DOCS_MSG}"
+        with self.assertRaises(NonSupportedSystemKey, msg=msg):
+            self.orchestrator.create_ci_environments()
+
+    def test_not_supported_system_key_zuul_system(self):
+        """Test that a NonSupportedSystemKey is raised if the configuration
+        contains invalid parameters for a zuul system."""
+        config = {
+            'environments': {
+                'env1': {
+                    'system1': {
+                        'system_type': 'zuul',
+                        'non-existing': 'tenant'}}}}
+        self.orchestrator.config.data = config
+        msg = "The following key in jenkins system type is not supported:"
+        msg += f" non-existing\n\n{CHECK_DOCS_MSG}"
+        with self.assertRaises(NonSupportedSystemKey, msg=msg):
+            self.orchestrator.create_ci_environments()


### PR DESCRIPTION
Removing the kwargs in the abstract System class prevented some __init__
arguments of JobsSystem and ZuulSystem to be considered in the
constructor. Those arguments that were in the API but were not passed to
the parent's __init__ were overriden there. For example, passing jobs to
a new JobsSystem or tenants to a new ZuulSystem would not work as
expected, since when the Model constructor would be called it would
override the passed values and set them empty. To ensure that regression
occurs, this change also introduces unit tests that cover the
constructor behaviour and the NonSupportedSystemKey exception.
