### PR TITLE
Support querying for overcloud templates in Jenkins

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -117,6 +117,9 @@ class Deployment(Model):
         'security_group': {
             'arguments': []
         },
+        'overcloud_templates': {
+            'arguments': []
+        },
         'network_backend': {
             'attr_type': str,
             'arguments': [Argument(name='--network-backend', arg_type=str,
@@ -139,7 +142,8 @@ class Deployment(Model):
                  network_backend: str = None, storage_backend: str = None,
                  dvr: str = None, tls_everywhere: str = None,
                  ml2_driver: str = None, ironic_inspector: str = None,
-                 cleaning_network: str = None, security_group: str = None):
+                 cleaning_network: str = None, security_group: str = None,
+                 overcloud_templates: set = None):
         super().__init__({'release': release, 'infra_type': infra_type,
                           'nodes': nodes, 'services': services,
                           'ip_version': ip_version, 'topology': topology,
@@ -149,7 +153,8 @@ class Deployment(Model):
                           'ml2_driver': ml2_driver,
                           'ironic_inspector': ironic_inspector,
                           'security_group': security_group,
-                          'cleaning_network': cleaning_network})
+                          'cleaning_network': cleaning_network,
+                          'overcloud_templates': overcloud_templates})
 
     def add_node(self, node: Node):
         """Add a node to the deployment.
@@ -202,6 +207,14 @@ class Deployment(Model):
             self.cleaning_network.value = other.cleaning_network.value
         if not self.security_group.value:
             self.security_group.value = other.security_group.value
+        if other.overcloud_templates.value:
+            other_templates = other.overcloud_templates.value
+            if self.overcloud_templates.value:
+                own_templates = self.overcloud_templates.value
+                all_templates = own_templates.union(other_templates)
+                self.overcloud_templates.value = all_templates
+            else:
+                self.overcloud_templates.value = other_templates
         for node in other.nodes.values():
             self.add_node(node)
         for service in other.services.values():

--- a/cibyl/plugins/openstack/printers/colored.py
+++ b/cibyl/plugins/openstack/printers/colored.py
@@ -56,41 +56,41 @@ class OSColoredPrinter(OSPrinter):
         :returns: Whether the network section of the deployment is empty
         """
         is_empty_network = True
-        printer.add(self._palette.blue("Network: "), 1)
+        printer.add(self.palette.blue("Network: "), 1)
         ip_version = deployment.ip_version.value
         if ip_version and ip_version != "unknown":
             is_empty_network = False
-            printer.add(self._palette.blue('IP version: '), 2)
+            printer.add(self.palette.blue('IP version: '), 2)
             printer[-1].append(deployment.ip_version)
 
         if deployment.network_backend.value:
             is_empty_network = False
-            printer.add(self._palette.blue('Network backend: '), 2)
+            printer.add(self.palette.blue('Network backend: '), 2)
             printer[-1].append(deployment.network_backend)
 
         if deployment.ml2_driver.value:
             if deployment.ml2_driver.value != "N/A" or self.verbosity > 0:
                 is_empty_network = False
-                printer.add(self._palette.blue('ML2 driver: '), 2)
+                printer.add(self.palette.blue('ML2 driver: '), 2)
                 printer[-1].append(deployment.ml2_driver)
 
         if deployment.security_group.value:
-            if deployment.ml2_driver.value != "N/A" or self.verbosity > 0:
+            if deployment.security_group.value != "N/A" or self.verbosity > 0:
                 is_empty_network = False
