### PR TITLE
Add exception for missing source type

### DIFF
--- a/cibyl/exceptions/config.py
+++ b/cibyl/exceptions/config.py
@@ -106,3 +106,14 @@ class MissingSourceKey(CibylException):
 is missing and required for the source to become operational: {colored_key}."""
 
         super().__init__(self.message)
+
+
+class MissingSourceType(CibylException):
+    """Configuration source type isn't specified."""
+
+    def __init__(self, source_name, source_types):
+        types = Colors.blue("\n  ".join([t.value for t in source_types]))
+        self.message = f"""Missing 'driver: <TYPE>' for source {source_name}
+Use one of the following source types:\n  {types}"""
+
+        super().__init__(self.message)

--- a/cibyl/sources/source_factory.py
+++ b/cibyl/sources/source_factory.py
@@ -16,7 +16,8 @@
 import re
 from enum import Enum
 
-from cibyl.exceptions.config import (MissingSourceKey, NonSupportedSourceKey,
+from cibyl.exceptions.config import (MissingSourceKey, MissingSourceType,
+                                     NonSupportedSourceKey,
                                      NonSupportedSourceType)
 from cibyl.sources.elasticsearch.api import ElasticSearchOSP
 from cibyl.sources.jenkins import Jenkins
@@ -86,4 +87,7 @@ class SourceFactory:
                 raise MissingSourceKey(source_type, re_missing_arg.group(1))
             raise
 
-        raise NonSupportedSourceType(source_type, SourceType)
+        if source_type:
+            raise NonSupportedSourceType(source_type, SourceType)
+        else:
+            raise MissingSourceType(name, SourceType)


### PR DESCRIPTION
This fixes the bug of a source missing
the "driver" key and the exception being displayed
the user is "Source type None is not supported".

Instead, this change introduces a custom exception
telling the user explicitly that "driver" key is missing
and it lists the different types the user can use in the
configuration.
