### PR TITLE
Add initial version of features mechanism

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -115,7 +115,9 @@ def main():
         orchestrator.parser.parse()
         orchestrator.validate_environments()
         orchestrator.setup_sources()
-        orchestrator.query_and_publish(arguments["output_style"])
+        features = orchestrator.load_features()
+        orchestrator.query_and_publish(arguments["output_style"],
+                                       features=features)
     except CibylException as ex:
         if arguments["debug"]:
             raise ex

--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -23,16 +23,20 @@ class QueryType(IntEnum):
     """
     NONE = 0
     """No data from host is requested."""
-    TENANTS = 1
+    FEATURES = 1
+    """Retrieve data using features."""
+    TENANTS = 2
     """Only retrieve data concerning tenants."""
-    PROJECTS = 2
+    PROJECTS = 3
     """Retrieve data concerning projects and above."""
-    PIPELINES = 3
+    PIPELINES = 4
     """Retrieve data concerning pipelines and above."""
-    JOBS = 4
+    JOBS = 5
     """Retrieve data concerning jobs and above."""
-    BUILDS = 5
+    BUILDS = 6
     """Retrieve data concerning builds and above."""
+    FEATURES_JOBS = 7
+    """Retrieve data using features and jobs."""
 
 
 class QuerySelector:
@@ -74,6 +78,12 @@ class QuerySelector:
         build_args = subset(kwargs, ["builds", "last_build", "build_status"])
         if build_args:
             result = QueryType.BUILDS
+
+        if 'features' in kwargs:
+            if job_args:
+                result = QueryType.FEATURES_JOBS
+            else:
+                result = QueryType.FEATURES
 
         return result
 

--- a/cibyl/exceptions/features.py
+++ b/cibyl/exceptions/features.py
@@ -13,18 +13,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.exceptions import CibylException
 
 
-class CibylException(Exception):
-    """Parent class for all cibyl exceptions for easier control of the
-    exceptions' representation.
+class MissingFeature(CibylException):
+    """Represents an error loading a feature.
     """
 
-    def __init__(self, message=''):
+    def __init__(self, message='Feature not found.'):
         """Constructor.
-
-        :param message: The reason for this error.
-        :type message: str
         """
-        self.message = message
-        super().__init__(*[message])
+        super().__init__(message)

--- a/cibyl/features/general.py
+++ b/cibyl/features/general.py
@@ -13,18 +13,3 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-
-
-class CibylException(Exception):
-    """Parent class for all cibyl exceptions for easier control of the
-    exceptions' representation.
-    """
-
-    def __init__(self, message=''):
-        """Constructor.
-
-        :param message: The reason for this error.
-        :type message: str
-        """
-        self.message = message
-        super().__init__(*[message])

--- a/cibyl/models/ci/base/system.py
+++ b/cibyl/models/ci/base/system.py
@@ -22,6 +22,7 @@ from cibyl.exceptions.model import NonSupportedModelType
 from cibyl.models.attribute import AttributeDictValue, AttributeListValue
 from cibyl.models.ci.base.job import Job
 from cibyl.models.model import Model
+from cibyl.models.product.feature import Feature
 from cibyl.sources.source import Source
 
 
@@ -61,7 +62,16 @@ class System(Model):
         'queried': {
             'attr_type': bool,
             'arguments': []
-        }
+        },
+        'features': {
+            'attr_type': Feature,
+            'attribute_value_class': AttributeDictValue,
+            'arguments': [
+                Argument(name='--features', arg_type=str,
+                         nargs="*",
+                         description="Template to query for a given feature")
+            ]
+        },
     }
     """Defines the CLI arguments for all systems.
     """
@@ -154,6 +164,10 @@ class System(Model):
                 self.add_toplevel_model(model)
         else:
             raise NonSupportedModelType(instances.attr_type)