-                printer.add(self._palette.blue('Security group mechanism: '),
+                printer.add(self.palette.blue('Security group mechanism: '),
                             2)
                 printer[-1].append(deployment.security_group)
 
         if deployment.dvr.value:
             if deployment.dvr.value != "N/A" or self.verbosity > 0:
                 is_empty_network = False
-                printer.add(self._palette.blue('DVR: '), 2)
+                printer.add(self.palette.blue('DVR: '), 2)
                 printer[-1].append(deployment.dvr)
 
         if deployment.tls_everywhere.value:
             if deployment.tls_everywhere.value != "N/A" or self.verbosity > 0:
                 is_empty_network = False
-                printer.add(self._palette.blue('TLS everywhere: '), 2)
+                printer.add(self.palette.blue('TLS everywhere: '), 2)
                 printer[-1].append(deployment.tls_everywhere)
 
         if is_empty_network:
@@ -107,12 +107,12 @@ class OSColoredPrinter(OSPrinter):
         :returns: Whether the network section of the deployment is empty
         """
         is_empty_storage = True
-        printer.add(self._palette.blue("Storage: "), 1)
+        printer.add(self.palette.blue("Storage: "), 1)
 
         if deployment.storage_backend.value:
             if deployment.storage_backend.value != "N/A" or self.verbosity > 0:
                 is_empty_storage = False
-                printer.add(self._palette.blue('Storage backend: '), 2)
+                printer.add(self.palette.blue('Storage backend: '), 2)
                 printer[-1].append(deployment.storage_backend)
 
         if is_empty_storage:
@@ -129,20 +129,20 @@ class OSColoredPrinter(OSPrinter):
         :returns: Whether the network section of the deployment is empty
         """
         is_empty_ironic = True
-        printer.add(self._palette.blue("Ironic: "), 1)
+        printer.add(self.palette.blue("Ironic: "), 1)
 
         if deployment.ironic_inspector.value:
             if deployment.ironic_inspector.value != "N/A" or \
                self.verbosity > 0:
                 is_empty_ironic = False
-                printer.add(self._palette.blue('Ironic inspector: '), 2)
+                printer.add(self.palette.blue('Ironic inspector: '), 2)
                 printer[-1].append(deployment.ironic_inspector)
 
         if deployment.cleaning_network.value:
             if deployment.cleaning_network.value != "N/A" or \
                self.verbosity > 0:
                 is_empty_ironic = False
-                printer.add(self._palette.blue('Cleaning network: '), 2)
+                printer.add(self.palette.blue('Cleaning network: '), 2)
                 printer[-1].append(deployment.cleaning_network)
 
         if is_empty_ironic:
@@ -152,22 +152,22 @@ class OSColoredPrinter(OSPrinter):
     def print_deployment(self, deployment):
         printer = IndentedTextBuilder()
 
-        printer.add(self._palette.blue('Openstack deployment: '), 0)
+        printer.add(self.palette.blue('Openstack deployment: '), 0)
         is_empty_deployment = True
 
         if deployment.release.value:
             is_empty_deployment = False
-            printer.add(self._palette.blue('Release: '), 1)
+            printer.add(self.palette.blue('Release: '), 1)
             printer[-1].append(deployment.release.value)
 
         if deployment.infra_type.value:
             is_empty_deployment = False
-            printer.add(self._palette.blue('Infra type: '), 1)
+            printer.add(self.palette.blue('Infra type: '), 1)
             printer[-1].append(deployment.infra_type)
 
         if deployment.topology.value:
             is_empty_deployment = False
-            printer.add(self._palette.blue('Topology: '), 1)
+            printer.add(self.palette.blue('Topology: '), 1)
             printer[-1].append(deployment.topology)
 
         is_empty_network = self._print_deployment_network_section(deployment,
@@ -176,12 +176,21 @@ class OSColoredPrinter(OSPrinter):
                                                                   printer)
         is_empty_ironic = self._print_deployment_ironic_section(deployment,
                                                                 printer)
+        if deployment.overcloud_templates.value:
+            if deployment.overcloud_templates.value != "N/A" or \
+               self.verbosity > 0:
+                is_empty_deployment = False
+                printer.add(self.palette.blue('Overcloud templates: '), 1)
+                for template in deployment.overcloud_templates.value:
+                    printer.add(self.palette.blue('- '), 2)
+                    printer[-1].append(template)
+
         is_empty_deployment &= (is_empty_network and is_empty_storage and
                                 is_empty_ironic)
 
         if deployment.nodes.values():
             is_empty_deployment = False
-            printer.add(self._palette.blue('Nodes: '), 1)
+            printer.add(self.palette.blue('Nodes: '), 1)
             for node in deployment.nodes.values():
                 printer.add(self.print_node(node), 2)
 
@@ -198,12 +207,12 @@ class OSColoredPrinter(OSPrinter):
     def print_node(self, node):
         printer = IndentedTextBuilder()
 
-        printer.add(self._palette.blue('- '), 0)
+        printer.add(self.palette.blue('- '), 0)
         printer[-1].append(node.name.value)
 
         if self.verbosity > 0:
             if node.role.value:
-                printer.add(self._palette.blue('Role: '), 1)
+                printer.add(self.palette.blue('Role: '), 1)
                 printer[-1].append(node.role)
 
         if node.containers.value:
@@ -219,11 +228,11 @@ class OSColoredPrinter(OSPrinter):
     def print_package(self, package):
         printer = IndentedTextBuilder()
 
-        printer.add(self._palette.blue('Package: '), 0)
+        printer.add(self.palette.blue('Package: '), 0)
         printer[-1].append(package.name)
 
         if package.origin.value:
-            printer.add(self._palette.blue('Origin: '), 1)
+            printer.add(self.palette.blue('Origin: '), 1)
             printer[-1].append(package.origin)
 
         return printer.build()
@@ -231,13 +240,13 @@ class OSColoredPrinter(OSPrinter):
     def print_service(self, service):
         printer = IndentedTextBuilder()
 
-        printer.add(self._palette.blue('Service name: '), 0)
+        printer.add(self.palette.blue('Service name: '), 0)
         printer[-1].append(service.name.value)
 
         if self.verbosity > 0:
             if service.configuration.value:
                 for parameter, value in service.configuration.value.items():
-                    printer.add(self._palette.blue(f'{parameter}: '), 1)
+                    printer.add(self.palette.blue(f'{parameter}: '), 1)
                     printer[-1].append(value)
 
         return printer.build()
@@ -245,11 +254,11 @@ class OSColoredPrinter(OSPrinter):
     def print_container(self, container):
         printer = IndentedTextBuilder()
 
-        printer.add(self._palette.blue('Container: '), 0)
+        printer.add(self.palette.blue('Container: '), 0)
         printer[-1].append(container.name)
 
         if container.image.value:
-            printer.add(self._palette.blue('Image: '), 1)
+            printer.add(self.palette.blue('Image: '), 1)
             printer[-1].append(container.image)
 
         if container.packages.value:

--- a/tests/unit/plugins/openstack/test_deployment.py
+++ b/tests/unit/plugins/openstack/test_deployment.py
@@ -34,6 +34,11 @@ class TestOpenstackDeployment(TestCase):
         self.storage = "ceph"
         self.dvr = "true"
         self.tls_everywhere = "false"
+        self.templates = set(["a", "b", "c"])
+        self.ml2_driver = "ovn"
+        self.ironic = "True"
+        self.cleaning_net = "False"
+        self.security_group = "native ovn"
 
         self.deployment = Deployment(self.release, self.infra, {}, {})
         self.second_deployment = Deployment(self.release, self.infra,
@@ -44,7 +49,12 @@ class TestOpenstackDeployment(TestCase):
                                             network_backend=self.network,
                                             storage_backend=self.storage,
                                             dvr=self.dvr,
-                                            tls_everywhere=self.tls_everywhere)
+                                            tls_everywhere=self.tls_everywhere,
+                                            ml2_driver=self.ml2_driver,
+                                            ironic_inspector=self.ironic,
+                                            cleaning_network=self.cleaning_net,
+                                            security_group=self.security_group,
+                                            overcloud_templates=self.templates)
 
     def test_merge_method(self):
         """Test merge method of Deployment class."""
