### PR TITLE
Improving error messages reported by Zuul source

### DIFF
--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -49,7 +49,7 @@ def source_information_from_method(source_method):
     :rtype: str
     """
     source = source_method.__self__
-    info_str = f"source {source.name} of type {source.driver}"
+    info_str = f"source: '{source.name}' of type: '{source.driver}'"
     if LOG.getEffectiveLevel() <= logging.DEBUG:
         info_str += f" using method {source_method.__name__}"
     return info_str
@@ -248,7 +248,8 @@ class Orchestrator:
                                 **system_args)
                         except SourceException as exception:
                             source_methods_store.add_call(source_method, False)
-                            LOG.error("Error in %s with system %s. %s",
+                            LOG.error("Error in %s under system: '%s'. "
+                                      "Reason: '%s'.",
                                       source_info, system.name.value,
                                       exception, exc_info=debug)
                             continue

--- a/cibyl/sources/zuul/apis/rest.py
+++ b/cibyl/sources/zuul/apis/rest.py
@@ -91,15 +91,32 @@ class ZuulSession(Closeable):
             code = request.status_code
 
             if code == 401:
-                raise ZuulAPIError('Unauthorized.') from ex
+                msg = f"Error - 401. " \
+                      f"Unauthorized access to resource: '{request.url}'. " \
+                      f"Check credentials and try again."
+
+                raise ZuulAPIError(msg) from ex
 
             if code == 403:
-                raise ZuulAPIError('Insufficient privileges.') from ex
+                msg = f"Error - 403. " \
+                      f"Insufficient privileges " \
+                      f"to access resource at: '{request.url}'. " \
+                      f"Check credentials and try again."
+
+                raise ZuulAPIError(msg) from ex
 
             if code == 404:
-                raise ZuulAPIError('Resource not found.') from ex
+                msg = f"Error - 404. " \
+                      f"Resource not found at: '{request.url}'. " \
+                      f"Check resource availability and try again."
 
-            raise ZuulAPIError(f'Unknown error code {code}') from ex
+                raise ZuulAPIError(msg) from ex
+
+            msg = f"Unknown error code: '{code}' " \
+                  f"returned by host at: {request.url}. " \
+                  f"Wait for a couple of minutes and try again..."
+
+            raise ZuulAPIError(msg) from ex
 
 
 class ZuulJobRESTClient(ZuulJobAPI):

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -185,7 +185,7 @@ class TestOrchestrator(TestCase):
         """Test that the source_information_from_method methods provides the
         correct representation of the source."""
         source = Source(name="source", driver="driver")
-        expected = "source source of type driver"
+        expected = "source: 'source' of type: 'driver'"
         output = source_information_from_method(source.setup)
         self.assertEqual(expected, output)
 


### PR DESCRIPTION
Providing more information to the error message so that this:
`ERROR    cibyl.orchestrator   Error in source zuul_cp of type zuul with system zuul_cp. Resource not found.`
Becomes this:
`ERROR    cibyl.orchestrator   Error in source: 'zuul' of type: 'zuul' under system: 'zuul'. Reason: 'Error - 404. Resource not found at: 'https://---.com/api/tenants'. Check resource availability and try again.'.`