+
+    def add_feature(self, feature):
+        """Add a feature to the system."""
+        self.features[feature.name.value] = feature
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/cibyl/models/product/__init__.py
+++ b/cibyl/models/product/__init__.py
@@ -1,5 +1,4 @@
-"""
-#    Copyright 2022 Red Hat
+# Copyright 2022 Red Hat
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -12,19 +11,3 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-"""
-
-
-class CibylException(Exception):
-    """Parent class for all cibyl exceptions for easier control of the
-    exceptions' representation.
-    """
-
-    def __init__(self, message=''):
-        """Constructor.
-
-        :param message: The reason for this error.
-        :type message: str
-        """
-        self.message = message
-        super().__init__(*[message])

--- a/cibyl/models/product/feature.py
+++ b/cibyl/models/product/feature.py
@@ -1,5 +1,5 @@
 """
-#    Copyright 2022 Red Hat
+# Copyright 2022 Red Hat
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -13,18 +13,27 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+# pylint: disable=no-member
+from cibyl.models.model import Model
 
 
-class CibylException(Exception):
-    """Parent class for all cibyl exceptions for easier control of the
-    exceptions' representation.
-    """
+class Feature(Model):
+    """Represents a Feature present (or not) in a CI environment."""
 
-    def __init__(self, message=''):
-        """Constructor.
+    API = {
+        'name': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'present': {
+            'attr_type': bool,
+            'arguments': []
+        },
+    }
 
-        :param message: The reason for this error.
-        :type message: str
-        """
-        self.message = message
-        super().__init__(*[message])
+    def __init__(self, name, present):
+        # Let IDEs know this model's attributes
+        self.name = None
+        self.present = None
+
+        super().__init__({'name': name, 'present': present})

--- a/cibyl/outputs/cli/ci/system/impls/base/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/colored.py
@@ -17,6 +17,7 @@ import logging
 
 from overrides import overrides
 
+from cibyl.cli.query import QueryType
 from cibyl.outputs.cli.ci.system.printer import CISystemPrinter
 from cibyl.outputs.cli.printer import ColoredPrinter
 from cibyl.utils.strings import IndentedTextBuilder
@@ -39,4 +40,22 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
         if self.verbosity > 0:
             printer[-1].append(f' (type: {system.system_type.value})')
 
+        if self.query in (QueryType.FEATURES_JOBS, QueryType.FEATURES):
+            for feature in system.features.values():
+                printer.add(self.print_feature(feature), 1)
+
+        return printer.build()
+
+    def print_feature(self, feature):
+        """Print a feature present in a system.
+        :param feature: The feature.
+        :type feature: :class:`cibyl.models.ci.base.feature.Feature`
+        :return: Textual representation of the provided model.
+        :rtype: str
+        """
+        printer = IndentedTextBuilder()
+        name = feature.name.value
+        present = feature.present.value
+        printer.add(self.palette.blue(f'{name} feature: '), 0)
+        printer[-1].append(present)
         return printer.build()

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -215,6 +215,10 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
         # Begin with the text common to all systems
         printer.add(super().print_system(system), indent)
 
+        if self.query == QueryType.FEATURES:
+            # if the user has only requested features, there is no need to
+            # print anythin else
+            return printer.build()
         # Continue with text specific for this system type
         if self.query >= QueryType.TENANTS:
             if hasattr(system, 'tenants'):

--- a/cibyl/plugins/__init__.py
+++ b/cibyl/plugins/__init__.py
@@ -73,6 +73,7 @@ def enable_plugins(plugins: list = None):
             LOG.debug("Loading plugin: %s", plugin)
             plugin_module = get_plugin_module(plugin)
             plugin_module.Plugin().extend_models()
+            plugin_module.Plugin().register_features()
             plugin_module_path = get_plugin_module_path(plugin_module)
             extend_source(plugin_module_path)
             plugin_module.Plugin().extend_query_types()

--- a/cibyl/plugins/openstack/__init__.py
+++ b/cibyl/plugins/openstack/__init__.py
@@ -15,6 +15,7 @@
 """
 from cibyl.cli.argument import Argument
 from cibyl.cli.query import QuerySelector, QueryType