@@ -55,6 +65,29 @@ class TestOpenstackDeployment(TestCase):
         self.assertEqual(self.nodes, self.deployment.nodes.value)
         self.assertEqual(self.services, self.deployment.services.value)
         self.assertEqual(self.ip_version, self.deployment.ip_version.value)
+        self.assertEqual(self.topology, self.deployment.topology.value)
+        self.assertEqual(self.network, self.deployment.network_backend.value)
+        self.assertEqual(self.storage, self.deployment.storage_backend.value)
+        self.assertEqual(self.dvr, self.deployment.dvr.value)
+        self.assertEqual(self.tls_everywhere,
+                         self.deployment.tls_everywhere.value)
+        self.assertEqual(self.templates,
+                         self.deployment.overcloud_templates.value)
+        self.assertEqual(self.ml2_driver, self.deployment.ml2_driver.value)
+        self.assertEqual(self.ironic, self.deployment.ironic_inspector.value)
+        self.assertEqual(self.cleaning_net,
+                         self.deployment.cleaning_network.value)
+        self.assertEqual(self.security_group,
+                         self.deployment.security_group.value)
+
+    def test_merge_method_existing_templates(self):
+        """Test merge method of Deployment class with both deployments having
+        templates."""
+        deployment = Deployment(self.release, self.infra, {}, {},
+                                overcloud_templates=set(["d"]))
+        deployment.merge(self.second_deployment)
+        self.assertEqual(deployment.overcloud_templates.value,
+                         set(["a", "b", "c", "d"]))
 
     def test_add_node(self):
         """Test add_node method of Deployment class."""


### PR DESCRIPTION
The heat teamplates are an important part of an Openstack deployment.
With this change, jenkins source can query for them as part of the spec
or by passing an 'overcloud_templates' argument to get_deployment, but
it introduces no cli argument.
