### PR TITLE
Switch to query and publish per system

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -17,7 +17,6 @@ import logging
 import sys
 
 from cibyl.cli.output import OutputStyle
-from cibyl.cli.query import get_query_type
 from cibyl.exceptions import CibylException
 from cibyl.exceptions.cli import InvalidArgument
 from cibyl.exceptions.config import ConfigurationNotFound
@@ -116,12 +115,7 @@ def main():
         orchestrator.parser.parse()
         orchestrator.validate_environments()
         orchestrator.setup_sources()
-        orchestrator.run_query()
-        orchestrator.publisher.publish(
-            environments=orchestrator.environments,
-            style=arguments["output_style"],
-            query=get_query_type(**orchestrator.parser.ci_args),
-            verbosity=orchestrator.parser.app_args.get('verbosity'))
+        orchestrator.query_and_publish(arguments["output_style"])
     except CibylException as ex:
         if arguments["debug"]:
             raise ex

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 
 import cibyl.exceptions.config as conf_exc
 from cibyl.cli.parser import Parser
+from cibyl.cli.query import get_query_type
 from cibyl.cli.validator import Validator
 from cibyl.config import Config, ConfigFactory
 from cibyl.exceptions.config import NonSupportedSystemKey
@@ -191,10 +192,8 @@ class Orchestrator:
                         if source.enabled:
                             source.setup()
 
-    def run_query(self, start_level=1):
+    def run_query(self, system, start_level=1):
         """Execute query based on provided arguments."""
-        valid_systems = [system for env in self.environments
-                         for system in env.systems]
         debug = self.parser.app_args.get("debug", False)
         # sort cli arguments in decreasing order by level
         sorted_args = sorted(self.parser.ci_args.values(),
@@ -208,68 +207,63 @@ class Orchestrator:
                     # associated, we should not consider it here, e.g.
                     # --sources
                     continue
-                # the validation process provides a flat list of systems
-                # because the environment information is not used from this
-                # point forward
-                for system in valid_systems:
-                    if not system.is_enabled():
-                        continue
-                    system_name = system.name.value
-                    source_methods_store = system_methods_stores[system_name]
-                    # collect system-level arguments that can affect the
-                    # result of the source method call
-                    system_args = system.export_attributes_to_source()
-                    try:
-                        source_methods = self.select_source_method(system, arg)
-                    except NoSupportedSourcesFound as exception:
-                        # if no sources are found in the system for this
-                        # particular query, jump to the next one without
-                        # stopping execution
-                        LOG.error(exception, exc_info=debug)
-                        continue
-
-                    for source_method, speed_score in source_methods:
-                        if source_methods_store.has_been_called(source_method):
-                            # we want to avoid repeating calls to the same
-                            # source method if several arguments with that
-                            # method are provided
-                            if source_methods_store.get_status(source_method):
-                                # if the previous call was successful, we do
-                                # not need to query the same method again
-                                break
-                            else:
-                                # if the previous call threw an error, let's
-                                # try a different source
-                                continue
-                        source_info = source_information_from_method(
-                                source_method)
-                        start_time = time.time()
-                        LOG.debug("Running %s and speed index %d",
-                                  source_info, speed_score)
-                        try:
-                            model_instances_dict = source_method(
-                                **self.parser.ci_args, **self.parser.app_args,
-                                **system_args)
-                        except SourceException as exception:
-                            source_methods_store.add_call(source_method, False)
-                            LOG.error("Error in %s under system: '%s'. "
-                                      "Reason: '%s'.",
-                                      source_info, system.name.value,
-                                      exception, exc_info=debug)
-                            continue
-                        source_methods_store.add_call(source_method, True)
-                        end_time = time.time()
-                        LOG.info("Took %.2fs to query system %s using %s",
-                                 end_time-start_time, system.name.value,
-                                 source_info)
-                        system.populate(model_instances_dict)
-                        system.register_query()
-                        # if one source has provided the information, there is
-                        # no need to query the rest
-                        break
+                if not system.is_enabled():
+                    return
                 # we update last_level if the the arg has a func attribute
                 # and valid sources to query
                 last_level = arg.level
+                source_methods_store = system_methods_stores[system.name.value]
+                # collect system-level arguments that can affect the
+                # result of the source method call
+                system_args = system.export_attributes_to_source()
+                try:
+                    source_methods = self.select_source_method(system, arg)
+                except NoSupportedSourcesFound as exception:
+                    # if no sources are found in the system for this
+                    # particular query, jump to the next one without
+                    # stopping execution
+                    LOG.error(exception, exc_info=debug)
+                    continue
+                for source_method, speed_score in source_methods:
+                    if source_methods_store.has_been_called(source_method):
+                        # we want to avoid repeating calls to the same
+                        # source method if several arguments with that
+                        # method are provided
+                        if source_methods_store.get_status(source_method):
+                            # if the previous call was successful, we do
+                            # not need to query the same method again
+                            break
+                        else:
+                            # if the previous call threw an error, let's
+                            # try a different source
+                            continue
+                    source_info = source_information_from_method(
+                            source_method)
+                    start_time = time.time()
+                    LOG.info(f"Performing query on system {system.name}")
+                    LOG.debug("Running %s and speed index %d",
+                              source_info, speed_score)
+                    try:
+                        model_instances_dict = source_method(
+                            **self.parser.ci_args, **self.parser.app_args,
+                            **system_args)
+                    except SourceException as exception:
+                        source_methods_store.add_call(source_method, False)
+                        LOG.error("Error in %s under system: '%s'. "
+                                  "Reason: '%s'.",
+                                  source_info, system.name.value,
+                                  exception, exc_info=debug)
+                        continue
+                    source_methods_store.add_call(source_method, True)
+                    end_time = time.time()
+                    LOG.info("Took %.2fs to query system %s using %s",
+                             end_time-start_time, system.name.value,
+                             source_info)
+                    system.populate(model_instances_dict)
+                    system.register_query()
+                    # if one source has provided the information, there is
+                    # no need to query the rest
+                    break
 
     def extend_parser(self, attributes, group_name='Environment',
                       level=0):
@@ -285,3 +279,22 @@ class Orchestrator:
                                        level=level+1)
                 else:
                     self.parser.extend(arguments, group_name, level=level)
