### PR TITLE
Add CI stages to Jenkins source

### DIFF
--- a/cibyl/models/attribute.py
+++ b/cibyl/models/attribute.py
@@ -106,5 +106,5 @@ class AttributeDictValue(AttributeValue):
         """Return dictionary values"""
         return self.value.keys()
 
-    def get(self, key, default):
+    def get(self, key, default=None):
         return self.value.get(key, default)

--- a/cibyl/models/ci/base/stage.py
+++ b/cibyl/models/ci/base/stage.py
@@ -1,0 +1,60 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+# pylint: disable=no-member
+from cibyl.models.model import Model
+
+
+class Stage(Model):
+    """General model for a build stage
+
+    @DynamicAttrs: Contains attributes added on runtime.
+    """
+    API = {
+        'name': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'status': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'duration': {
+            'attr_type': int,
+            'arguments': [],
+        }
+    }
+
+    def __init__(self, name: str, status: str = None,
+                 duration: int = None):
+        if status is not None:
+            status = status.upper()
+        super().__init__({'name': name, 'status': status,
+                          'duration': duration})
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.name.value == other.name.value
+
+    def merge(self, other):
+        """Merge the information of two build objects representing the same
+        build.
+
+        :param other: The Build object to merge
+        :type other: :class:`.Build`
+        """
+        if not self.status.value:
+            self.status.value = other.status.value

--- a/cibyl/outputs/cli/ci/system/common/builds.py
+++ b/cibyl/outputs/cli/ci/system/common/builds.py
@@ -47,6 +47,8 @@ def get_status_section(palette, build):
     status_x_color_map = {
         'SUCCESS': lambda: palette.green(build.status.value),
         'FAILURE': lambda: palette.red(build.status.value),
+        'FAILED': lambda: palette.red(build.status.value),
+        'NOT EXECUTED': lambda: palette.blue(build.status.value),
         'UNSTABLE': lambda: palette.yellow(build.status.value)
     }
 

--- a/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
@@ -35,7 +35,7 @@ class ColoredJobsSystemPrinter(ColoredPrinter, CISystemPrinter):
     def print_system(self, system, indent=0):
         printer = IndentedTextBuilder()
 
-        printer.add(self._palette.blue('System: '), indent)
+        printer.add(self.palette.blue('System: '), indent)
         printer[-1].append(system.name.value)
 
         if self.verbosity > 0:
@@ -48,10 +48,10 @@ class ColoredJobsSystemPrinter(ColoredPrinter, CISystemPrinter):
             if system.is_queried():
                 header = 'Total jobs found in query: '
 
-                printer.add(self._palette.blue(header), indent+1)
+                printer.add(self.palette.blue(header), indent+1)
                 printer[-1].append(len(system.jobs))
             else:
-                printer.add(self._palette.blue('No query performed'), indent+1)
+                printer.add(self.palette.blue('No query performed'), indent+1)
 
         return printer.build()
 
@@ -64,12 +64,12 @@ class ColoredJobsSystemPrinter(ColoredPrinter, CISystemPrinter):
         """
         printer = IndentedTextBuilder()
 
-        printer.add(self._palette.blue('Job: '), 0)
+        printer.add(self.palette.blue('Job: '), 0)
         printer[-1].append(job.name.value)
 
         if self.verbosity > 0:
             if job.url.value:
-                printer.add(self._palette.blue('URL: '), 1)
+                printer.add(self.palette.blue('URL: '), 1)
                 printer[-1].append(job.url.value)
 
         if job.builds.value:
@@ -90,7 +90,7 @@ class ColoredJobsSystemPrinter(ColoredPrinter, CISystemPrinter):
         """
         printer = IndentedTextBuilder()
 
-        printer.add(self._palette.blue('Build: '), 0)
+        printer.add(self.palette.blue('Build: '), 0)
         printer[0].append(build.build_id.value)
 
         if build.status.value:
@@ -104,6 +104,32 @@ class ColoredJobsSystemPrinter(ColoredPrinter, CISystemPrinter):
             for test in build.tests.values():
                 printer.add(self.print_test(test), 1)
 
+        if build.stages.value:
+            for stage in build.stages:
+                printer.add(self.print_stage(stage), 1)
+
+        return printer.build()
+
+    def print_stage(self, stage):
+        """
+            Generate string representation of a Stage model.
+
+            :param test: The stage.
+            :type test: :class:`cibyl.models.ci.base.stage.Stage`
+            :return: Textual representation of the provided model.
+            :rtype: str
+        """
+        printer = IndentedTextBuilder()
+
+        printer.add(self.palette.blue('Stage: '), 0)
+        printer[-1].append(stage.name.value)
+
+        if self.verbosity > 0:
+            if stage.status.value:
+                printer.add(get_status_section(self.palette, stage), 1)
+
+            if stage.duration.value:
+                printer.add(get_duration_section(self.palette, stage), 1)
         return printer.build()
 
     def print_test(self, test):
