### PR TITLE
Decouple OpenStack from Elsaticsearch source

### DIFF
--- a/cibyl/plugins/__init__.py
+++ b/cibyl/plugins/__init__.py
@@ -52,9 +52,8 @@ def extend_source(plugin_name, plugin_module_path):
                if f.endswith('.py') and f != '__init__.py']:
         mod = __import__('.'.join(
             [f"cibyl.plugins.{plugin_name}.sources", py]), fromlist=[py])
-        new_element = [source_tuple[1] for source_tuple in
-                       inspect.getmembers(mod, is_plugin_class)]
-        plugin_sources.extend(new_element)
+        plugin_sources.extend([source_tuple[1] for source_tuple in
+                               inspect.getmembers(mod, is_plugin_class)])
     for plugin_source in plugin_sources:
         SourceFactory.extend_source(plugin_source)
 

--- a/cibyl/plugins/openstack/sources/elasticsearch.py
+++ b/cibyl/plugins/openstack/sources/elasticsearch.py
@@ -1,0 +1,198 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+import logging
+import re
+
+from cibyl.models.attribute import AttributeDictValue
+from cibyl.models.ci.base.job import Job
+from cibyl.plugins.openstack.deployment import Deployment
+from cibyl.sources.source import speed_index
+from cibyl.utils.filtering import IP_PATTERN
+
+LOG = logging.getLogger(__name__)
+
+
+class ElasticSearch:
+    """Elasticsearch Source"""
+
+    @speed_index({'base': 2})
+    def get_deployment(self, **kwargs):
+        """Get deployment information for jobs from elasticsearch server.
+
+        :returns: container of jobs with deployment information from
+        elasticsearch server
+        :rtype: :class:`AttributeDictValue`
+        """
+        jobs_found = self.get_jobs(**kwargs)
+
+        query_body = {
+            "query": {
+              "bool": {
+                "must": [
+                  {
+                    "bool": {
+                      "must": []
+                    }
+                  },
+                  {
+                    "bool": {
+                      "should": [
+                        {
+                          "exists": {
+                            "field": "ip_version"
+                          }
+                        },
+                        {
+                          "exists": {
+                            "field": "storage_backend"
+                          }
+                        },
+                        {
+                          "exists": {
+                            "field": "network_backend"
+                          }
+                        },
+                        {
+                          "exists": {
+                            "field": "dvr"
+                          }
+                        },
+                        {
+                          "exists": {
+                            "field": "topology"
+                          }
+                        }
+                      ],
+                      "minimum_should_match": 1
+                    }
+                  }
+                ]
+              }
+            },
+            "size": 1,
+            "sort": [
+                {
+                    "timestamp.keyword": {
+                        "order": "desc"
+                    }
+                }
+            ]
+        }
+
+        results = []
+        hits = []
+        for job in jobs_found:
+            query_body['query']['bool']['must'][0]['bool']['must'] = {
+                "match": {
+                    "job_name.keyword": f"{job}"
+                }
+            }
+            results = self.__query_get_hits(
+                query=query_body,
+                index='logstash_jenkins'
+            )
+            if results:
+                hits.append(results[0])
+
+        if not results:
+            return jobs_found
+
+        ip_version_argument = None
+        if 'ip_version' in kwargs:
+            ip_version_argument = kwargs.get('ip_version').value
+        dvr_argument = None
+        if 'dvr' in kwargs:
+            dvr_argument = kwargs.get('dvr').value
+        release_argument = None
+        if 'release' in kwargs:
+            release_argument = kwargs.get('release').value
+        network_argument = None
+        if 'network_backend' in kwargs:
+            network_argument = kwargs.get('network_backend').value
+        storage_argument = None
+        if 'storage_backend' in kwargs:
+            storage_argument = kwargs.get('storage_backend').value
+        if 'osp_release' in kwargs:
+            storage_argument = kwargs.get('osp_release').value
+
+        job_objects = {}
+        for hit in hits:
+            job_name = hit['_source']['job_name']
+            job_url = re.compile(r"(.*)/\d").search(
+                hit['_source']['build_url']
+            ).group(1)
+
+            # If the key exists assign the value otherwise assign unknown
+            topology = hit['_source'].get(
+                "topology", "unknown")
+            network_backend = hit['_source'].get(
+                "network_backend", "unknown")
+            ip_version = hit['_source'].get(
+                "ip_version", "unknown")
+            storage_backend = hit['_source'].get(
+                "storage_backend", "unknown")
+            dvr = hit['_source'].get(
+                "dvr", "unknown")
+            osp_release = hit['_source'].get(
+                "osp_release", "unknown")
+
+            if ip_version != 'unknown':
+                matches = IP_PATTERN.search(ip_version)
+                ip_version = matches.group(1)
+
+            # Check if necessary filter by IP version:
+            if ip_version_argument and \
+                    ip_version not in ip_version_argument:
+                continue
+
+            # Check if necessary filter by dvr:
+            if isinstance(dvr_argument, list) and \
+                    dvr not in dvr_argument:
+                continue
+
+            # Check if necessary filter by release version:
+            if release_argument and \
+                    osp_release not in release_argument:
+                continue
+
+            # Check if necessary filter by network backend:
+            if network_argument and \
+                    network_backend not in network_argument:
+                continue
+
+            # Check if necessary filter by storage backend:
+            if storage_argument and \
+                    storage_backend not in storage_argument:
+                continue
+
+            job_objects[job_name] = Job(name=job_name, url=job_url)
+            deployment = Deployment(
+                release=osp_release,
+                infra_type='',
+                nodes={},
+                services={},
+                ip_version=ip_version,
+                topology=topology,
+                network_backend=network_backend,
+                dvr=dvr,
+                storage_backend=storage_backend,
+                tls_everywhere=''
+            )
+
+            job_objects[job_name].add_deployment(deployment)
+
+        return AttributeDictValue("jobs", attr_type=Job, value=job_objects)