+from cibyl.features import add_feature_location
 from cibyl.models.ci.base.job import Job
 from cibyl.models.ci.zuul.job import Job as ZuulJob
 from cibyl.plugins.openstack.deployment import Deployment
@@ -87,5 +88,11 @@ class Plugin:
         extend_job_model()
         extend_variant_model()
 
+    def register_features(self):
+        """Add the path of the features found in this plugin to the
+        features module."""
+        add_feature_location(f"{__path__[0]}/features")
+
     def extend_query_types(self):
+        """Register the plugin function to deduce the type of query."""
         QuerySelector.query_selector_functions.append(get_query_openstack)

--- a/cibyl/plugins/openstack/features/__init__.py
+++ b/cibyl/plugins/openstack/features/__init__.py
@@ -13,18 +13,15 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+import logging
+
+from cibyl.features import FeatureTemplate
+
+LOG = logging.getLogger(__name__)
 
 
-class CibylException(Exception):
-    """Parent class for all cibyl exceptions for easier control of the
-    exceptions' representation.
-    """
+class OpenstackFeatureTemplate(FeatureTemplate):
+    """Skeleton for an openstack specific feature."""
 
-    def __init__(self, message=''):
-        """Constructor.
-
-        :param message: The reason for this error.
-        :type message: str
-        """
-        self.message = message
-        super().__init__(*[message])
+    def get_method_to_query(self):
+        return "get_deployment"

--- a/cibyl/plugins/openstack/features/network.py
+++ b/cibyl/plugins/openstack/features/network.py
@@ -1,0 +1,66 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import logging
+
+from cibyl.cli.argument import Argument
+from cibyl.plugins.openstack.features import OpenstackFeatureTemplate
+
+LOG = logging.getLogger(__name__)
+
+
+class HA(OpenstackFeatureTemplate):
+    """Highly available Openstack deployment with at least 2 controllers."""
+    def __init__(self):
+        super().__init__("HA")
+
+    def get_template_args(self):
+        """Get the arguments necessary to obtain the information that defines
+        the feature."""
+        ha_arg = Argument("controllers", arg_type=str,
+                          description="Number of controller nodes",
+                          func="get_deployment",
+                          ranged=True, value=[">=2"])
+        return {'controllers': ha_arg}
+
+
+class IPV4(OpenstackFeatureTemplate):
+    """Openstack deployment using IPv4."""
+    def __init__(self):
+        super().__init__("IPV4")
+
+    def get_template_args(self):
+        """Get the arguments necessary to obtain the information that defines
+        the feature."""
+        ip_arg = Argument("ip_version", arg_type=str,
+                          description="IP version used",
+                          func="get_deployment",
+                          value=["4"])
+        return {'ip_version': ip_arg}
+
+
+class IPV6(OpenstackFeatureTemplate):
+    """Openstack deployment using IPv6."""
+    def __init__(self):
+        super().__init__("IPV6")
+
+    def get_template_args(self):
+        """Get the arguments necessary to obtain the information that defines
+        the feature."""
+        ip_arg = Argument("ip_version", arg_type=str,
+                          description="IP version used",
+                          func="get_deployment",
+                          value=["6"])
+        return {'ip_version': ip_arg}

