### PR TITLE
Adding retrieval of artifacts from a build.

### DIFF
--- a/cibyl/sources/zuul/api.py
+++ b/cibyl/sources/zuul/api.py
@@ -16,6 +16,7 @@
 from abc import ABC, abstractmethod
 
 from cibyl.exceptions.source import SourceException
+from cibyl.sources.zuul.apis.builds import Artifact, ArtifactKind
 from cibyl.sources.zuul.providers import JobsProvider, PipelinesProvider
 from cibyl.utils.io import Closeable
 
@@ -90,6 +91,37 @@ class ZuulBuildAPI(Closeable, ABC):
         :rtype: int
         """
         return self._build['duration']
+
+    @property
+    def artifacts(self):
+        """
+        :return: Information on artifacts published by the build.
+        :rtype: list[:class:`Artifact`]
+        """
+        result = []
+
+        for entry in self._build['artifacts']:
+            artifact = Artifact()
+
+            # Try to fill the artifact with as much information given by the
+            # build as possible. Those fields unknown have a default value
+            # to go back to.
+
+            if 'name' in entry:
+                artifact.name = entry['name']
+
+            if 'url' in entry:
+                artifact.url = entry['url']
+
+            if 'metadata' in entry:
+                metadata = entry['metadata']
+
+                if 'type' in metadata:
+                    artifact.kind = ArtifactKind.from_string(metadata['type'])
+
+            result.append(artifact)
+
+        return result
 
     @property
     def raw(self):

--- a/cibyl/sources/zuul/apis/builds/__init__.py
+++ b/cibyl/sources/zuul/apis/builds/__init__.py
@@ -1,0 +1,56 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from enum import Enum
+
+
+class ArtifactKind(Enum):
+    """Represents all known types of artifacts.
+    """
+    OTHER = 0
+    """Type unknown, treat as generic."""
+    ZUUL_MANIFEST = 1
+    """Artifact is a manifest, which gives information on the log files 
+    resulted from the build's execution."""
+
+    @staticmethod
+    def from_string(string):
+        """Gets the artifact type from a string.
+
+        Known strings:
+            - 'zuul_manifest' -> :attr:`ArtifactKind.ZUUL_MANIFEST`
+
+        Any other string will return :attr:`ArtifactKind.OTHER`.
+
+        :param string: Text to parse.
+        :type string: str
+        :return: Type inferred through the text.
+        :rtype: :class:`ArtifactKind`
+        """
+        if string == 'zuul_manifest':
+            return ArtifactKind.ZUUL_MANIFEST
+
+        return ArtifactKind.OTHER
+
+
+class Artifact:
+    """Represents an artifact published by a build.
+    """
+    name: str = 'Unknown'
+    """Name of the artifact."""
+    url: str = 'Unknown'
+    """URL where its contents are located."""
+    kind: ArtifactKind = ArtifactKind.OTHER
+    """The type of artifact."""

--- a/cibyl/sources/zuul/apis/builds/__init__.py
+++ b/cibyl/sources/zuul/apis/builds/__init__.py
@@ -22,7 +22,7 @@ class ArtifactKind(Enum):
     OTHER = 0
     """Type unknown, treat as generic."""
     ZUUL_MANIFEST = 1
-    """Artifact is a manifest, which gives information on the log files 
+    """Artifact is a manifest, which gives information on the log files
     resulted from the build's execution."""
 
     @staticmethod


### PR DESCRIPTION
On this pull request:
- Adding a non-model representation of a build's artifacts.
- Parsing the artifact type based on data obtained from its definition.
- Adding a function to the API to get all artifacts published by a build.