### PR TITLE
Add openstack cli arguments to get_query_type

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -35,6 +35,61 @@ class QueryType(IntEnum):
     """Retrieve data concerning builds and above."""
 
 
+class QuerySelector:
+    """Deduce the type of query performed from the cli argument considering
+    both core argument and plugin provided ones."""
+    query_selector_functions = []
+
+    def get_query_type_core(self, **kwargs):
+        """Deduces the type of query from a set of arguments related to cibyl
+        core ci models.
+
+        :param kwargs: The arguments.
+        :key tenants: Query targets tenants.
+        :key projects: Query targets projects.
+        :key pipelines: Query targets pipelines.
+        :key jobs: Query targets jobs.
+        :key builds: Query target builds.
+        :return: The lowest query level possible. For example,
+            if both 'tenants' and 'builds' are requested, this will choose
+            'builds' over 'tenants'.
+        :rtype: :class:`QueryType`
+        """
+
+        result = QueryType.NONE
+
+        if 'tenants' in kwargs:
+            result = QueryType.TENANTS
+
+        if 'projects' in kwargs:
+            result = QueryType.PROJECTS
+
+        if 'pipelines' in kwargs:
+            result = QueryType.PIPELINES
+
+        job_args = subset(kwargs, ["jobs", "variants", "job_url"])
+        if job_args:
+            result = QueryType.JOBS
+
+        build_args = subset(kwargs, ["builds", "last_build", "build_status"])
+        if build_args:
+            result = QueryType.BUILDS
+
+        return result
+
+    def get_type_query(self, **kwargs):
+        """Deduce the type of query from the given arguments, taking into
+        account arguments provided by the plugins, if present. It will return
+        the largest query type provided by either the core types or the
+        plugins."""
+        core_query = self.get_query_type_core(**kwargs)
+        plugins_query = QueryType.NONE
+        if self.query_selector_functions:
+            plugins_query = max([get_query(**kwargs) for get_query in
+                                 self.query_selector_functions])
+        return max(core_query, plugins_query)
+
+
 def get_query_type(**kwargs):
     """Deduces the type of query from a set of arguments.
 
@@ -49,23 +104,5 @@ def get_query_type(**kwargs):
         'builds' over 'tenants'.
     :rtype: :class:`QueryType`
     """
-    result = QueryType.NONE
-
-    if 'tenants' in kwargs:
-        result = QueryType.TENANTS
-
-    if 'projects' in kwargs:
-        result = QueryType.PROJECTS
-
-    if 'pipelines' in kwargs:
-        result = QueryType.PIPELINES
-
-    job_args = subset(kwargs, ["jobs", "variants", "job_url"])
-    if job_args or 'spec' in kwargs:
-        result = QueryType.JOBS
-
-    build_args = subset(kwargs, ["builds", "last_build", "build_status"])
-    if build_args:
-        result = QueryType.BUILDS
-
-    return result
+    query_selector = QuerySelector()
+    return query_selector.get_type_query(**kwargs)

--- a/cibyl/plugins/__init__.py
+++ b/cibyl/plugins/__init__.py
@@ -67,3 +67,4 @@ def enable_plugins(plugins: list = None):
             plugin_module.Plugin().extend_models()
             plugin_module_path = get_plugin_module_path(plugin_module)
             extend_source(plugin, plugin_module_path)
+            plugin_module.Plugin().extend_query_types()

--- a/tests/unit/cli/test_query.py
+++ b/tests/unit/cli/test_query.py
@@ -16,6 +16,7 @@
 from unittest import TestCase
 
 from cibyl.cli.query import QueryType, get_query_type
+from tests.utils import OpenstackPluginWithJobSystem
 
 
 class TestGetQueryType(TestCase):