@@ -115,30 +141,30 @@ class ColoredJobsSystemPrinter(ColoredPrinter, CISystemPrinter):
         """
         printer = IndentedTextBuilder()
 
-        printer.add(self._palette.blue('Test: '), 0)
+        printer.add(self.palette.blue('Test: '), 0)
         printer[-1].append(test.name.value)
 
         if test.result.value:
-            printer.add(self._palette.blue('Result: '), 1)
+            printer.add(self.palette.blue('Result: '), 1)
 
             if test.result.value in ['SUCCESS', 'PASSED']:
-                printer[-1].append(self._palette.green(test.result.value))
+                printer[-1].append(self.palette.green(test.result.value))
             elif test.result.value in ['FAILURE', 'FAILED', 'REGRESSION']:
-                printer[-1].append(self._palette.red(test.result.value))
+                printer[-1].append(self.palette.red(test.result.value))
             elif test.result.value == "UNSTABLE":
-                printer[-1].append(self._palette.yellow(test.result.value))
+                printer[-1].append(self.palette.yellow(test.result.value))
             elif test.result.value == "SKIPPED":
-                printer[-1].append(self._palette.blue(test.result.value))
+                printer[-1].append(self.palette.blue(test.result.value))
 
         if test.class_name.value:
-            printer.add(self._palette.blue('Class name: '), 1)
+            printer.add(self.palette.blue('Class name: '), 1)
             printer[-1].append(test.class_name.value)
 
         if self.verbosity > 0:
             if test.duration.value:
                 duration = as_minutes(test.duration.value)
 
-                printer.add(self._palette.blue('Duration: '), 1)
+                printer.add(self.palette.blue('Duration: '), 1)
                 printer[-1].append(f'{duration:.2f}m')
 
         return printer.build()

--- a/tests/unit/models/ci/base/test_build.py
+++ b/tests/unit/models/ci/base/test_build.py
@@ -17,6 +17,7 @@
 import unittest
 
 from cibyl.models.ci.base.build import Build
+from cibyl.models.ci.base.stage import Stage
 from cibyl.models.ci.base.test import Test
 
 
@@ -81,12 +82,17 @@ str")
         test = Test("test_name", "failure")
         self.build.status.value = "SUCCESS"
         self.build.add_test(test)
+        self.build.add_stage(Stage("Run", "SUCCESS"))
         self.second_build.merge(self.build)
         self.assertEqual(self.second_build.status.value, "SUCCESS")
         self.assertEqual(len(self.second_build.tests), 1)
+        self.assertEqual(len(self.second_build.stages), 1)
         test_obj = self.second_build.tests["test_name"]
         self.assertEqual(test_obj.name.value, "test_name")
         self.assertEqual(test_obj.result.value, "FAILURE")
+        stage_obj = self.second_build.stages[0]
+        self.assertEqual(stage_obj.name.value, "Run")
+        self.assertEqual(stage_obj.status.value, "SUCCESS")
 
     def test_build_add_existing_test(self):
         """Test Build add_test method with existing Test."""

--- a/tests/unit/models/ci/base/test_stage.py
+++ b/tests/unit/models/ci/base/test_stage.py
@@ -1,0 +1,82 @@
+"""
+# Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+# pylint: disable=no-member
+import unittest
+
+from cibyl.models.ci.base.stage import Stage
+
+
+class TestStage(unittest.TestCase):
+    """Test Stage CI model."""
+
+    def setUp(self):
+        self.name = 'test-stage'
+        self.stage_status = 'FAILURE'
+        self.stage = Stage(name=self.name)
+        self.second_stage = Stage(name=self.name)
+
+    def test_name(self):
+        """Test new Stage name attribute"""
+        self.assertTrue(
+            hasattr(self.stage, 'name'),
+            msg="Stage lacks name attribute")
+
+        self.assertEqual(
+            self.stage.name.value, self.name,
+            msg=f"Stage id is {self.stage.name.value}. \
+Should be {self.name}")
+
+    def test_stage_status(self):
+        """Test new Stage status attribute."""
+        self.assertTrue(
+            hasattr(self.stage, 'status'), msg="Stage lacks status attribute")
+
+        self.assertEqual(
+            self.stage.status.value, None,
+            msg=f"Stage default status is {self.stage.status.value}. \
+Should be None")
+
+        self.assertEqual(
+            self.second_stage.status.value, None,
+            msg=f"Stage default status is {self.second_stage.status.value}.\
+ Should be None")
+
+        self.stage.status.value = self.stage_status
+
+        self.assertEqual(
+            self.stage.status.value, self.stage_status,
+            msg="New stage status is {self.stage.status.value}. \
+Should be {self.stage_status}")
+
+    def test_stages_comparison(self):
+        """Test new Stage instances comparison."""
+        self.assertEqual(
+            self.stage, self.second_stage,
+            msg=f"Stages {self.stage.name.value} and \
+{self.second_stage.name.value} are not equal")
+
+    def test_stages_comparison_other_types(self):
+        """Test new Stage instances comparison."""
+        self.assertNotEqual(
+            self.stage, "test",
+            msg=f"Stage {self.stage.name.value} should be different from \
+str")
+
+    def test_stage_merge(self):
+        """Test Stage merge method."""
+        self.stage.status.value = "SUCCESS"
+        self.second_stage.merge(self.stage)
+        self.assertEqual(self.second_stage.status.value, "SUCCESS")

