### PR TITLE
Add security group mechanism to the spec in Jenkins

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -61,7 +61,7 @@ def get_query_type(**kwargs):
         result = QueryType.PIPELINES
 
     job_args = subset(kwargs, ["jobs", "variants", "job_url"])
-    if job_args:
+    if job_args or 'spec' in kwargs:
         result = QueryType.JOBS
 
     build_args = subset(kwargs, ["builds", "last_build", "build_status"])

--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -114,6 +114,9 @@ class Deployment(Model):
         'cleaning_network': {
             'arguments': []
         },
+        'security_group': {
+            'arguments': []
+        },
         'network_backend': {
             'attr_type': str,
             'arguments': [Argument(name='--network-backend', arg_type=str,
@@ -136,7 +139,7 @@ class Deployment(Model):
                  network_backend: str = None, storage_backend: str = None,
                  dvr: str = None, tls_everywhere: str = None,
                  ml2_driver: str = None, ironic_inspector: str = None,
-                 cleaning_network: str = None):
+                 cleaning_network: str = None, security_group: str = None):
         super().__init__({'release': release, 'infra_type': infra_type,
                           'nodes': nodes, 'services': services,
                           'ip_version': ip_version, 'topology': topology,
@@ -145,6 +148,7 @@ class Deployment(Model):
                           'dvr': dvr, 'tls_everywhere': tls_everywhere,
                           'ml2_driver': ml2_driver,
                           'ironic_inspector': ironic_inspector,
+                          'security_group': security_group,
                           'cleaning_network': cleaning_network})
 
     def add_node(self, node: Node):
@@ -196,6 +200,8 @@ class Deployment(Model):
             self.ironic_inspector.value = other.ironic_inspector.value
         if not self.cleaning_network.value:
             self.cleaning_network.value = other.cleaning_network.value
+        if not self.security_group.value:
+            self.security_group.value = other.security_group.value
         for node in other.nodes.values():
             self.add_node(node)
         for service in other.services.values():

--- a/cibyl/plugins/openstack/printers/colored.py
+++ b/cibyl/plugins/openstack/printers/colored.py
@@ -74,6 +74,13 @@ class OSColoredPrinter(OSPrinter):
                 printer.add(self._palette.blue('ML2 driver: '), 2)
                 printer[-1].append(deployment.ml2_driver)
 
+        if deployment.security_group.value:
+            if deployment.ml2_driver.value != "N/A" or self.verbosity > 0:
+                is_empty_network = False
+                printer.add(self._palette.blue('Security group mechanism: '),
+                            2)
+                printer[-1].append(deployment.security_group)
+
         if deployment.dvr.value:
             if deployment.dvr.value != "N/A" or self.verbosity > 0:
                 is_empty_network = False

--- a/tests/intr/output/test_output_colored_openstack.py
+++ b/tests/intr/output/test_output_colored_openstack.py
@@ -80,8 +80,6 @@ class TestOutputZuulSystemWithOpenstackPlugin(OpenstackPluginWithZuulSystem):
         printer = zuul_colored.ColoredZuulSystemPrinter(palette=palette,
                                                         query=QueryType.JOBS)
         output = printer.print_system(system)
-        print("")
-        print(output)
         # check that output is five lines long(system line, one line per job
         # and the line for total number of jobs)
         self.assertEqual(12, len(output.split("\n")))
@@ -99,6 +97,4 @@ class TestOutputZuulSystemWithOpenstackPlugin(OpenstackPluginWithZuulSystem):
         expected += "    Total projects found in query for tenant"
         expected += " 'tenant': 1\n"
         expected += "  Total tenants found in query: 1"
-        print("")
-        print(expected)
         self.assertEqual(output, expected)


### PR DESCRIPTION
In the network section of the spec, add the security group mechanism
used. It's only added to the spec, not as a cli argument. The
assumptions are that for a job using ovn, a native security group
implementation is used. With ovs, this can be either using openvswitch
or iptables, default is iptables.
