### PR TITLE
Print overloud templates correctly when N/A

### DIFF
--- a/cibyl/plugins/openstack/printers/colored.py
+++ b/cibyl/plugins/openstack/printers/colored.py
@@ -181,9 +181,12 @@ class OSColoredPrinter(OSPrinter):
                self.verbosity > 0:
                 is_empty_deployment = False
                 printer.add(self.palette.blue('Overcloud templates: '), 1)
-                for template in deployment.overcloud_templates.value:
-                    printer.add(self.palette.blue('- '), 2)
-                    printer[-1].append(template)
+                if isinstance(deployment.overcloud_templates.value, str):
+                    printer[-1].append(deployment.overcloud_templates.value)
+                else:
+                    for template in deployment.overcloud_templates.value:
+                        printer.add(self.palette.blue('- '), 2)
+                        printer[-1].append(template)
 
         is_empty_deployment &= (is_empty_network and is_empty_storage and
                                 is_empty_ironic)

--- a/tests/unit/plugins/openstack/printers/test_raw.py
+++ b/tests/unit/plugins/openstack/printers/test_raw.py
@@ -102,6 +102,18 @@ class TestOSRawPrinter(TestCase):
         self.assertIn("Nodes:", result)
         self.assertIn('controller-0', result)
 
+    def test_print_overcloud_templates_not_available(self):
+        """Test that overcloud_templates are printed correctly
+        when set to N/A."""
+        release = '17.0'
+        infra = 'ovb'
+        deployment = Deployment(release, infra, {}, {},
+                                overcloud_templates="N/A")
+        printer = OSRawPrinter(verbosity=1)
+
+        result = printer.print_deployment(deployment)
+        self.assertIn("Overcloud templates: N/A", result)
+
     def test_print_empty_deployment(self):
         """Test that the string representation of an empty deployment shows the
         apropiate message.


### PR DESCRIPTION
When overloud templates where set to the string used to mark a missing
value (N/A) they value was printed as three strings, instead of one. The
templates printer is modified to distinguish the case when the templates
have a string value.