--- a/tests/unit/models/test_attribute.py
+++ b/tests/unit/models/test_attribute.py
@@ -1,0 +1,226 @@
+"""
+# Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+# pylint: disable=no-member
+import unittest
+
+from cibyl.models.attribute import (AttributeDictValue, AttributeListValue,
+                                    AttributeValue)
+
+
+class TestAttributeValue(unittest.TestCase):
+    """Testing AttributeValue model"""
+
+    def setUp(self):
+        self.name = "test"
+        self.value = "test_value"
+        self.attr = AttributeValue(self.name, attr_type=str,
+                                   value=self.value)
+
+    def test_init(self):
+        """Test __init__ method of AttributeValue."""
+        self.assertEqual(self.name, self.attr.name)
+        self.assertEqual(self.value, self.attr.value)
+        self.assertEqual(str, self.attr.attr_type)
+        self.assertIsNone(self.attr.arguments)
+
+    def test_eq(self):
+        """Test __eq__ method of AttributeValue."""
+        attr2 = AttributeValue(self.name, attr_type=str,
+                               value="test_value")
+        self.assertEqual(self.attr, attr2)
+        attr2 = AttributeValue("name", attr_type=str,
+                               value="test_value")
+        self.assertNotEqual(self.attr, attr2)
+        attr2 = AttributeValue(self.name, attr_type=str,
+                               value="value")
+        self.assertNotEqual(self.attr, attr2)
+
+    def test_str(self):
+        """Test __str__ method of AttributeValue."""
+        self.assertEqual(str(self.attr), self.value)
+
+
+class TestAttributeListValue(unittest.TestCase):
+    """Test AttributeListValue model"""
+
+    def setUp(self):
+        self.name = "test"
+        self.value = ["test_value"]
+        self.attr = AttributeListValue(self.name, attr_type=str,
+                                       value=self.value)
+
+    def test_init(self):
+        """Test __init__ method of AttributeListValue."""
+        self.assertEqual(self.name, self.attr.name)
+        self.assertEqual(self.value, self.attr.value)
+        self.assertEqual(str, self.attr.attr_type)
+        self.assertIsNone(self.attr.arguments)
+
+    def test_init_non_list_value(self):
+        """Test __init__ method of AttributeListValue with a value not of
+        type list."""
+        attr2 = AttributeListValue(self.name, attr_type=str,
+                                   value="test_value")
+        self.assertEqual(self.name, attr2.name)
+        self.assertEqual("test_value", attr2.value)
+        self.assertEqual(str, attr2.attr_type)
+        self.assertIsNone(attr2.arguments)
+
+    def test_init_none_value(self):
+        """Test __init__ method of AttributeListValue with a value of
+        type None."""
+        attr2 = AttributeListValue(self.name, attr_type=str,
+                                   value=None)
+        self.assertEqual(self.name, attr2.name)
+        self.assertEqual([], attr2.value)
+        self.assertEqual(str, attr2.attr_type)
+        self.assertIsNone(attr2.arguments)
+
+    def test_eq(self):
+        """Test __eq__ method of AttributeListValue."""
+        attr2 = AttributeListValue(self.name, attr_type=str,
+                                   value=self.value)
+        self.assertEqual(self.attr, attr2)
+        attr2 = AttributeListValue("name", attr_type=str,
+                                   value="test_value")
+        self.assertNotEqual(self.attr, attr2)
+        attr2 = AttributeListValue(self.name, attr_type=str,
+                                   value="value")
+        self.assertNotEqual(self.attr, attr2)
+
+    def test_str(self):
+        """Test __str__ method of AttributeListValue."""
+        self.assertEqual(str(self.attr), str(self.value))
+
+    def test_get_item(self):
+        """Test __getitem__ method of type AttributeListValue."""
+        self.assertEqual(self.attr[0], self.value[0])
+        self.assertEqual(self.attr[-1], self.value[-1])
+        with self.assertRaises(IndexError):
+            print(self.attr[3])
+
+    def test_len(self):
+        """Test __len__ method of type AttributeListValue."""
+        self.assertEqual(len(self.attr), 1)
+
+    def test_append(self):
+        """Test append method of type AttributeListValue."""
+        self.assertEqual(len(self.attr), 1)
+        self.attr.append("second")
+        self.assertEqual(len(self.attr), 2)
+
+
+class TestAttributeDictValue(unittest.TestCase):
+    """Test AttributeDictValue model"""
+
+    def setUp(self):
+        self.name = "test"
+        self.value = {"test_value": "value"}
+        self.attr = AttributeDictValue(self.name, attr_type=str,
+                                       value=self.value)
+
+    def test_init(self):
+        """Test __init__ method of AttributeDictValue."""
+        self.assertEqual(self.name, self.attr.name)
+        self.assertEqual(self.value, self.attr.value)
+        self.assertEqual(str, self.attr.attr_type)
+        self.assertIsNone(self.attr.arguments)
+
+    def test_init_non_dict_value(self):
+        """Test __init__ method of AttributeDictValue with a value not of
+        type dict."""
+        attr2 = AttributeDictValue(self.name, attr_type=str,
+                                   value="test_value")
+        self.assertEqual(self.name, attr2.name)
+        self.assertEqual("test_value", attr2.value)
+        self.assertEqual(str, attr2.attr_type)
+        self.assertIsNone(attr2.arguments)
+
+    def test_init_none_value(self):
+        """Test __init__ method of AttributeDictValue with a value of
+        type None."""
+        attr2 = AttributeDictValue(self.name, attr_type=str,
+                                   value=None)
+        self.assertEqual(self.name, attr2.name)
+        self.assertEqual({}, attr2.value)
+        self.assertEqual(str, attr2.attr_type)
+        self.assertIsNone(attr2.arguments)
+
+    def test_eq(self):
+        """Test __eq__ method of AttributeDictValue."""
+        attr2 = AttributeDictValue(self.name, attr_type=str,
+                                   value=self.value)
+        self.assertEqual(self.attr, attr2)
+        attr2 = AttributeDictValue("name", attr_type=str,
+                                   value="test_value")
+        self.assertNotEqual(self.attr, attr2)
+        attr2 = AttributeDictValue(self.name, attr_type=str,
+                                   value="value")
+        self.assertNotEqual(self.attr, attr2)
+
+    def test_str(self):
+        """Test __str__ method of AttributeDictValue."""
+        self.assertEqual(str(self.attr), str(self.value))
+
+    def test_get_item(self):
+        """Test __getitem__ method of type AttributeDictValue."""
+        self.assertEqual(self.attr["test_value"], self.value["test_value"])
+        with self.assertRaises(KeyError):
+            print(self.attr["3"])
+
+    def test_set_item(self):
+        """Test __setitem__ method of type AttributeDictValue."""
+        self.attr["key"] = "value"
+        self.assertEqual(self.attr["key"], "value")
+
+    def test_len(self):
+        """Test __len__ method of type AttributeDictValue."""
+        self.assertEqual(len(self.attr), 1)
+
+    def test_iter(self):
+        """Test __iter__ method of type AttributeDictValue."""
+        keys = list(self.attr)
+        self.assertEqual(len(keys), 1)
+        self.assertEqual(keys[0], "test_value")
+
+    def test_delitem(self):
+        """Test __delitem__ method of type AttributeDictValue."""
+        del self.attr["test_value"]
+        self.assertEqual(len(self.attr), 0)
+
+    def test_items(self):
+        """Test items method of type AttributeDictValue."""
+        items = self.attr.items()
+        self.assertEqual(len(items), 1)
+        self.assertIn(('test_value', 'value'), items)
+
+    def test_values(self):
+        """Test values method of type AttributeDictValue."""
+        values = self.attr.values()
+        self.assertEqual(len(values), 1)
+        self.assertIn('value', values)
+
+    def test_keys(self):
+        """Test keys method of type AttributeDictValue."""
+        keys = self.attr.keys()
+        self.assertEqual(len(keys), 1)
+        self.assertIn('test_value', keys)
+
+    def test_get(self):
+        """Test get method of type AttributeDictValue."""
+        self.assertEqual(self.attr.get("test_value"), "value")
+        self.assertEqual(self.attr.get("missing", "default"), "default")
+        self.assertIsNone(self.attr.get("missing"))


### PR DESCRIPTION
Allow querying for the CI stages of a jenkins build. This incorporates
a new Stage model, querying jenkins for them and printing the Stage
model along with unit tests.