+
+    def query_and_publish(self, output_style="colorized"):
+        """Iterate over the environments and their systems and publish
+        the results of the queries.
+
+        The query and publish is performed per system"""
+        for env in self.environments:
+            self.publisher.publish(
+                model_instance=env,
+                style=output_style,
+                query=get_query_type(**self.parser.ci_args),
+                verbosity=self.parser.app_args.get('verbosity'))
+            for system in env.systems:
+                self.run_query(system)
+                self.publisher.publish(
+                    model_instance=system,
+                    style=output_style,
+                    query=get_query_type(**self.parser.ci_args),
+                    verbosity=self.parser.app_args.get('verbosity'))

--- a/cibyl/outputs/cli/ci/colored.py
+++ b/cibyl/outputs/cli/ci/colored.py
@@ -44,12 +44,9 @@ class CIColoredPrinter(ColoredPrinter, CIPrinter):
         printer.add(self._palette.blue('Environment: '), 0)
         printer[0].append(env.name.value)
 
-        for system in env.systems:
-            printer.add(self._print_system(system), 1)
-
         return printer.build()
 
-    def _print_system(self, system):
+    def print_system(self, system, indent=1):
         """
         :param system: The system.
         :type system: :class:`cibyl.models.ci.base.system.System`
@@ -80,4 +77,4 @@ class CIColoredPrinter(ColoredPrinter, CIPrinter):
                 self.query, self.verbosity, self.palette
             )
 
-        return get_printer().print_system(system)
+        return get_printer().print_system(system, indent)

--- a/cibyl/outputs/cli/ci/system/impls/base/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/colored.py
@@ -30,10 +30,10 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
     """
 
     @overrides
-    def print_system(self, system):
+    def print_system(self, system, indent=0):
         printer = IndentedTextBuilder()
 
-        printer.add(self._palette.blue('System: '), 0)
+        printer.add(self._palette.blue('System: '), indent)
         printer[-1].append(system.name.value)
 
         if self.verbosity > 0:

