### PR TITLE
Allowing usage of a session to download files from host.

### DIFF
--- a/cibyl/utils/net.py
+++ b/cibyl/utils/net.py
@@ -53,6 +53,8 @@ def download_file(url, dest):
 
     os.makedirs(os.path.dirname(dest), exist_ok=True)
 
+    LOG.info("Downloading file from: '%s'", url)
+
     with requests.get(url, stream=True) as request:
         if not request.ok:
             raise DownloadError(
@@ -67,7 +69,7 @@ def download_file(url, dest):
                 file.write(chunk)
 
 
-def download_into_memory(url):
+def download_into_memory(url, session=None):
     """Downloads the contents of a URL into memory, leaving the filesystem
     untouched.
 
@@ -78,13 +80,18 @@ def download_into_memory(url):
     ..  doctest::
         >>> download_into_memory('http://localhost/file.txt')
 
-    :param url: The URL to request.
+    :param url: URL to download.
     :type url: str
+    :param session: Session used to perform request. This function will not
+        close the session, that task is up to the caller.
+    :type session: :class:`requests.Session` or None
     :return: Contents of the page.
     :rtype: str
     :raise DownloadError: If the download failed.
     """
-    request = requests.get(url)
+    LOG.info("Downloading file from: '%s'", url)
+
+    request = session.get(url) if session else requests.get(url)
 
     if not request.ok:
         raise DownloadError(

--- a/tests/unit/utils/test_net.py
+++ b/tests/unit/utils/test_net.py
@@ -53,3 +53,22 @@ class TestDownloadIntoMemory(TestCase):
         self.assertEqual(string, download_into_memory(url))
 
         requests.get.assert_called_once_with(url)
+
+    def test_uses_session(self):
+        """Checks that if a session is passed, that is used instead.
+        """
+        url = 'https://localhost:8080'
+        string = 'HELLO'
+        content = bytearray(string, 'utf-8')
+
+        response = Mock()
+        response.ok = True
+        response.content = content
+
+        session = Mock()
+        session.get = Mock()
+        session.get.return_value = response
+
+        self.assertEqual(string, download_into_memory(url, session))
+
+        session.get.assert_called_once_with(url)


### PR DESCRIPTION
While working on Zuul tests, I realized that in order to download a file from Zuul I need to have the SSL session up and running. I already got that, but I could not pass it to the 'download' function. This request adds the opportunity to override the HTTP session that the function uses to perform the request.