### PR TITLE
Adding models for Zuul tests.

### DIFF
--- a/cibyl/models/ci/base/test.py
+++ b/cibyl/models/ci/base/test.py
@@ -36,7 +36,7 @@ class Test(Model):
                                    description="Test result")]
         },
         'duration': {
-            'attr_type': int,
+            'attr_type': float,
             'arguments': [Argument(name='--test-duration', arg_type=str,
                                    func='get_tests', nargs='*',
                                    ranged=True,
@@ -49,11 +49,19 @@ class Test(Model):
     }
 
     def __init__(self, name: str, result: str = None,
-                 duration: int = None, class_name: str = None):
+                 duration: int = None, class_name: str = None, **kwargs):
         if result:
             result = result.upper()
-        super().__init__({'name': name, 'result': result,
-                          'duration': duration, 'class_name': class_name})
+
+        super().__init__(
+            {
+                'name': name,
+                'result': result,
+                'duration': duration,
+                'class_name': class_name,
+                **kwargs
+            }
+        )
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/cibyl/models/ci/zuul/test.py
+++ b/cibyl/models/ci/zuul/test.py
@@ -1,0 +1,91 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from enum import IntEnum
+
+from cibyl.models.model import Model
+
+
+class TestKind(IntEnum):
+    UNKNOWN = 0
+    ANSIBLE = 1
+    TEMPEST = 2
+
+
+class TestStatus(IntEnum):
+    UNKNOWN = 0
+    SUCCESS = 1
+    FAILURE = 2
+
+
+class Test(Model):
+    """
+    @DynamicAttrs: Contains attributes added on runtime.
+    """
+
+    class Data:
+        name = 'UNDEFINED'
+        status = TestStatus.UNKNOWN
+        duration = None
+        url = None
+
+    API = {
+        'kind': {
+            'attr_type': TestKind,
+            'arguments': []
+        },
+        'name': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'status': {
+            'attr_type': int,
+            'arguments': []
+        },
+        'duration': {
+            'attr_type': float,
+            'arguments': []
+        },
+        'url': {
+            'attr_type': str,
+            'arguments': []
+        }
+    }
+
+    def __init__(self, kind, data, **kwargs):
+        super().__init__(
+            {
+                'kind': kind,
+                'name': data.name,
+                'status': data.status,
+                'duration': data.duration,
+                'url': data.url,
+                **kwargs
+            }
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        if self is other:
+            return True
+
+        return \
+            self.kind == other.kind and \
+            self.name == other.name and \
+            self.status == other.status and \
+            self.duration == other.duration and \
+            self.url == other.url

--- a/cibyl/models/ci/zuul/test.py
+++ b/cibyl/models/ci/zuul/test.py
@@ -19,27 +19,41 @@ from cibyl.models.model import Model
 
 
 class TestKind(IntEnum):
+    """Defines the different kind of test cases known to Cibyl.
+    """
     UNKNOWN = 0
+    """Type is unknown, best effort will be tried."""
     ANSIBLE = 1
+    """Test represents the execution of an Ansible task."""
     TEMPEST = 2
+    """Test represents the execution of a Tempest test case."""
 
 
 class TestStatus(IntEnum):
+    """Default possible test results.
+    """
     UNKNOWN = 0
     SUCCESS = 1
     FAILURE = 2
 
 
 class Test(Model):
-    """
+    """Model for test cases on a Zuul environment.
+
     @DynamicAttrs: Contains attributes added on runtime.
     """
 
     class Data:
+        """Holds the data that will define the model.
+        """
         name = 'UNDEFINED'
+        """Name of the test case."""
         status = TestStatus.UNKNOWN
+        """Result of the test case."""
         duration = None
+        """How long the test took to complete, in seconds."""
         url = None
+        """Page where more information about the test can be obtained."""
 
     API = {
         'kind': {
@@ -63,8 +77,18 @@ class Test(Model):
             'arguments': []
         }
     }
+    """Defines base contents of the model."""
 
     def __init__(self, kind, data, **kwargs):
+        """Constructor.
+
+        :param kind: The type of test.
+        :type kind: :class:`TestKind`
+        :param data: Defining data for this test.
+        :type data: :class:`Test.Data`
+        :param kwargs: Additional data.
+        :type kwargs: Any
+        """
         super().__init__(
             {
                 'kind': kind,

--- a/cibyl/models/ci/zuul/test.py
+++ b/cibyl/models/ci/zuul/test.py
@@ -15,7 +15,9 @@
 """
 from enum import IntEnum
 
-from cibyl.models.model import Model
+from overrides import overrides
+
+from cibyl.models.ci.base.test import Test as BaseTest
 
 
 class TestKind(IntEnum):
@@ -37,7 +39,7 @@ class TestStatus(IntEnum):
     FAILURE = 2
 
 
-class Test(Model):
+class Test(BaseTest):
     """Model for test cases on a Zuul environment.
 
     @DynamicAttrs: Contains attributes added on runtime.
@@ -56,20 +58,9 @@ class Test(Model):
         """Page where more information about the test can be obtained."""
 
     API = {
+        **BaseTest.API,
         'kind': {
             'attr_type': TestKind,
-            'arguments': []
-        },
-        'name': {
-            'attr_type': str,
-            'arguments': []
-        },
-        'status': {
-            'attr_type': int,
-            'arguments': []
-        },
-        'duration': {
-            'attr_type': float,
             'arguments': []
         },
         'url': {
@@ -90,16 +81,15 @@ class Test(Model):
         :type kwargs: Any
         """
         super().__init__(
-            {
-                'kind': kind,
-                'name': data.name,
-                'status': data.status,
-                'duration': data.duration,
-                'url': data.url,
-                **kwargs
-            }
+            name=data.name,
+            result=data.status.name,
+            duration=data.duration,
+            kind=kind,
+            url=data.url,
+            **kwargs
         )
 
+    @overrides
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
@@ -110,6 +100,6 @@ class Test(Model):
         return \
             self.kind == other.kind and \
             self.name == other.name and \
-            self.status == other.status and \
+            self.result == other.result and \
             self.duration == other.duration and \
             self.url == other.url

--- a/cibyl/models/ci/zuul/tests/__init__.py
+++ b/cibyl/models/ci/zuul/tests/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/cibyl/models/ci/zuul/tests/ansible.py
+++ b/cibyl/models/ci/zuul/tests/ansible.py
@@ -1,0 +1,80 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from enum import IntEnum
+
+from overrides import overrides
+
+from cibyl.models.ci.zuul.test import Test, TestKind
+
+
+class AnsibleTestStatus(IntEnum):
+    UNKNOWN = 0
+    SUCCESS = 1
+    FAILURE = 2
+    CHANGED = 3
+    SKIPPED = 4
+
+
+class AnsibleTest(Test):
+    class Data(Test.Data):
+        phase = 'UNKNOWN'
+        host = 'UNKNOWN'
+        command = None
+        message = None
+
+    API = {
+        **Test.API,
+        'phase': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'host': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'command': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'message': {
+            'attr_type': str,
+            'arguments': []
+        }
+    }
+
+    def __init__(self, data):
+        super().__init__(
+            TestKind.ANSIBLE,
+            data,
+            **{
+                'phase': data.phase,
+                'host': data.host,
+                'command': data.command,
+                'message': data.message
+            }
+        )
+
+    @overrides
+    def __eq__(self, other):
+        if not super().__eq__(other):
+            return False
+
+        # Check additional fields of this test
+        return \
+            self.phase == other.phase and \
+            self.host == other.host and \
+            self.command == other.command and \
+            self.message == other.message

--- a/cibyl/models/ci/zuul/tests/ansible.py
+++ b/cibyl/models/ci/zuul/tests/ansible.py
@@ -21,19 +21,37 @@ from cibyl.models.ci.zuul.test import Test, TestKind
 
 
 class AnsibleTestStatus(IntEnum):
+    """Possible results of an Ansible task.
+    """
     UNKNOWN = 0
+    """Could not determine how the task finished."""
     SUCCESS = 1
+    """The task completed without errors."""
     FAILURE = 2
+    """The task met an error it could not recover from."""
     CHANGED = 3
+    """The task produced changes on the system."""
     SKIPPED = 4
+    """The task was ignored."""
 
 
 class AnsibleTest(Test):
+    """Model for the execution of an Ansible task by a Zuul host.
+
+    @DynamicAttrs: Contains attributes added on runtime.
+    """
+
     class Data(Test.Data):
+        """Holds the data that will define the model.
+        """
         phase = 'UNKNOWN'
+        """Phase on which the task was executed in."""
         host = 'UNKNOWN'
+        """Target host for the task."""
         command = None
+        """Command that it executed."""
         message = None
+        """Returned message."""
 
     API = {
         **Test.API,
@@ -54,8 +72,14 @@ class AnsibleTest(Test):
             'arguments': []
         }
     }
+    """Defines base contents of the model."""
 
     def __init__(self, data=Data()):
+        """Constructor.
+
+        :param data: Defining data for this test.
+        :type data: :class:`AnsibleTest.Data`
+        """
         super().__init__(
             TestKind.ANSIBLE,
             data,

--- a/cibyl/models/ci/zuul/tests/tempest.py
+++ b/cibyl/models/ci/zuul/tests/tempest.py
@@ -20,36 +20,26 @@ from overrides import overrides
 from cibyl.models.ci.zuul.test import Test, TestKind
 
 
-class AnsibleTestStatus(IntEnum):
+class TempestTestStatus(IntEnum):
     UNKNOWN = 0
     SUCCESS = 1
     FAILURE = 2
-    CHANGED = 3
+    ERROR = 3
     SKIPPED = 4
 
 
-class AnsibleTest(Test):
+class TempestTest(Test):
     class Data(Test.Data):
-        phase = 'UNKNOWN'
-        host = 'UNKNOWN'
-        command = None
-        message = None
+        class_name = 'UNKNOWN'
+        skip_reason = None
 
     API = {
         **Test.API,
-        'phase': {
+        'class_name': {
             'attr_type': str,
             'arguments': []
         },
-        'host': {
-            'attr_type': str,
-            'arguments': []
-        },
-        'command': {
-            'attr_type': str,
-            'arguments': []
-        },
-        'message': {
+        'skip_reason': {
             'attr_type': str,
             'arguments': []
         }
@@ -57,13 +47,11 @@ class AnsibleTest(Test):
 
     def __init__(self, data=Data()):
         super().__init__(
-            TestKind.ANSIBLE,
+            TestKind.TEMPEST,
             data,
             **{
-                'phase': data.phase,
-                'host': data.host,
-                'command': data.command,
-                'message': data.message
+                'class_name': data.class_name,
+                'skip_reason': data.skip_reason
             }
         )
 
@@ -74,7 +62,5 @@ class AnsibleTest(Test):
 
         # Check this model's additional fields
         return \
-            self.phase == other.phase and \
-            self.host == other.host and \
-            self.command == other.command and \
-            self.message == other.message
+            self.class_name == other.class_name and \
+            self.skip_reason == other.skip_reason

--- a/cibyl/models/ci/zuul/tests/tempest.py
+++ b/cibyl/models/ci/zuul/tests/tempest.py
@@ -21,17 +21,33 @@ from cibyl.models.ci.zuul.test import Test, TestKind
 
 
 class TempestTestStatus(IntEnum):
+    """Possible results of a Tempest test case.
+    """
     UNKNOWN = 0
+    """Could not determine how the test finished."""
     SUCCESS = 1
+    """The test passed."""
     FAILURE = 2
+    """Some condition from the test was not met."""
     ERROR = 3
+    """The test found some error it could not recover from."""
     SKIPPED = 4
+    """The test was ignored."""
 
 
 class TempestTest(Test):
+    """Model for the execution of a Tempest test case by a Zuul host.
+
+    @DynamicAttrs: Contains attributes added on runtime.
+    """
+
     class Data(Test.Data):
+        """Holds the data that will define the model.
+        """
         class_name = 'UNKNOWN'
+        """Full name of the class that contains the test case."""
         skip_reason = None
+        """Message indicating why the test case was ignored."""
 
     API = {
         **Test.API,
@@ -44,8 +60,14 @@ class TempestTest(Test):
             'arguments': []
         }
     }
+    """Defines the base contents of the model."""
 
     def __init__(self, data=Data()):
+        """Constructor.
+
+        :param data: Defining data for this test.
+        :type data: :class:`TempestTest.Data`
+        """
         super().__init__(
             TestKind.TEMPEST,
             data,

--- a/tests/unit/models/ci/zuul/test_test.py
+++ b/tests/unit/models/ci/zuul/test_test.py
@@ -42,7 +42,7 @@ class TestTest(TestCase):
 
         self.assertEqual(kind, model.kind.value)
         self.assertEqual(name, model.name.value)
-        self.assertEqual(status, model.status.value)
+        self.assertEqual(status.name, model.result.value)
         self.assertEqual(duration, model.duration.value)
         self.assertEqual(url, model.url.value)
 

--- a/tests/unit/models/ci/zuul/test_test.py
+++ b/tests/unit/models/ci/zuul/test_test.py
@@ -1,0 +1,74 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.models.ci.zuul.test import Test, TestKind, TestStatus
+
+
+class TestTest(TestCase):
+    def test_attributes(self):
+        """Checks that the model has the desired attributes.
+        """
+        kind = TestKind.ANSIBLE
+        name = 'test'
+        status = TestStatus.SUCCESS
+        duration = 1.2
+        url = 'url-to-test'
+
+        data = Test.Data()
+        data.name = name
+        data.status = status
+        data.duration = duration
+        data.url = url
+
+        model = Test(kind, data)
+
+        self.assertEqual(kind, model.kind.value)
+        self.assertEqual(name, model.name.value)
+        self.assertEqual(status, model.status.value)
+        self.assertEqual(duration, model.duration.value)
+        self.assertEqual(url, model.url.value)
+
+    def test_equality_by_type(self):
+        """Checks that two models are no the same if they are of different
+        type.
+        """
+        model = Test(TestKind.UNKNOWN, Test.Data())
+        other = Mock()
+
+        self.assertNotEqual(other, model)
+
+    def test_equality_by_reference(self):
+        """Checks that a model is equal to itself.
+        """
+        model = Test(TestKind.UNKNOWN, Test.Data())
+
+        self.assertEqual(model, model)
+
+    def test_equality_by_contents(self):
+        """Checks that two models are equal if they hold the same data.
+        """
+        data = Test.Data()
+        data.name = 'test'
+        data.status = TestStatus.SUCCESS
+        data.duration = 1.2
+        data.url = 'url-to-test'
+
+        model1 = Test(TestKind.ANSIBLE, data)
+        model2 = Test(TestKind.ANSIBLE, data)
+
+        self.assertEqual(model2, model1)

--- a/tests/unit/models/ci/zuul/tests/__init__.py
+++ b/tests/unit/models/ci/zuul/tests/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/unit/models/ci/zuul/tests/test_ansible.py
+++ b/tests/unit/models/ci/zuul/tests/test_ansible.py
@@ -16,7 +16,7 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from cibyl.models.ci.zuul.test import TestStatus, TestKind
+from cibyl.models.ci.zuul.test import TestKind, TestStatus
 from cibyl.models.ci.zuul.tests.ansible import AnsibleTest, AnsibleTestStatus
 
 

--- a/tests/unit/models/ci/zuul/tests/test_ansible.py
+++ b/tests/unit/models/ci/zuul/tests/test_ansible.py
@@ -1,0 +1,90 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.models.ci.zuul.test import TestStatus, TestKind
+from cibyl.models.ci.zuul.tests.ansible import AnsibleTest, AnsibleTestStatus
+
+
+class TestAnsibleTest(TestCase):
+    def test_attributes(self):
+        """Checks that the model has the desired attributes.
+        """
+        name = 'test'
+        status = AnsibleTestStatus.SUCCESS
+        duration = 1.2
+        url = 'url-to-test'
+        phase = 'phase'
+        host = 'host'
+        command = 'command'
+        message = 'message'
+
+        data = AnsibleTest.Data()
+        data.name = name
+        data.status = status
+        data.duration = duration
+        data.url = url
+        data.phase = phase
+        data.host = host
+        data.command = command
+        data.message = message
+
+        model = AnsibleTest(data)
+
+        self.assertEqual(TestKind.ANSIBLE, model.kind.value)
+        self.assertEqual(name, model.name.value)
+        self.assertEqual(status, model.status.value)
+        self.assertEqual(duration, model.duration.value)
+        self.assertEqual(url, model.url.value)
+        self.assertEqual(phase, model.phase.value)
+        self.assertEqual(host, model.host.value)
+        self.assertEqual(command, model.command.value)
+        self.assertEqual(message, model.message.value)
+
+    def test_equality_by_type(self):
+        """Checks that two models are no the same if they are of different
+        type.
+        """
+        model = AnsibleTest(AnsibleTest.Data())
+        other = Mock()
+
+        self.assertNotEqual(other, model)
+
+    def test_equality_by_reference(self):
+        """Checks that a model is equal to itself.
+        """
+        model = AnsibleTest(AnsibleTest.Data())
+
+        self.assertEqual(model, model)
+
+    def test_equality_by_contents(self):
+        """Checks that two models are equal if they hold the same data.
+        """
+        data = AnsibleTest.Data()
+        data.name = 'test'
+        data.status = TestStatus.SUCCESS
+        data.duration = 1.2
+        data.url = 'url-to-test'
+        data.phase = 'phase'
+        data.host = 'host'
+        data.command = 'command'
+        data.message = 'message'
+
+        model1 = AnsibleTest(data)
+        model2 = AnsibleTest(data)
+
+        self.assertEqual(model2, model1)

--- a/tests/unit/models/ci/zuul/tests/test_ansible.py
+++ b/tests/unit/models/ci/zuul/tests/test_ansible.py
@@ -50,7 +50,7 @@ class TestAnsibleTest(TestCase):
 
         self.assertEqual(TestKind.ANSIBLE, model.kind.value)
         self.assertEqual(name, model.name.value)
-        self.assertEqual(status, model.status.value)
+        self.assertEqual(status.name, model.result.value)
         self.assertEqual(duration, model.duration.value)
         self.assertEqual(url, model.url.value)
         self.assertEqual(phase, model.phase.value)

--- a/tests/unit/models/ci/zuul/tests/test_ansible.py
+++ b/tests/unit/models/ci/zuul/tests/test_ansible.py
@@ -59,7 +59,7 @@ class TestAnsibleTest(TestCase):
         """Checks that two models are no the same if they are of different
         type.
         """
-        model = AnsibleTest(AnsibleTest.Data())
+        model = AnsibleTest()
         other = Mock()
 
         self.assertNotEqual(other, model)
@@ -67,7 +67,7 @@ class TestAnsibleTest(TestCase):
     def test_equality_by_reference(self):
         """Checks that a model is equal to itself.
         """
-        model = AnsibleTest(AnsibleTest.Data())
+        model = AnsibleTest()
 
         self.assertEqual(model, model)
 

--- a/tests/unit/models/ci/zuul/tests/test_ansible.py
+++ b/tests/unit/models/ci/zuul/tests/test_ansible.py
@@ -21,6 +21,9 @@ from cibyl.models.ci.zuul.tests.ansible import AnsibleTest, AnsibleTestStatus
 
 
 class TestAnsibleTest(TestCase):
+    """Tests for :class:`AnsibleTest`.
+    """
+
     def test_attributes(self):
         """Checks that the model has the desired attributes.
         """

--- a/tests/unit/models/ci/zuul/tests/test_tempest.py
+++ b/tests/unit/models/ci/zuul/tests/test_tempest.py
@@ -47,7 +47,7 @@ class TestTempestTest(TestCase):
 
         self.assertEqual(kind, model.kind.value)
         self.assertEqual(name, model.name.value)
-        self.assertEqual(status, model.status.value)
+        self.assertEqual(status.name, model.result.value)
         self.assertEqual(duration, model.duration.value)
         self.assertEqual(url, model.url.value)
         self.assertEqual(class_name, model.class_name.value)

--- a/tests/unit/models/ci/zuul/tests/test_tempest.py
+++ b/tests/unit/models/ci/zuul/tests/test_tempest.py
@@ -17,7 +17,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from cibyl.models.ci.zuul.test import TestKind
-from cibyl.models.ci.zuul.tests.tempest import TempestTestStatus, TempestTest
+from cibyl.models.ci.zuul.tests.tempest import TempestTest, TempestTestStatus
 
 
 class TestTempestTest(TestCase):

--- a/tests/unit/models/ci/zuul/tests/test_tempest.py
+++ b/tests/unit/models/ci/zuul/tests/test_tempest.py
@@ -21,6 +21,9 @@ from cibyl.models.ci.zuul.tests.tempest import TempestTestStatus, TempestTest
 
 
 class TestTempestTest(TestCase):
+    """Tests for :class:`TempestTest`.
+    """
+
     def test_attributes(self):
         """Checks that the model has the desired attributes.
         """

--- a/tests/unit/models/ci/zuul/tests/test_tempest.py
+++ b/tests/unit/models/ci/zuul/tests/test_tempest.py
@@ -16,41 +16,45 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from cibyl.models.ci.zuul.test import Test, TestKind, TestStatus
+from cibyl.models.ci.zuul.test import TestKind
+from cibyl.models.ci.zuul.tests.tempest import TempestTestStatus, TempestTest
 
 
-class TestTest(TestCase):
-    """Tests for :class:`Test`.
-    """
-
+class TestTempestTest(TestCase):
     def test_attributes(self):
         """Checks that the model has the desired attributes.
         """
-        kind = TestKind.ANSIBLE
+        kind = TestKind.TEMPEST
         name = 'test'
-        status = TestStatus.SUCCESS
+        status = TempestTestStatus.SUCCESS
         duration = 1.2
         url = 'url-to-test'
+        class_name = 'class'
+        skip_reason = 'reason'
 
-        data = Test.Data()
+        data = TempestTest.Data()
         data.name = name
         data.status = status
         data.duration = duration
         data.url = url
+        data.class_name = class_name
+        data.skip_reason = skip_reason
 
-        model = Test(kind, data)
+        model = TempestTest(data)
 
         self.assertEqual(kind, model.kind.value)
         self.assertEqual(name, model.name.value)
         self.assertEqual(status, model.status.value)
         self.assertEqual(duration, model.duration.value)
         self.assertEqual(url, model.url.value)
+        self.assertEqual(class_name, model.class_name.value)
+        self.assertEqual(skip_reason, model.skip_reason.value)
 
     def test_equality_by_type(self):
         """Checks that two models are no the same if they are of different
         type.
         """
-        model = Test(TestKind.UNKNOWN, Test.Data())
+        model = TempestTest()
         other = Mock()
 
         self.assertNotEqual(other, model)
@@ -58,20 +62,22 @@ class TestTest(TestCase):
     def test_equality_by_reference(self):
         """Checks that a model is equal to itself.
         """
-        model = Test(TestKind.UNKNOWN, Test.Data())
+        model = TempestTest()
 
         self.assertEqual(model, model)
 
     def test_equality_by_contents(self):
         """Checks that two models are equal if they hold the same data.
         """
-        data = Test.Data()
+        data = TempestTest.Data()
         data.name = 'test'
-        data.status = TestStatus.SUCCESS
+        data.status = TempestTestStatus.SUCCESS
         data.duration = 1.2
         data.url = 'url-to-test'
+        data.class_name = 'class_name'
+        data.skip_reason = 'skip_reason'
 
-        model1 = Test(TestKind.ANSIBLE, data)
-        model2 = Test(TestKind.ANSIBLE, data)
+        model1 = TempestTest(data)
+        model2 = TempestTest(data)
 
         self.assertEqual(model2, model1)


### PR DESCRIPTION
On this pull request:
- Added 'Test' model for generic test cases.
- Added 'AnsibleTest' model for tests based on Ansible tasks.
- Added 'TempestTest' model for test best on Tempest test cases.

The models are not integrated yet, just defined.