--- a/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
@@ -32,10 +32,10 @@ class ColoredJobsSystemPrinter(ColoredPrinter, CISystemPrinter):
     """
 
     @overrides
-    def print_system(self, system):
+    def print_system(self, system, indent=0):
         printer = IndentedTextBuilder()
 
-        printer.add(self._palette.blue('System: '), 0)
+        printer.add(self._palette.blue('System: '), indent)
         printer[-1].append(system.name.value)
 
         if self.verbosity > 0:
@@ -43,15 +43,15 @@ class ColoredJobsSystemPrinter(ColoredPrinter, CISystemPrinter):
 
         if self.query != QueryType.NONE:
             for job in system.jobs.values():
-                printer.add(self.print_job(job), 1)
+                printer.add(self.print_job(job), indent+1)
 
             if system.is_queried():
                 header = 'Total jobs found in query: '
 
-                printer.add(self._palette.blue(header), 1)
+                printer.add(self._palette.blue(header), indent+1)
                 printer[-1].append(len(system.jobs))
             else:
-                printer.add(self._palette.blue('No query performed'), 1)
+                printer.add(self._palette.blue('No query performed'), indent+1)
 
         return printer.build()
 

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -209,29 +209,29 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
             return result.build()
 
     @overrides
-    def print_system(self, system):
+    def print_system(self, system, indent=0):
         printer = IndentedTextBuilder()
 
         # Begin with the text common to all systems
-        printer.add(super().print_system(system), 0)
+        printer.add(super().print_system(system), indent)
 
         # Continue with text specific for this system type
         if self.query >= QueryType.TENANTS:
             if hasattr(system, 'tenants'):
                 if system.tenants.value:
                     for tenant in system.tenants.values():
-                        printer.add(self._print_tenant(tenant), 1)
+                        printer.add(self._print_tenant(tenant), indent+1)
 
                     if system.is_queried():
                         header = 'Total tenants found in query: '
-                        printer.add(self.palette.blue(header), 1)
+                        printer.add(self.palette.blue(header), indent+1)
                         printer[-1].append(len(system.tenants))
                     else:
                         msg = 'No query performed.'
-                        printer.add(self.palette.blue(msg), 1)
+                        printer.add(self.palette.blue(msg), indent+1)
                 else:
                     msg = 'No tenants found in query.'
-                    printer.add(self.palette.red(msg), 1)
+                    printer.add(self.palette.red(msg), indent+1)
             else:
                 LOG.warning(
                     'Requested tenant printing on a non-zuul interface. '

--- a/cibyl/publisher.py
+++ b/cibyl/publisher.py
@@ -29,7 +29,7 @@ class Publisher:
     """
 
     @staticmethod
-    def publish(environments,
+    def publish(model_instance,
                 target="terminal",
                 style=OutputStyle.TEXT,
                 query=QueryType.NONE,
@@ -38,7 +38,8 @@ class Publisher:
         chosen destination.
         """
         if target == "terminal":
-            for env in environments:
-                printer = CIPrinterFactory.from_style(style, query, verbosity)
+            printer = CIPrinterFactory.from_style(style, query, verbosity)
 
-                print(printer.print_environment(env))
+            model_type = model_instance.__module__.split('.')[-1]
+            method_to_call = getattr(printer, f"print_{model_type}")
+            print(method_to_call(model_instance))

--- a/tests/unit/test_publisher.py
+++ b/tests/unit/test_publisher.py
@@ -42,7 +42,7 @@ class TestOrchestrator(TestCase):
 
         mock_printer_factory.return_value = printer
 
-        self.publisher.publish(environments=[self.environment],
+        self.publisher.publish(model_instance=self.environment,
                                target="terminal",
                                style=style)
 


### PR DESCRIPTION
The current behavior is to first query all the systems
specified in the configuration file and only then publish the
results. The problem with this approach is that the user sees
nothing until all the queries are performed. Perhaps for one
or two systems that's not too bad, but for a dozen of systems
that becomes a bad UX.

This change modifies this behavior to publish the results for
each system, allowing the user to see some output, even if
it didn't finish to query all systems.

In addition, before each query, a message is logged to the
screen, letting the user know that a query started.
