### PR TITLE
Update query and delete query templates

### DIFF
--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -81,7 +81,21 @@ class ElasticSearch(ServerSource):
         if jobs_scope_arg:
             jobs_scope_pattern = re.compile(jobs_scope_arg)
 
-        query_body = QueryTemplate(key_filter, jobs_to_search).get
+        # Empty query for all hits or elements
+        if not jobs_to_search:
+            query_body = {
+                "query": {
+                    "match_all": {}
+                }
+            }
+        else:
+            query_body = {
+                'query': {
+                    'match_phrase_prefix': {
+                        key_filter: jobs_to_search[0]
+                    }
+                }
+            }
 
         hits = self.__query_get_hits(
             query=query_body,
@@ -392,68 +406,3 @@ class ElasticSearch(ServerSource):
             if not operator(test_duration, float(operand)):
                 return False
         return True
-
-
-class QueryTemplate():
-    """Used for template and substitutions according to the
-       elements received and return a dictionary equivalent to
-       a DSL query
-    """
-
-    def __init__(self: object, search_key: str,
-                 search_values: list, **kwargs) -> None:
-        if not isinstance(search_values, list):
-            raise TypeError(f"search_values argument received: \
-                            '{search_values}' is not a list")
-
-        # Empty query for all hits or elements
-        if not search_values:
-            self.query_body = {
-                "query": {
-                    "exists": {
-                        "field": search_key
-                    }
-                }
-            }
-        # Just one element that start with string
-        # is better to use 'match_phrase_prefix'
-        elif len(search_values) == 1:
-            query_type = 'match_phrase_prefix'
-
-            if 'query_type' in kwargs:
-                query_type = kwargs.get('query_type')
-
-            self.query_body = {
-                'query': {
-                    query_type: {
-                        search_key: search_values[0]
-                    }
-                }
-            }
-        # If we want to find more than one element and all of them
-        # start with string we need to search using OR condition
-        else:
-            match_to_process = {
-                'should': [],
-                "minimum_should_match": 1
-            }
-
-            for value in search_values:
-                match_to_process['should'].append(
-                    {
-                        "match_phrase": {
-                            search_key: value
-                        }
-                    }
-                )
-
-            self.query_body = {
-                'query': {
-                    'bool': match_to_process,
-                }
-            }
-
-    @property
-    def get(self: object) -> dict:
-        """Return DSL query in dictionary format"""
-        return self.query_body

--- a/tests/unit/sources/elasticsearch/test_api.py
+++ b/tests/unit/sources/elasticsearch/test_api.py
@@ -20,7 +20,7 @@ from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 from cibyl.cli.argument import Argument
 from cibyl.exceptions.source import MissingArgument
-from cibyl.sources.elasticsearch.api import ElasticSearch, QueryTemplate
+from cibyl.sources.elasticsearch.api import ElasticSearch
 from tests.utils import OpenstackPluginWithJobSystem
 
 
@@ -428,73 +428,3 @@ class TestElasticSearchOpenstackPlugin(OpenstackPluginWithJobSystem):
         deployment = builds['test'].deployment.value
         self.assertEqual(deployment.ip_version.value, '4')
         self.assertEqual(deployment.topology.value, 'unknown')
-
-
-class TestQueryTemplate(TestCase):
-    """Test cases for :class:`QueryTemplate`.
-    """
-
-    def setUp(self) -> None:
-        self.one_element_template = {
-            'query':
-                {
-                    'match_phrase_prefix':
-                    {
-                        'search_key': 'test'
-                    }
-                }
-        }
-
-        self.multiple_element_template = {
-            'query':
-                {
-                    'bool':
-                    {
-                        'minimum_should_match': 1,
-                        'should': [
-                            {
-                                'match_phrase':
-                                    {
-                                        'search_key': 'test'
-                                    }
-                            },
-                            {
-                                'match_phrase':
-                                    {
-                                        'search_key': 'test2'
-                                    }
-                            }
-                        ]
-                    }
-                }
-        }
-
-        self.all_elements_template = {
-            'query':
-                {
-                    'exists':
-                    {
-                        'field': 'search_key'
-                    }
-                }
-        }
-
-    def test_constructor(self: object) -> None:
-        """Test :class:`QueryTemplate` exceptions and
-           if it returns valid templates
-        """
-        with self.assertRaises(TypeError):
-            QueryTemplate('search_key', 'search_value')
-
-        # These are simple tests, but if we change something in
-        # :class:`QueryTemplate` tests will fail
-        self.assertEqual(QueryTemplate('search_key', []).get,
-                         self.all_elements_template)
-        self.assertEqual(
-            QueryTemplate('search_key', ['test']).get,
-            self.one_element_template
-        )
-        self.assertEqual(
-            QueryTemplate('search_key', ['test', 'test2']).get,
-            self.multiple_element_template
-        )


### PR DESCRIPTION
- Changed the query used to get all the information of jobs.

We have reduced the time from:

```
INFO     cibyl.orchestrator   Took 1.12s to query system osp_jenkins using source elasticsearch of type elasticsearch using method get_jobs
```

To:
```
INFO     cibyl.orchestrator   Took 0.83s to query system osp_jenkins using source elasticsearch of type elasticsearch using method get_jobs
```
Approximately.

- Delete QueryTemplate. Now the queries are very different so it's not necessary to have it because we're not using the same more than one time.