### PR TITLE
Revert change in CibylException constructor

### DIFF
--- a/tests/unit/exceptions/__init__.py
+++ b/tests/unit/exceptions/__init__.py
@@ -13,17 +13,3 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-
-
-class CibylException(Exception):
-    """Parent class for all cibyl exceptions for easier control of the
-    exceptions' representation.
-    """
-
-    def __init__(self, message=''):
-        """Constructor.
-
-        :param message: The reason for this error.
-        :type message: str
-        """
-        super().__init__(*[message])

--- a/tests/unit/exceptions/test_cibyl_exceptions.py
+++ b/tests/unit/exceptions/test_cibyl_exceptions.py
@@ -14,16 +14,17 @@
 #    under the License.
 """
 
+from unittest import TestCase
 
-class CibylException(Exception):
-    """Parent class for all cibyl exceptions for easier control of the
-    exceptions' representation.
-    """
+from cibyl.exceptions.source import NoSupportedSourcesFound
 
-    def __init__(self, message=''):
-        """Constructor.
 
-        :param message: The reason for this error.
-        :type message: str
-        """
-        super().__init__(*[message])
+class TestCibylExceptions(TestCase):
+    """Test the behavior of CibylException types."""
+
+    def test_cibyl_no_supported_sources_found_message(self):
+        """"""""
+        exception = NoSupportedSourcesFound("system", "func")
+        expected = "Couldn't find any enabled source for the system "
+        expected += "system that implements the function func."
+        self.assertEqual(str(exception), expected)

--- a/tests/unit/sources/test_sources.py
+++ b/tests/unit/sources/test_sources.py
@@ -79,5 +79,7 @@ class TestGetSourceMethod(TestCase):
     def test_get_source_no_valid_sources(self):
         """Test that get_source_method raises an exceptions with no valid
         source."""
-        self.assertRaises(NoSupportedSourcesFound, get_source_method,
-                          "test_system", [], "get_builds", {})
+        msg = """Couldn't find any enabled source for the system test_system
+         that implements the function get_builds.""""".replace("\n", " ")
+        with self.assertRaises(NoSupportedSourcesFound, msg=msg):
+            get_source_method("test_system", [], "get_builds", {})


### PR DESCRIPTION
In a previous change the CibylException constructor was changed to
simply store the message attribute. This is problematic since  it does
not populate the args attribute via the BaseException constructor and
some exceptions do show the expected message correctly.
