### PR TITLE
Add stages info to get_deployment in Jenkins

### DIFF
--- a/cibyl/outputs/cli/ci/system/common/builds.py
+++ b/cibyl/outputs/cli/ci/system/common/builds.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.outputs.cli.ci.system.common.status import get_status_colored
 from cibyl.utils.strings import IndentedTextBuilder
 from cibyl.utils.time import as_minutes
 
@@ -44,21 +45,8 @@ def get_status_section(palette, build):
 
     text = IndentedTextBuilder()
 
-    status_x_color_map = {
-        'SUCCESS': lambda: palette.green(build.status.value),
-        'FAILURE': lambda: palette.red(build.status.value),
-        'FAILED': lambda: palette.red(build.status.value),
-        'NOT EXECUTED': lambda: palette.blue(build.status.value),
-        'UNSTABLE': lambda: palette.yellow(build.status.value)
-    }
-
-    status = status_x_color_map.get(
-        build.status.value,
-        lambda: palette.underline(build.status.value)
-    )()
-
     text.add(palette.blue('Status: '), 0)
-    text[-1].append(status)
+    text[-1].append(get_status_colored(palette, build.status.value))
 
     return text.build()
 

--- a/cibyl/outputs/cli/ci/system/common/jobs.py
+++ b/cibyl/outputs/cli/ci/system/common/jobs.py
@@ -94,7 +94,7 @@ def get_plugin_section(printer, job):
                     printer.query, printer.verbosity, printer.palette
                 )
 