--- a/docs/source/development/sources.rst
+++ b/docs/source/development/sources.rst
@@ -5,8 +5,10 @@ To add/develop a new type of source, follow the following guidelines:
 
 * A source should be added to cibyl/sources/<SOURCE_NAME>
 
-* The source class you develop should inherit from the Source class (cibyl/sources/)
+* The source class you develop should inherit from the Source class (``cibyl/sources/source.py``)
 
 * For a source to support an argument, it should implement the function name associated with that argument
 
 * Each source method that implements a method of an argument, should be returning an AttributeDict value of the top level entity associated with the CI systems (e.g. ``AttributeDictValue("jobs", attr_type=Job, value=job_objects)``)
+
+* A source should handle only CI/CD related data. If you would like a certain source to pull a product related data, you should add a source class (with the same name as the CI/CD source) to corresponding plugin (``cibyl/plugin/<PLUGIN_NAME>/sources/<SOURCE_DIR/FILE>``)

--- a/tests/unit/sources/elasticsearch/test_api.py
+++ b/tests/unit/sources/elasticsearch/test_api.py
@@ -20,16 +20,16 @@ from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 from cibyl.cli.argument import Argument
 from cibyl.exceptions.source import MissingArgument
-from cibyl.sources.elasticsearch.api import ElasticSearchOSP, QueryTemplate
+from cibyl.sources.elasticsearch.api import ElasticSearch, QueryTemplate
 from tests.utils import OpenstackPluginWithJobSystem
 
 
-class TestElasticsearchOSP(TestCase):
-    """Test cases for :class:`ElasticSearchOSP`.
+class TestElasticSearch(TestCase):
+    """Test cases for :class:`ElasticSearch`.
     """
 
     def setUp(self) -> None:
-        self.es_api = ElasticSearchOSP(elastic_client=Mock())
+        self.es_api = ElasticSearch(elastic_client=Mock())
         self.job_hits = [
                     {
                         '_id': 1,
@@ -127,9 +127,9 @@ class TestElasticsearchOSP(TestCase):
             }
         ]
 
-    @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
+    @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
     def test_get_jobs(self: object, mock_query_hits: object) -> None:
-        """Tests that the internal logic from :meth:`ElasticSearchOSP.get_jobs`
+        """Tests that the internal logic from :meth:`ElasticSearch.get_jobs`
             is correct.
         """
         mock_query_hits.return_value = self.job_hits
@@ -143,9 +143,9 @@ class TestElasticsearchOSP(TestCase):
         self.assertEqual(jobs['test'].name.value, 'test')
         self.assertEqual(jobs['test'].url.value, "http://domain.tld/test")
 
-    @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
+    @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
     def test_get_jobs_jobs_scope(self: object, mock_query_hits: object):
-        """Tests that the internal logic from :meth:`ElasticSearchOSP.get_jobs`
+        """Tests that the internal logic from :meth:`ElasticSearch.get_jobs`
             is correct using jobs_scope argument.
         """
         mock_query_hits.return_value = self.job_hits
@@ -157,10 +157,10 @@ class TestElasticsearchOSP(TestCase):
         self.assertEqual(jobs['test4'].name.value, 'test4')
         self.assertEqual(jobs['test4'].url.value, "http://domain.tld/test4")
 
-    @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
+    @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
     def test_get_builds(self: object, mock_query_hits: object) -> None:
         """Tests that the internal logic from
-           :meth:`ElasticSearchOSP.get_builds` is correct.
+           :meth:`ElasticSearch.get_builds` is correct.
         """
         mock_query_hits.return_value = self.build_hits
 
@@ -180,10 +180,10 @@ class TestElasticsearchOSP(TestCase):
         self.assertEqual(build.build_id.value, '1')
         self.assertEqual(build.status.value, "SUCCESS")
 
-    @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
+    @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
     def test_get_builds_by_status(self: object,
                                   mock_query_hits: object) -> None:
-        """Tests filtering by status in :meth:`ElasticSearchOSP.get_builds`
+        """Tests filtering by status in :meth:`ElasticSearch.get_builds`
             is correct.
         """
         mock_query_hits.return_value = self.job_hits