--- a/cibyl/utils/dicts.py
+++ b/cibyl/utils/dicts.py
@@ -15,6 +15,8 @@
 """
 import logging
 
+from cibyl.models.attribute import AttributeDictValue
+
 LOG = logging.getLogger(__name__)
 
 
@@ -88,3 +90,26 @@ def chunk_dictionary_into_lists(dictionary: dict, size: int = 300) -> list:
             )[chunk_max_value:chunk_max_value + size]
         )
     return chunked_list
+
+
+def intersect_models(dict1, dict2):
+    """Combine two dictionaries that are returned from a source method call to
+    keep only those models that are present in both. It assumes that the models
+    present in both dictionaries are identical and takes them for the first
+    input dictionary.
+
+    :param dict1: The first dictionary with models.
+    :type dict1: dict
+    :param dict2: The second dictionary with models.
+    :type dict2: dict
+    :return: A new dictionary that contains only the models present in both
+    input dictionaries.
+    :rtype: dict
+    """
+    # TODO: jgilaber implement an intersection method in all models so that the
+    # intersection works for models that might contain other models, e.g.
+    # tenants in zuul
+    intersection = dict1.keys() & dict2.keys()
+    models = {key: dict1[key] for key in intersection}
+    return AttributeDictValue(dict1.name, attr_type=dict1.attr_type,
+                              value=models)

--- a/docs/source/development/features.rst
+++ b/docs/source/development/features.rst
@@ -1,0 +1,77 @@
+Features
+========
+
+In cibyl we define *features*, which are classes containing a query method that
+can run a custom query using python code. There is a FeatureTemplate class that
+can be used to quickly define simple features. The query method of this class
+will select the most appropiate source considering the speed_index and the
+method to query in the source. To define a new feature using this template, one
+only needs to define a class that inherits from FeatureTemplate, set the
+attribute *method_to_query* to the method of choice for the source and include
+in the *args* attribute the arguments that should be passed to the source's
+method  to perform the query (see for example the HA, IPV4, IPV6 features as
+a sample).
+
+One could define a feature without using the
+FeatureTemplate code at all, the only requirements would be that the class
+should provide a query method that accepts a system and returns an
+AttributeDictValue object, and should define a name attribute for the feature.
+This way of implementing a feature gives the developer total freedom, but does
+not provide some functionality like selecting the best sources given the input
+arguments. There could be a mixed implementation, that relies on the
+FeatureTemplate query method but provided a bit more flexibility. Let's say for
+exampla that one wanted a feature called Example that wants to check whether
+a system has any job called 'example' with at least 3 passing builds and runs
+a test called 'test_example'. Such a feature could be implemented for example
+like:
+
+.. code-block:: python
+
+   class Example(FeatureTemplate):
+       def __init__(self):
+           self.name = "Example"
+
+       def query(self, system, **kwargs):
+           self.method_to_query = "get_builds"
+           self.args['jobs'] = Argument("jobs",  arg_type=str,
+                                        description="jobs",
+                                        value=["example"])
+           self.args['builds'] = Argument("build",  arg_type=str,
+                                        description="build",
+                                        value=[])
+           return_builds = super().query(system, **self.args, **kwargs)
+           self.method_to_query = "get_tests"
+           self.args['jobs'] = Argument("tests",  arg_type=str,
+                                        description="tests",
+                                        value=["test_example"])
+           return_tests = super().query(system, **self.args, **kwargs)
+           # more code to combine the the returns and apply the desired
+           # conditions
+
+Features are classes defined inside modules in a feature subpackage, like
+cibyl/features or cibyl/plugins/openstack/features. The name of the module is
+used as a category for the features it contains. Features are loaded in the
+orchestrator, in the load_features method. There, a FeaturesLoader class is
+created that will look through the paths that are registered by the plugins and
+the default location to look for features. If features are found and requested
+by the user, the the run_features method ir executed. If not, a normal query is
+executed.
+
+As mentioned before, the query method should return an AttributeDictValue with
+the appropiate CI model according to the system and source used. These models
+are added to the system in the run_features method. If more than one feature is
+run, the output is combined to filter the returned models to add only those
+that satisfy all features. In addition, for each feature that runs, a Feature
+model is added to the system. This model (which is a CI model, akin to a System
+or Job) has only two attributes, the feature name and a boolean marking whether
+the feature is present in the system or not.
+
+After all features run, the publisher is used to print all the output. The same
+publisher is used for both normal queries and feature queries. The printers for
+all systems will print the Feature models added to each system, and after that
+it will continue printing other information found in the system if the user ran
+cibyl with other arguments like --jobs. In order to handle the different cases,
+there are two kind of queries added to the QueryType class: *FEATURES* and
+*FEATURES_JOBS*. The first will signal the case when the user has only
+requested --feature, while the second will mark the case where the user has
+passed both --feature and some job-related argument.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,6 +81,7 @@ Index
 
    development/tests
    development/sources
+   development/features
    development/contribute
 
 

--- a/tests/unit/cli/test_query.py
+++ b/tests/unit/cli/test_query.py
@@ -123,6 +123,24 @@ class TestGetQueryType(TestCase):
 
         self.assertEqual(QueryType.NONE, get_query_type(**args))
 
+    def test_get_feature(self):
+        """Checks that "FEATURES" is returned for "--feature"."""
+        args = {
+            'features': None
+        }
+
+        self.assertEqual(QueryType.FEATURES, get_query_type(**args))
+
+    def test_get_feature_jobs(self):
+        """Checks that "FEATURES_JOBS" is returned for "--feature" and
+        "--jobs"."""
+        args = {
+            'features': None,
+            'jobs': None
+        }
+
+        self.assertEqual(QueryType.FEATURES_JOBS, get_query_type(**args))
+
 
 class TestGetQueryTypeOpenstackPlugin(OpenstackPluginWithJobSystem):
     """Tests for :func:`get_query_type` with the openstack plugin loaded."""

--- a/tests/unit/features/__init__.py
+++ b/tests/unit/features/__init__.py
@@ -13,18 +13,3 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-
-
-class CibylException(Exception):
-    """Parent class for all cibyl exceptions for easier control of the
-    exceptions' representation.
-    """
-
-    def __init__(self, message=''):
-        """Constructor.
-
-        :param message: The reason for this error.
-        :type message: str
-        """
-        self.message = message
-        super().__init__(*[message])

--- a/tests/unit/features/data/__init__.py
+++ b/tests/unit/features/data/__init__.py
@@ -13,18 +13,3 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-
-
-class CibylException(Exception):
-    """Parent class for all cibyl exceptions for easier control of the
-    exceptions' representation.
-    """
-
-    def __init__(self, message=''):
-        """Constructor.
-
-        :param message: The reason for this error.
-        :type message: str
-        """
-        self.message = message
-        super().__init__(*[message])

--- a/tests/unit/features/data/testing.py
+++ b/tests/unit/features/data/testing.py
@@ -1,0 +1,69 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+from cibyl.cli.argument import Argument
+from cibyl.features import FeatureTemplate
+
+
+class Feature1(FeatureTemplate):
+    """Feature for testing1"""
+
+    def __init__(self):
+        super().__init__("Feature1")
+
+    def get_method_to_query(self):
+        return "get_jobs"
+
+    def get_template_args(self):
+        jobs = Argument("jobs", arg_type=str,
+                        description="jobs",
+                        func="get_jobs",
+                        value=["pep8"])
+
+        return {"jobs": jobs}
+
+
+class Feature2(FeatureTemplate):
+    """Feature for testing2"""
+    def __init__(self):
+        super().__init__("Feature2")
+
+    def get_method_to_query(self):
+        return "get_jobs"
+
+    def get_template_args(self):
+        jobs = Argument("jobs", arg_type=str,
+                        description="jobs",
+                        func="get_jobs",
+                        value=["pep8"])
+
+        return {"jobs": jobs}
+
+
+class Feature3(FeatureTemplate):
+    def __init__(self):
+        super().__init__("Feature3")
+
+    def get_method_to_query(self):
+        return "get_jobs"
+
+    def get_template_args(self):
+        jobs = Argument("jobs", arg_type=str,
+                        description="jobs",
+                        func="get_jobs",
+                        value=["pep8"])
+
+        return {"jobs": jobs}

--- a/tests/unit/features/test_features.py
+++ b/tests/unit/features/test_features.py
@@ -1,0 +1,91 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import inspect
+import os
+from copy import deepcopy
+from unittest import TestCase
+
+from cibyl import features
+from cibyl.exceptions.cli import InvalidArgument
+from cibyl.features import (FeatureTemplate, get_feature,
+                            get_string_all_features, is_feature_class,
+                            load_features)
+from cibyl.utils.colors import Colors
+from tests.unit.features.data.testing import Feature1, Feature2
+from tests.utils import RestoreAPIs
+
+
+class TestFeaturesLoader(RestoreAPIs):
+    """Testing FeaturesLoader class"""
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.feature_path = os.path.dirname(inspect.getfile(Feature1))
+        load_features(feature_paths=[cls.feature_path])
+
+    def test_is_feature_class(self):
+        """Test that the is_feature_class function properly filters the classes
+        that correspond to features."""
+        self.assertTrue(is_feature_class(Feature1))
+        self.assertTrue(is_feature_class(Feature2))
+        # is class, but not feature
+        self.assertFalse(is_feature_class(TestCase))
+        # is not class
+        self.assertFalse(is_feature_class(TestCase))
+        # is abstract class
+        self.assertFalse(is_feature_class(FeatureTemplate))
+
+    def test_get_feature_successful(self):
+        """Test that the FeaturesLoader properly gets the loaded features by
+        name"""
+        feature1 = get_feature("Feature1")
+        # test lowercase/uppercase cases
+        feature2 = get_feature("feature2")
+        feature3 = get_feature("FEATURE3")
+        self.assertEqual(feature1.name, "Feature1")
+        self.assertEqual(feature2.name, "Feature2")
+        self.assertEqual(feature3.name, "Feature3")
+
+    def test_get_feature_inexistent(self):
+        """Test that an error is raised when a non-existent feature is
+        requested."""
+        msg = "No feature non-existing. Choose one of the following "
+        msg += "features:\n"
+        msg += "\nTesting:\n * Feature1 - Feature for testing1\n"
+        msg += " * Feature2 - Feature for testing2"
+        with self.assertRaises(InvalidArgument, msg=msg):
+            get_feature("non-existing")
+
+    def test_get_string_all_features(self):
+        """Test that get_string_all_features provides the correct string
+        representation."""
+        output = get_string_all_features()
+        expected = f"\n{Colors.blue('Testing')}:\n"
+        expected += f"{Colors.red(' * ')}{Colors.blue('Feature1')}"
+        expected += f"{Colors.red(' - Feature for testing1')}\n"
+        expected += f"{Colors.red(' * ')}{Colors.blue('Feature2')}"
+        expected += f"{Colors.red(' - Feature for testing2')}\n"
+        expected += f"{Colors.red(' * ')}{Colors.blue('Feature3')}"
+        self.assertEqual(output, expected)
+
+    def test_add_feature_location(self):
+        """Test that add_feature_location modifies the features_locations
+        attribute of FeaturesLoader."""
+        original_location = deepcopy(features.features_locations)
+        features.add_feature_location(self.feature_path)
+        self.assertEqual(len(features.features_locations), 2)
+        self.assertIn(self.feature_path, features.features_locations)
+        features.features_locations = deepcopy(original_location)

--- a/tests/unit/models/ci/base/test_system.py
+++ b/tests/unit/models/ci/base/test_system.py
@@ -20,6 +20,7 @@ from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.base.job import Job
 from cibyl.models.ci.base.system import JobsSystem, System
 from cibyl.models.model import Model
+from cibyl.models.product.feature import Feature
 
 
 class TestSystem(unittest.TestCase):
@@ -60,6 +61,13 @@ class TestSystem(unittest.TestCase):
         """Test system export_attributes_to_source method."""
         output = self.system.export_attributes_to_source()
         self.assertEqual({}, output)
+
+    def test_add_feature(self):
+        self.system.add_feature(Feature("test", True))
+        self.assertEqual(len(self.system.features), 1)
+        feature = self.system.features["test"]
+        self.assertEqual(feature.name.value, "test")
+        self.assertEqual(feature.present.value, True)
 
 
 class TestJobsSystem(unittest.TestCase):

--- a/tests/unit/plugins/test_plugin.py
+++ b/tests/unit/plugins/test_plugin.py
@@ -13,13 +13,13 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from unittest import TestCase
 
 from cibyl.exceptions.plugin import MissingPlugin
 from cibyl.plugins import enable_plugins
+from tests.utils import RestoreAPIs
 
 
-class TestPlugin(TestCase):
+class TestPlugin(RestoreAPIs):
     """Test Plugins mechanism"""
 
     def test_enable_plugins(self):

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -20,9 +20,7 @@ import cibyl.orchestrator
 from cibyl.config import Config
 from cibyl.exceptions.config import (CHECK_DOCS_MSG, InvalidConfiguration,
                                      NonSupportedSystemKey)
-from cibyl.exceptions.source import NoValidSources
-from cibyl.orchestrator import Orchestrator, source_information_from_method
-from cibyl.sources.source import Source
+from cibyl.orchestrator import Orchestrator
 
 
 class TestOrchestrator(TestCase):
@@ -172,54 +170,6 @@ class TestOrchestrator(TestCase):
             self.orchestrator.environments[0].systems[0].name.value, 'system3')
         self.assertEqual(
             self.orchestrator.environments[0].systems[1].name.value, 'system4')
-
-    @patch("cibyl.orchestrator.get_source_method")
-    def test_orchestrator_select_source(self, patched_method):
-        """Testing Orchestartor select_source_method method"""
-        self.orchestrator.config.data = self.valid_env_sources
-        self.orchestrator.create_ci_environments()
-        self.orchestrator.parser.ci_args["sources"] = Mock()
-        self.orchestrator.parser.ci_args["sources"].value = ["jenkins"]
-        system = Mock()
-        system.name = Mock()
-        system.name.value = "system"
-        system.sources = Mock()
-        source = Mock()
-        source.name = "jenkins"
-        system.sources = [source]
-        argument = Mock()
-        argument.func = None
-        self.orchestrator.select_source_method(system, argument)
-        patched_method.assert_called_with(
-            "system", [source], None, args=self.orchestrator.parser.ci_args)
-
-    def test_orchestrator_select_source_invalid_source(self):
-        """Testing Orchestrator select_source_method method with no valid
-        source.
-        """
-        self.orchestrator.config.data = self.valid_env_sources
-        self.orchestrator.create_ci_environments()
-        self.orchestrator.parser.ci_args["sources"] = Mock()
-        self.orchestrator.parser.ci_args["sources"].value = ["unknown"]
-        system = Mock()
-        system.name = Mock()
-        system.name.value = "system"
-        system.sources = Mock()
-        source = Source(name="source", driver="jenkins")
-        system.sources = [source]
-        argument = Mock()
-        argument.func = None
-        self.assertRaises(NoValidSources,
-                          self.orchestrator.select_source_method,
-                          system, argument)
-
-    def test_source_information_from_method(self):
-        """Test that the source_information_from_method methods provides the
-        correct representation of the source."""
-        source = Source(name="source", driver="driver")
-        expected = "source: 'source' of type: 'driver'"
-        output = source_information_from_method(source.setup)
-        self.assertEqual(expected, output)
 
     def test_extend_parser(self):
         """Test that extend_parser creates the right cli arguments for a single