-                text.add(os_printer.print_deployment(value), 1)
+                text.add(os_printer.print_deployment(value), 0)
             else:
                 LOG.warning(
                     'Ignoring unknown plugin type: %s', type(value)

--- a/cibyl/outputs/cli/ci/system/common/stages.py
+++ b/cibyl/outputs/cli/ci/system/common/stages.py
@@ -1,0 +1,47 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from cibyl.outputs.cli.ci.system.common.status import get_status_colored
+from cibyl.utils.strings import IndentedTextBuilder
+from cibyl.utils.time import as_minutes
+
+
+def print_stage(stage, palette, verbosity=0):
+    """
+        Generate string representation of a Stage model.
+
+        :param test: The stage.
+        :type test: :class:`cibyl.models.ci.base.stage.Stage`
+        :param palette: The palette of colors to follow.
+        :type palette: :class:`cibyl.utils.colors.ColorPalette`
+        :param verbosity: The verbosity level to use.
+        :type verbosity: int
+        :return: Textual representation of the provided model.
+        :rtype: str
+    """
+    printer = IndentedTextBuilder()
+
+    printer.add(palette.blue('- '), 0)
+    printer[-1].append(stage.name.value)
+
+    if verbosity > 0:
+        if stage.status.value:
+            printer.add(palette.blue('Status: '), 1)
+            printer[-1].append(get_status_colored(palette, stage.status.value))
+
+        if stage.duration.value:
+            printer.add(palette.blue('Duration: '), 1)
+            printer[-1].append(f'{as_minutes(stage.duration.value):.4f}min')
+    return printer.build()

--- a/cibyl/outputs/cli/ci/system/common/status.py
+++ b/cibyl/outputs/cli/ci/system/common/status.py
@@ -1,0 +1,37 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+
+def get_status_colored(palette, status):
+    """Generates the text describing the status of a build.
+
+    :param palette: The palette of colors to follow.
+    :type palette: :class:`cibyl.utils.colors.ColorPalette`
+    :param status: The status to color.
+    :type status: str
+    :return: The text with the status colored.
+    :rtype: str
+    """
+
+    status_x_color_map = {
+            'SUCCESS': lambda: palette.green(status),
+            'FAILURE': lambda: palette.red(status),
+            'FAILED': lambda: palette.red(status),
+            'NOT_EXECUTED': lambda: palette.blue(status),
+            'UNSTABLE': lambda: palette.yellow(status)
+    }
+
+    return status_x_color_map.get(status, lambda: palette.underline(status))()

--- a/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
@@ -20,6 +20,7 @@ from cibyl.outputs.cli.ci.system.common.builds import (get_duration_section,
                                                        get_status_section)
 from cibyl.outputs.cli.ci.system.common.jobs import (get_plugin_section,
                                                      has_plugin_section)
+from cibyl.outputs.cli.ci.system.common.stages import print_stage
 from cibyl.outputs.cli.ci.system.printer import CISystemPrinter
 from cibyl.outputs.cli.printer import ColoredPrinter
 from cibyl.utils.strings import IndentedTextBuilder
@@ -105,31 +106,11 @@ class ColoredJobsSystemPrinter(ColoredPrinter, CISystemPrinter):
                 printer.add(self.print_test(test), 1)
 
         if build.stages.value:
+            printer.add(self.palette.blue('Stages: '), 1)
             for stage in build.stages:
-                printer.add(self.print_stage(stage), 1)
+                printer.add(print_stage(stage, self.palette,
+                                        self.verbosity), 2)
 
-        return printer.build()
-
-    def print_stage(self, stage):
-        """
-            Generate string representation of a Stage model.
-
-            :param test: The stage.
-            :type test: :class:`cibyl.models.ci.base.stage.Stage`
-            :return: Textual representation of the provided model.
-            :rtype: str
-        """
-        printer = IndentedTextBuilder()
-
-        printer.add(self.palette.blue('Stage: '), 0)
-        printer[-1].append(stage.name.value)
-
-        if self.verbosity > 0:
-            if stage.status.value:
-                printer.add(get_status_section(self.palette, stage), 1)
-
-            if stage.duration.value:
-                printer.add(get_duration_section(self.palette, stage), 1)
         return printer.build()
 
     def print_test(self, test):

--- a/cibyl/plugins/openstack/printers/colored.py
+++ b/cibyl/plugins/openstack/printers/colored.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 from cibyl.cli.query import QueryType
+from cibyl.outputs.cli.ci.system.common.stages import print_stage
 from cibyl.plugins.openstack.printers import OSPrinter
 from cibyl.utils.colors import DefaultPalette
 from cibyl.utils.strings import IndentedTextBuilder
@@ -211,6 +212,13 @@ class OSColoredPrinter(OSPrinter):
         for service in deployment.services.values():
             is_empty_deployment = False
             printer.add(self.print_service(service), 1)
+
+        if deployment.stages.value:
+            is_empty_deployment = False
+            printer.add(self.palette.blue('Stages: '), 1)
+            for stage in deployment.stages:
+                printer.add(print_stage(stage, self.palette,
+                                        self.verbosity), 2)
 
         if is_empty_deployment:
             # remove the "Openstack deployment" line

--- a/tests/unit/plugins/openstack/printers/test_raw.py
+++ b/tests/unit/plugins/openstack/printers/test_raw.py
@@ -15,6 +15,7 @@
 """
 from unittest import TestCase
 
+from cibyl.models.ci.base.stage import Stage
 from cibyl.plugins.openstack import Deployment
 from cibyl.plugins.openstack.container import Container
 from cibyl.plugins.openstack.node import Node
@@ -290,3 +291,18 @@ class TestOSRawPrinter(TestCase):
         self.assertIn("    - test1", result)
         self.assertIn("    - test2", result)
         self.assertIn("  Setup: rpm", result)
+
+    def test_print_stages(self):
+        """Test that the string representation of Stage within a
+        deployment works."""
+        stages = [Stage("Build", "FAILED", 60e3),
+                  Stage("Run", "SUCCESS", 120e3)]
+        deployment = Deployment("17.0", "virt", {}, {}, stages=stages)
+        printer = OSRawPrinter(verbosity=1)
+
+        result = printer.print_deployment(deployment)
+        expected = "Openstack deployment: \n  Release: 17.0\n  Infra type: "
+        expected += "virt\n  Stages: \n    - Build\n      Status: FAILED\n"
+        expected += "      Duration: 1.0000min\n    - Run\n      Status: "
+        expected += "SUCCESS\n      Duration: 2.0000min"
+        self.assertEqual(result, expected)

--- a/tests/unit/plugins/openstack/test_deployment.py
+++ b/tests/unit/plugins/openstack/test_deployment.py
@@ -15,6 +15,7 @@
 """
 from unittest import TestCase
 
+from cibyl.models.ci.base.stage import Stage
 from cibyl.plugins.openstack.deployment import Deployment
 from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.package import Package
@@ -62,6 +63,7 @@ class TestOpenstackDeployment(TestCase):
         self.assertIsNone(self.deployment.ip_version.value)
         self.assertEqual({}, self.deployment.services.value)
         self.assertEqual({}, self.deployment.nodes.value)
+        self.second_deployment.add_stage(Stage("Run", "SUCCESS"))
         self.deployment.merge(self.second_deployment)
         self.assertEqual(self.nodes, self.deployment.nodes.value)
         self.assertEqual(self.services, self.deployment.services.value)
@@ -80,6 +82,10 @@ class TestOpenstackDeployment(TestCase):
                          self.deployment.cleaning_network.value)
         self.assertEqual(self.security_group,
                          self.deployment.security_group.value)
+        self.assertEqual(len(self.deployment.stages), 1)
+        stage_obj = self.deployment.stages[0]
+        self.assertEqual(stage_obj.name.value, "Run")
+        self.assertEqual(stage_obj.status.value, "SUCCESS")
 
     def test_merge_method_existing_templates(self):
         """Test merge method of Deployment class with both deployments having


### PR DESCRIPTION
If the user passes the --stages argument when querying for any
get_deployment argument in Jenkins source, the stages run in the
lastCompleted build will be added to the deployment and printed.
