### PR TITLE
Add language property to sphinx configuration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ copyright = u'2022, Red Hat'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
CI was failing due to language property set to None. Setting it to 'en'
should fix the issue and keep the same behaviour.