@@ -207,10 +207,10 @@ class TestElasticsearchOSP(TestCase):
         self.assertEqual(build.build_id.value, '2')
         self.assertEqual(build.status.value, "FAIL")
 
-    @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
+    @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
     def test_get_tests(self: object,
                        mock_query_hits: object) -> None:
-        """Tests internal logic :meth:`ElasticSearchOSP.get_tests`
+        """Tests internal logic :meth:`ElasticSearch.get_tests`
             is correct.
         """
         mock_query_hits.return_value = self.tests_hits
@@ -278,20 +278,20 @@ class TestElasticsearchOSP(TestCase):
 
     @patch('cibyl.sources.elasticsearch.api.ElasticSearchClient')
     def test_setup(self, mock_client):
-        """Test setup method of ElasticSearchOSP"""
-        es_api = ElasticSearchOSP(elastic_client=None,
-                                  url="https://example.com:9200")
+        """Test setup method of ElasticSearch"""
+        es_api = ElasticSearch(elastic_client=None,
+                               url="https://example.com:9200")
         client = mock_client.return_value
         client.connect.side_effect = None
         es_api.setup()
         mock_client.assert_called_with("https://example.com", 9200)
 
 
-class TestElasticsearchOSPOpenstackPlugin(OpenstackPluginWithJobSystem):
-    """Test cases for :class:`ElasticSearchOSP` with openstack plugin."""
+class TestElasticSearchOpenstackPlugin(OpenstackPluginWithJobSystem):
+    """Test cases for :class:`ElasticSearch` with openstack plugin."""
 
     def setUp(self) -> None:
-        self.es_api = ElasticSearchOSP(elastic_client=Mock())
+        self.es_api = ElasticSearch(elastic_client=Mock())
         self.job_hits = [
                     {
                         '_id': 1,
@@ -389,10 +389,10 @@ class TestElasticsearchOSPOpenstackPlugin(OpenstackPluginWithJobSystem):
             }
         ]
 
-    @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
+    @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
     def test_get_deployment(self: object, mock_query_hits: object) -> None:
         """Tests that the internal logic from
-        :meth:`ElasticSearchOSP.get_deployment` is correct.
+        :meth:`ElasticSearch.get_deployment` is correct.
         """
         mock_query_hits.return_value = self.build_hits
 
@@ -411,10 +411,10 @@ class TestElasticsearchOSPOpenstackPlugin(OpenstackPluginWithJobSystem):
         self.assertEqual(deployment.ip_version.value, '4')
         self.assertEqual(deployment.topology.value, 'unknown')
 
-    @patch.object(ElasticSearchOSP, '_ElasticSearchOSP__query_get_hits')
+    @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
     def test_deployment_filtering(self: object,
                                   mock_query_hits: object) -> None:
-        """Tests that the internal logic from :meth:`ElasticSearchOSP.get_jobs`
+        """Tests that the internal logic from :meth:`ElasticSearch.get_jobs`
             is correct.
         """
         mock_query_hits.return_value = self.build_hits

--- a/tests/unit/sources/test_source_factory.py
+++ b/tests/unit/sources/test_source_factory.py
@@ -16,7 +16,7 @@
 from unittest import TestCase
 
 from cibyl.exceptions.config import NonSupportedSourceType
-from cibyl.sources.elasticsearch.api import ElasticSearchOSP
+from cibyl.sources.elasticsearch.api import ElasticSearch
 from cibyl.sources.jenkins import Jenkins
 from cibyl.sources.jenkins_job_builder import JenkinsJobBuilder
 from cibyl.sources.source_factory import SourceFactory
@@ -40,7 +40,7 @@ class TestSourceFactory(TestCase):
         source = SourceFactory.create_source("elasticsearch", "elastic_source",
                                              driver="elastic",
                                              url="url")
-        self.assertTrue(isinstance(source, ElasticSearchOSP))
+        self.assertTrue(isinstance(source, ElasticSearch))
         self.assertEqual(source.name, "elastic_source")
         self.assertEqual(source.driver, "elastic")
         self.assertEqual(source.url, "url")

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -235,7 +235,7 @@ class TestOrchestrator(TestCase):
         self.assertEqual(env.name.value, 'env4')
         self.assertEqual(env.systems[0].name.value, 'system1')
 
-    @patch("cibyl.sources.elasticsearch.api.ElasticSearchOSP.setup")
+    @patch("cibyl.sources.elasticsearch.api.ElasticSearch.setup")
     def test_setup_sources(self, patched_setup):
         """Test that setup_sources calls the setup method of the sources
         enabled in the environment."""


### PR DESCRIPTION
Same as was done for Jenkins - decouple the OpenStack
methods/logic from Elasticsearch source and attach it
only if OpenStack plugin is used.
