### PR TITLE
Update/improve get deployment elastic

### DIFF
--- a/cibyl/plugins/openstack/sources/elasticsearch.py
+++ b/cibyl/plugins/openstack/sources/elasticsearch.py
@@ -129,7 +129,6 @@ class ElasticSearch:
                 )
 
         if 'topology' in kwargs:
-            dvr_argument = kwargs.get('topology').value
             append_exists_field_to_query('topology')
             append_get_specific_field('topology')
         ip_version_argument = None

--- a/cibyl/plugins/openstack/sources/elasticsearch.py
+++ b/cibyl/plugins/openstack/sources/elasticsearch.py
@@ -182,25 +182,26 @@ class ElasticSearch:
             query_body['query']['bool']['must'][0]['bool']['should'].clear()
 
         job_objects = {}
-        for job_name in hits_info.keys():
-            job_source_data = hits_info[job_name]
-            job_url = re.compile(r"(.*)/\d").search(
-                job_source_data['_source']['build_url']
-            ).group(1)
+        for job_name in jobs_found.keys():
 
+            job_source_data = {}
+            if job_name in hits_info:
+                job_source_data = hits_info[job_name]['_source']
+
+            job_url = jobs_found[job_name].url
             # If data does not exist in the source we 
             # don't wanna display it
-            topology = job_source_data['_source'].get(
+            topology = job_source_data.get(
                 "topology", "")
-            network_backend = job_source_data['_source'].get(
+            network_backend = job_source_data.get(
                 "network_backend", "")
-            ip_version = job_source_data['_source'].get(
+            ip_version = job_source_data.get(
                 "ip_version", "")
-            storage_backend = job_source_data['_source'].get(
+            storage_backend = job_source_data.get(
                 "storage_backend", "")
-            dvr = job_source_data['_source'].get(
+            dvr = job_source_data.get(
                 "dvr", "")
-            osp_release = job_source_data['_source'].get(
+            osp_release = job_source_data.get(
                 "osp_release", "")
 
             if ip_version != '':

--- a/cibyl/plugins/openstack/sources/elasticsearch.py
+++ b/cibyl/plugins/openstack/sources/elasticsearch.py
@@ -15,7 +15,6 @@
 """
 
 import logging
-import re
 
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.base.job import Job
@@ -123,10 +122,10 @@ class ElasticSearch:
         # We will select just the field we receive
         # in the kwargs
         def append_get_specific_field(field: str):
-            query_body['aggs']['group_by_job_name']['aggs']\
-                ['last_build']['top_hits']['_source'].append(
-                    f"{field}"
-                )
+            (query_body['aggs']['group_by_job_name']['aggs']
+             ['last_build']['top_hits']['_source'].append(
+                 f"{field}"
+             ))
 
         if 'topology' in kwargs:
             append_exists_field_to_query('topology')
@@ -189,7 +188,7 @@ class ElasticSearch:
                 job_source_data = hits_info[job_name]['_source']
 
             job_url = jobs_found[job_name].url
-            # If data does not exist in the source we 
+            # If data does not exist in the source we
             # don't wanna display it
             topology = job_source_data.get(
                 "topology", "")

--- a/tests/unit/sources/elasticsearch/test_api.py
+++ b/tests/unit/sources/elasticsearch/test_api.py
@@ -360,31 +360,47 @@ class TestElasticSearchOpenstackPlugin(OpenstackPluginWithJobSystem):
                     }
         ]
 
+        # This is an aggregation + query results
         self.tests_hits = [
             {
                 '_source': {
                     'job_name': 'test',
-                    'job_url': 'http://domain.tld/test/',
-                    'build_result': 'SUCCESS',
-                    'build_id': '1',
-                    'build_num': '1',
-                    'test_name': 'it_is_just_a_test',
-                    'time_duration': '720',
-                    'test_status': 'SUCCESS',
-                    'test_time': '720',
+                    'job_url': 'http://domain.tld/test/'
+                },
+                'key': 'test',
+                'last_build': {
+                    'hits': {
+                        'hits': [
+                            {
+
+                                '_source': {
+                                    'job_name': 'test',
+                                    'job_url': 'http://domain.tld/test/',
+                                    'ip_version': 'ipv4',
+                                }
+                            }
+                        ]
+                    }
                 }
             },
             {
                 '_source': {
                     'job_name': 'test2',
-                    'job_url': 'http://domain.tld/test2/',
-                    'build_result': 'FAIL',
-                    'build_id': '2',
-                    'build_num': '2',
-                    'test_name': 'it_is_just_a_test2',
-                    'time_duration': '0.0001_bad_parsed',
-                    'test_status': 'FAIL',
-                    'test_time': '0.0001_bad_parsed',
+                    'job_url': 'http://domain.tld/test2/'
+                },
+                'key': 'test',
+                'last_build': {
+                    'hits': {
+                        'hits': [
+                            {
+                                '_source': {
+                                    'job_name': 'test2',
+                                    'job_url': 'http://domain.tld/test2/',
+                                    'ip_version': 'ipv4',
+                                }
+                            }
+                        ]
+                    }
                 }
             }
         ]
@@ -394,7 +410,7 @@ class TestElasticSearchOpenstackPlugin(OpenstackPluginWithJobSystem):
         """Tests that the internal logic from
         :meth:`ElasticSearch.get_deployment` is correct.
         """
-        mock_query_hits.return_value = self.build_hits
+        mock_query_hits.return_value = self.tests_hits
 
         jobs_argument = Mock()
         jobs_argument.value = ['test']
@@ -409,7 +425,7 @@ class TestElasticSearchOpenstackPlugin(OpenstackPluginWithJobSystem):
                                           ip_version=ip_address_kwargs)
         deployment = jobs['test'].deployment.value
         self.assertEqual(deployment.ip_version.value, '4')
-        self.assertEqual(deployment.topology.value, 'unknown')
+        self.assertEqual(deployment.topology.value, '')
 
     @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
     def test_deployment_filtering(self: object,
@@ -417,7 +433,7 @@ class TestElasticSearchOpenstackPlugin(OpenstackPluginWithJobSystem):
         """Tests that the internal logic from :meth:`ElasticSearch.get_jobs`
             is correct.
         """
-        mock_query_hits.return_value = self.build_hits
+        mock_query_hits.return_value = self.tests_hits
 
         jobs_argument = Mock()
         jobs_argument.value = ['test']
@@ -433,7 +449,7 @@ class TestElasticSearchOpenstackPlugin(OpenstackPluginWithJobSystem):
 
         deployment = builds['test'].deployment.value
         self.assertEqual(deployment.ip_version.value, '4')
-        self.assertEqual(deployment.topology.value, 'unknown')
+        self.assertEqual(deployment.topology.value, '')
 
 
 class TestQueryTemplate(TestCase):


### PR DESCRIPTION
- I wanted to do the SQL equivalent of `GROUP BY` to take the information of the last build. The way to approach it is using aggregations so I've modified the query used.
- We have been using the scan helper to get the documents from Elasticsearch through a query. In this case it doesn't support the aggregations so in this case we'll have a condition to use the search method of the elastic client.
- We can't send a giant query in the request to the Elasticsearch for asking to all the jobs information so we have been asking the information of the deployment for each job 1:1. Instead of doing one query for job we create a list of jobs sub lists and do calls divided by chunks.  `chunk_size_for_search` quantity will be the size of every sub list. e.g, If we have 2000 jobs we will have the following calls: 2000 / 600 = 3.33 -> 4 calls.
- With method `append_get_specific_field` we'll get just the specific fields we require from the source field, equivalent to `SELECT field` in SQL instead of `SELECT *`.