--- a/tests/unit/utils/test_dicts.py
+++ b/tests/unit/utils/test_dicts.py
@@ -15,10 +15,14 @@
 """
 from unittest import TestCase
 
-from cibyl.utils.dicts import chunk_dictionary_into_lists, nsubset, subset
+from cibyl.models.attribute import AttributeDictValue
+from cibyl.models.ci.base.job import Job
+from cibyl.utils.dicts import (chunk_dictionary_into_lists, intersect_models,
+                               nsubset, subset)
 
 
 class TestSubset(TestCase):
+    """Test subset function of utils.dicts module."""
     def test_subset_is_generated(self):
         """Checks that this is capable of creating a dictionary from another.
         """
@@ -79,3 +83,20 @@ class TestChunkDictionaryResult(TestCase):
         self.assertEqual(200, len(lists[0]))
         self.assertEqual(200, len(lists[1]))
         self.assertEqual(100, len(lists[2]))
+
+
+class TestIntersectModels(TestCase):
+    """Test intersect_models function of utils.dicts module."""
+    def test_intersect_jobs(self):
+
+        jobs1 = {"job1": Job("job1", url="url"), "jobs2": Job("job2")}
+        jobs2 = {"job1": Job("job1"), "jobs3": Job("job3")}
+        models1 = AttributeDictValue("models1", attr_type=Job,
+                                     value=jobs1)
+        models2 = AttributeDictValue("models2", attr_type=Job,
+                                     value=jobs2)
+        intersection = intersect_models(models1, models2)
+        self.assertEqual(len(intersection), 1)
+        job = intersection["job1"]
+        self.assertEqual(job.name.value, "job1")
+        self.assertEqual(job.url.value, "url")

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -16,6 +16,7 @@
 from copy import deepcopy
 from unittest import TestCase
 
+from cibyl import features
 from cibyl.cli.query import QuerySelector
 from cibyl.models.ci.base.job import Job
 from cibyl.models.ci.base.system import JobsSystem, System
@@ -35,6 +36,7 @@ class RestoreAPIs(TestCase):
         cls.original_zuul_job_api = deepcopy(ZuulJob.API)
         cls.original_system_api = deepcopy(System.API)
         cls.plugin_attributes = deepcopy(Job.plugin_attributes)
+        cls.feature_paths = deepcopy(features.features_locations)
 
     @classmethod
     def tearDownClass(cls):
@@ -45,6 +47,7 @@ class RestoreAPIs(TestCase):
         ZuulJob.API = deepcopy(cls.original_zuul_job_api)
         System.API = deepcopy(cls.original_system_api)
         QuerySelector.query_selector_functions = []
+        features.features_locations = deepcopy(cls.feature_paths)
 
 
 class JobSystemAPI(RestoreAPIs):


### PR DESCRIPTION
This PR is marked as a draft while I finish writing tests, but it's ready for
review. 

Features represent a new mechanism to query for information, particularly for
that information that can not be retrieved by a simple call combining
cli arguments.

Features are classes that inherit from the FeatureTemplate class and are
defined inside subpackages called 'features'. They must provide a
'query' method to be called, but the FeatureTemplate class provides on
that can be reused with slight tweaks in simple cases. The 'query' method
from  The FeatureTemplate can be overriden for any given Feature, it's
not mandatory to call it.

Currently there are two
locations for features a general (cibyl/features, empty) and an openstack
specific (cibyl/plugins/openstack/features, three features provided, HA,
IPV4 and IPV6). Plugins that add features must add their paths to the
FeatureLoader class when the plugin is enabled.

In the orchestrator the features are loaded and executed (calling the
query method). If more than one feature is requested, their results are
combined. If the user uses other cli arguments like --jobs, the
intersection of the jobs that satisfy each feature will be finally
published. If not, for each system it will be simply published whether
each feature is present or not.

The result of a Feature query without --jobs is to add a Feature model
to the system queried. This should not be confused with any particular
Feature like (HA or IPV4). The Feature model is a ci model (similar to
Job or System) stored in cibyl/models/ci/base/feature.py and serves as
store for the result of a Feature query.
