### PR TITLE
Modify environments argument name

### DIFF
--- a/cibyl/models/ci/base/environment.py
+++ b/cibyl/models/ci/base/environment.py
@@ -27,14 +27,14 @@ class Environment(Model):
     API = {
         'name': {
             'attr_type': str,
-            'arguments': [Argument(name='--env-name', arg_type=str,
-                                   description="Name of the environment")]
+            'arguments': [Argument(name='--envs', arg_type=str,
+                                   description="Environment names")]
         },
         'systems': {
             'attr_type': System,
             'attribute_value_class': AttributeListValue,
             'arguments': [Argument(name='--systems', arg_type=str, nargs='*',
-                                   description="Systems of the environment")]
+                                   description="Systems names")]
         }
     }
 

--- a/tests/unit/cli/test_parser.py
+++ b/tests/unit/cli/test_parser.py
@@ -61,14 +61,14 @@ class TestParser(TestCase):
         self.assertEqual(self.parser.ci_args, {})
 
         self.parser.extend(self.environment.arguments, 'Environment')
-        self.parser.parse(['--env-name', 'env1', '--plugin', 'openshift'])
+        self.parser.parse(['--envs', 'env1', '--plugin', 'openshift'])
         self.assertEqual(self.parser.app_args, {'plugin': 'openshift',
                                                 'verbosity': 0,
                                                 'output_style': 'colorized',
                                                 'debug': False})
         self.assertEqual(self.parser.ci_args,
-                         {'env_name': Argument(
-                             name='env_name', arg_type=str,
+                         {'envs': Argument(
+                             name='envs', arg_type=str,
                              description='Name of the environment', nargs=1,
                              func=None, populated=False, level=0,
                              value=['env1'])})


### PR DESCRIPTION
So far there was mostly some consistency
in arguments names. For example:

* --jobs
* --systems
* --builds
...

The only one that is quite different from
that is "--env-name". This change aligns it
so it's renamed to "--envs"