@@ -109,6 +110,170 @@ class TestGetQueryType(TestCase):
         """Checks that "Jobs" is returned for "--variants"."""
         args = {
             'variants': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_ip_version(self):
+        """Checks that "None" is returned for "--ip-version" if the openstack
+        plugin is not added."""
+        args = {
+            'ip_version': None
+        }
+
+        self.assertEqual(QueryType.NONE, get_query_type(**args))
+
+
+class TestGetQueryTypeOpenstackPlugin(OpenstackPluginWithJobSystem):
+    """Tests for :func:`get_query_type` with the openstack plugin loaded."""
+
+    def test_get_release(self):
+        """Checks that "Jobs" is returned for "--release" if the openstack
+        plugin is added."""
+        args = {
+            'release': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_spec(self):
+        """Checks that "Jobs" is returned for "--spec" if the openstack
+        plugin is added."""
+        args = {
+            'spec': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_infra_type(self):
+        """Checks that "Jobs" is returned for "--infra-type" if the openstack
+        plugin is added."""
+        args = {
+            'infra_type': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_nodes(self):
+        """Checks that "Jobs" is returned for "--nodes" if the openstack
+        plugin is added."""
+        args = {
+            'nodes': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_controllers(self):
+        """Checks that "Jobs" is returned for "--controllers" if the openstack
+        plugin is added."""
+        args = {
+            'controllers': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_computes(self):
+        """Checks that "Jobs" is returned for "--computes" if the openstack
+        plugin is added."""
+        args = {
+            'computes': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_services(self):
+        """Checks that "Jobs" is returned for "--services" if the openstack
+        plugin is added."""
+        args = {
+            'services': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_ip_version(self):
+        """Checks that "Jobs" is returned for "--ip-version" if the openstack
+        plugin is added."""
+        args = {
+            'ip_version': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_topology(self):
+        """Checks that "Jobs" is returned for "--topology" if the openstack
+        plugin is added."""
+        args = {
+            'topology': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_dvr(self):
+        """Checks that "Jobs" is returned for "--dvr" if the openstack
+        plugin is added."""
+        args = {
+            'dvr': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_ml2_driver(self):
+        """Checks that "Jobs" is returned for "--ml2-driver" if the openstack
+        plugin is added."""
+        args = {
+            'ml2_driver': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_tls_everywhere(self):
+        """Checks that "Jobs" is returned for "--tls-everywhere" if the
+        openstack plugin is added.
+        """
+        args = {
+            'tls_everywhere': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_ironic_inspector(self):
+        """Checks that "Jobs" is returned for "--ironic-inspector" if the
+        openstack plugin is added.
+        """
+        args = {
+            'ironic_inspector': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_network_backend(self):
+        """Checks that "Jobs" is returned for "--network-backend" if the
+        openstack plugin is added.
+        """
+        args = {
+            'network_backend': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_storage_backend(self):
+        """Checks that "Jobs" is returned for "--storage-backend" if the
+        openstack plugin is added.
+        """
+        args = {
+            'storage_backend': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_spec_tenants(self):
+        """Checks that "Jobs" is returned for "--storage-backend" if the
+        openstack plugin is added and is run in combination of arguments like
+        --tenants.
+        """
+        args = {
+            'tenants': None,
+            'storage_backend': None
         }
 
         self.assertEqual(QueryType.JOBS, get_query_type(**args))

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -16,6 +16,7 @@
 from copy import deepcopy
 from unittest import TestCase
 
+from cibyl.cli.query import QuerySelector
 from cibyl.models.ci.base.job import Job
 from cibyl.models.ci.base.system import JobsSystem, System
 from cibyl.models.ci.zuul.job import Job as ZuulJob
@@ -43,6 +44,7 @@ class RestoreAPIs(TestCase):
         Job.plugin_attributes = deepcopy(cls.plugin_attributes)
         ZuulJob.API = deepcopy(cls.original_zuul_job_api)
         System.API = deepcopy(cls.original_system_api)
+        QuerySelector.query_selector_functions = []
 
 
 class JobSystemAPI(TestCase):


### PR DESCRIPTION
In order to introduce the plugin arguments in the get_query_type
function, it will use a QuerySelector class, where functions to check
the query type will be injected by the plugins. The largest value
provided by either the core cli argument or the ones from the plugin
will be returned. This changes maintains the same interface for the
get_query_type and uses the class only internally, to avoid breaking any
existing code.
