### PR TITLE
Add testing info to spec in Jenkins source

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -20,6 +20,7 @@ from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.model import Model
 from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.service import Service
+from cibyl.plugins.openstack.test_collection import TestCollection
 
 # pylint: disable=no-member
 
@@ -120,6 +121,10 @@ class Deployment(Model):
         'overcloud_templates': {
             'arguments': []
         },
+        'test_collection': {
+            'attr_type': TestCollection,
+            'arguments': []
+        },
         'network_backend': {
             'attr_type': str,
             'arguments': [Argument(name='--network-backend', arg_type=str,
@@ -143,7 +148,8 @@ class Deployment(Model):
                  dvr: str = None, tls_everywhere: str = None,
                  ml2_driver: str = None, ironic_inspector: str = None,
                  cleaning_network: str = None, security_group: str = None,
-                 overcloud_templates: set = None):
+                 overcloud_templates: set = None,
+                 test_collection: TestCollection = None):
         super().__init__({'release': release, 'infra_type': infra_type,
                           'nodes': nodes, 'services': services,
                           'ip_version': ip_version, 'topology': topology,
@@ -154,7 +160,8 @@ class Deployment(Model):
                           'ironic_inspector': ironic_inspector,
                           'security_group': security_group,
                           'cleaning_network': cleaning_network,
-                          'overcloud_templates': overcloud_templates})
+                          'overcloud_templates': overcloud_templates,
+                          'test_collection': test_collection})
 
     def add_node(self, node: Node):
         """Add a node to the deployment.
@@ -207,6 +214,7 @@ class Deployment(Model):
             self.cleaning_network.value = other.cleaning_network.value
         if not self.security_group.value:
             self.security_group.value = other.security_group.value
+
         if other.overcloud_templates.value:
             other_templates = other.overcloud_templates.value
             if self.overcloud_templates.value:
@@ -215,6 +223,13 @@ class Deployment(Model):
                 self.overcloud_templates.value = all_templates
             else:
                 self.overcloud_templates.value = other_templates
+
+        if other.test_collection.value:
+            if self.test_collection.value:
+                self.test_collection.value.merge(other.test_collection.value)
+            else:
+                self.test_collection.value = other.test_collection.value
+
         for node in other.nodes.values():
             self.add_node(node)
         for service in other.services.values():

--- a/cibyl/plugins/openstack/printers/colored.py
+++ b/cibyl/plugins/openstack/printers/colored.py
@@ -188,6 +188,17 @@ class OSColoredPrinter(OSPrinter):
                         printer.add(self.palette.blue('- '), 2)
                         printer[-1].append(template)
 
+        if deployment.test_collection.value:
+            if deployment.test_collection.value != "N/A" or \
+               self.verbosity > 0:
+                is_empty_deployment = False
+                if isinstance(deployment.test_collection.value, str):
+                    printer.add(self.palette.blue('Testing information: '), 1)
+                    printer[-1].append(deployment.test_collection.value)
+                else:
+                    printer.add(self.print_test_collection(
+                                    deployment.test_collection.value), 1)
+
         is_empty_deployment &= (is_empty_network and is_empty_storage and
                                 is_empty_ironic)
 
@@ -205,6 +216,25 @@ class OSColoredPrinter(OSPrinter):
             # remove the "Openstack deployment" line
             printer.pop()
             printer.add("No openstack information associated with this job", 1)
+        return printer.build()
+
+    def print_test_collection(self, test_collection):
+        """Print the test collection used in an Openstack deployment.
+
+        :param test_collection: The test collection used in the deployment
+        :type test_collection: :class:`TestCollection`
+        """
+        printer = IndentedTextBuilder()
+        printer.add(self.palette.blue('Testing information: '), 0)
+        printer.add(self.palette.blue('Test suites: '), 1)
+        if test_collection.tests.value:
+            for test in test_collection.tests.value:
+                printer.add(self.palette.blue('- '), 2)
+                printer[-1].append(test)
+
+        if test_collection.setup.value:
+            printer.add(self.palette.blue('Setup: '), 1)
+            printer[-1].append(test_collection.setup.value)
         return printer.build()
 
     def print_node(self, node):

--- a/cibyl/plugins/openstack/test_collection.py
+++ b/cibyl/plugins/openstack/test_collection.py
@@ -1,0 +1,52 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+from typing import Optional, Set
+
+from cibyl.models.model import Model
+
+# pylint: disable=no-member
+
+
+class TestCollection(Model):
+    """ Model for a collection of tests run in an Openstack deployment."""
+
+    API = {
+        'tests': {
+            'attr_type': set,
+            'arguments': []
+        },
+        'setup': {
+            'attr_type': str,
+            'arguments': []
+        }
+    }
+
+    def __init__(self, tests: Optional[Set[str]] = None, setup: str = None):
+        if tests is None:
+            tests = set()
+        super().__init__({'tests': tests, 'setup': setup})
+
+    def merge(self, other):
+        """Merge the information of two TestCollection objects representing the
+        same collection of tests.
+
+        :param other: The TestCollection object to merge
+        :type other: :class:`.TestCollection`
+        """
+        if not self.setup.value:
+            self.setup.value = other.setup.value
+        self.tests.value.update(other.tests.value)

--- a/cibyl/utils/files.py
+++ b/cibyl/utils/files.py
@@ -55,3 +55,16 @@ def get_first_available_file(filenames, file_check=is_file_available):
 
     # None of the files exist
     return None
+
+
+def get_file_name_from_path(path):
+    """Get the file name from a path. Strip all leading path
+    information as well as the extension.
+    :param path: Path of the file
+    :type path: str
+    :returns: The name of the file that path points to, without extension
+    :rtype: str
+    """
+    path = path.replace("\\", os.sep)
+    _, file_name = os.path.split(path)
+    return os.path.splitext(file_name)[0]

--- a/tests/unit/plugins/openstack/sources/test_jenkins.py
+++ b/tests/unit/plugins/openstack/sources/test_jenkins.py
@@ -53,6 +53,23 @@ def get_yaml_from_topology_string(topology):
     return yaml.dump(provision)
 
 
+def get_yaml_tests(test_suites, setup=None):
+    """Provide a yaml representation for the parameters obtained from an
+    infrared test.yml file.
+
+    :param test_suites: Suites to be run
+    :type test_suites: list
+    :param setup: Source of setup packages
+    :type setup: str
+    """
+    test_dict = {'tests': []}
+    for suite in test_suites:
+        test_dict['tests'].append(f"/path/to/suite/{suite}.yml")
+    if setup:
+        test_dict['setup'] = setup
+    return yaml.dump({'test': test_dict})
+
+
 def get_yaml_overcloud(ip, release, storage_backend, network_backend, dvr,
                        tls_everywhere, infra_type, ml2_driver=None,
                        ironic_inspector=None, cleaning_network=None,
@@ -313,7 +330,8 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(topologies[0]),
                 get_yaml_overcloud(ip_versions[0], releases[0],
                                    "ceph", "geneve", False,
-                                   False, "path/to/ovb")]
+                                   False, "path/to/ovb"),
+                JenkinsError]  # mock test.yaml
         # one call to get_packages_node and get_containers_node per node
         artifacts.extend([JenkinsError()]*(5*2))
         artifacts.extend([services])
@@ -321,7 +339,8 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(topologies[1]),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", False,
-                                   False, "path/to/ovb")])
+                                   False, "path/to/ovb"),
+                JenkinsError])  # mock test.yaml
         # one call to get_packages_node and get_containers_node per node
         artifacts.extend([JenkinsError()]*(3*2))
         artifacts.extend([services])
@@ -330,7 +349,8 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(topologies[2]),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", False,
-                                   False, "path/to/ovb")])
+                                   False, "path/to/ovb"),
+                JenkinsError])  # mock test.yaml
         # one call to get_packages_node and get_containers_node per node
         artifacts.extend([JenkinsError()]*(4*2))
         artifacts.extend([services])
@@ -399,7 +419,7 @@ tripleo_ironic_conductor.service loaded    active     running
                                                             logs_url}})
         # ensure that all deployment properties are found in the artifact so
         # that it does not fallback to reading values from job name
-        artifacts = [JenkinsError()]*9
+        artifacts = [JenkinsError()]*12
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -758,16 +778,17 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_overcloud(ip_versions[0], releases[0],
                                    "ceph", "geneve", dvr_status[0], False, "",
                                    ironic_inspector=True),
+                JenkinsError(),  # mock test.yaml
                 get_yaml_from_topology_string(topologies[1]),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", dvr_status[1],
                                    False, "", ironic_inspector=False),
+                JenkinsError(),  # mock test.yaml
                 get_yaml_from_topology_string(topologies[2]),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", dvr_status[2],
-                                   False, "")]
-        # one call to get_packages_node and get_containers_node per node, plus
-        # one to get_services
+                                   False, ""),
+                JenkinsError()]
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -820,16 +841,17 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(topologies[0]),
                 get_yaml_overcloud(ip_versions[0], releases[0],
                                    "ceph", "geneve", dvr_status[0], False, ""),
+                JenkinsError(),  # test.yaml
                 get_yaml_from_topology_string(topologies[1]),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", dvr_status[1],
                                    False, ""),
+                JenkinsError(),  # test.yaml
                 get_yaml_from_topology_string(topologies[2]),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", dvr_status[2],
-                                   False, "")]
-        # one call to get_packages_node and get_containers_node per node, plus
-        # one to get_services
+                                   False, ""),
+                JenkinsError()]
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -882,14 +904,17 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_overcloud(ip_versions[0], releases[0],
                                    "ceph", "geneve", dvr_status[0], False, "",
                                    ml2_driver="ovs"),
+                JenkinsError(),  # mock test.yaml
                 get_yaml_from_topology_string(topologies[1]),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", dvr_status[1],
                                    False, "", ml2_driver="ovn"),
+                JenkinsError(),  # mock test.yaml
                 get_yaml_from_topology_string(topologies[2]),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", dvr_status[2],
-                                   False, "")]
+                                   False, ""),
+                JenkinsError()]  # mock test.yaml
         # one call to get_packages_node and get_containers_node per node, plus
         # one to get_services
 
@@ -945,15 +970,18 @@ tripleo_ironic_conductor.service loaded    active     running
                                    "ceph", "geneve", dvr_status[0], False, "",
                                    ml2_driver="ovs",
                                    overcloud_templates=["a", "b"]),
+                JenkinsError(),  # mock test.yaml
                 get_yaml_from_topology_string(topologies[1]),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", dvr_status[1],
                                    False, "", ml2_driver="ovn",
                                    overcloud_templates=["c"]),
+                JenkinsError(),  # mock test.yaml
                 get_yaml_from_topology_string(topologies[2]),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", dvr_status[2],
-                                   False, "")]
+                                   False, ""),
+                JenkinsError()]  # mock test.yaml
         # one call to get_packages_node and get_containers_node per node, plus
         # one to get_services
 
@@ -1039,14 +1067,17 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(topologies[0]),
                 get_yaml_overcloud(ip_versions[0], releases[0],
                                    "ceph", "geneve", False, tls_status[0], ""),
+                JenkinsError(),  # mock test.yaml
                 get_yaml_from_topology_string(topologies[1]),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", False,
                                    tls_status[1], ""),
+                JenkinsError(),  # mock test.yaml
                 get_yaml_from_topology_string(topologies[2]),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", False,
-                                   tls_status[2], "")]
+                                   tls_status[2], ""),
+                JenkinsError()]
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -1099,14 +1130,17 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(""),
                 get_yaml_overcloud(ip_versions[0], releases[0],
                                    "ceph", "geneve", False, tls_status[0], ""),
+                JenkinsError(),  # mock test.yaml
                 get_yaml_from_topology_string(""),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", False,
                                    tls_status[1], ""),
+                JenkinsError(),  # mock test.yaml
                 get_yaml_from_topology_string(""),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", False,
-                                   tls_status[2], "")]
+                                   tls_status[2], ""),
+                JenkinsError()]
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -1260,7 +1294,8 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(topologies[0]),
                 get_yaml_overcloud(ip_versions[0], releases[0],
                                    "ceph", "geneve", False,
-                                   False, "path/to/ovb")]
+                                   False, "path/to/ovb"),
+                JenkinsError]  # mock test.yaml
         # one call to get_packages_node and get_containers_node per node
         artifacts.extend([JenkinsError()]*(5*2))
         artifacts.extend([services])
@@ -1268,7 +1303,8 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(topologies[1]),
                 get_yaml_overcloud(ip_versions[1], releases[1],
                                    "ceph", "geneve", False,
-                                   False, "path/to/ovb")])
+                                   False, "path/to/ovb"),
+                JenkinsError])  # mock test.yaml
         # one call to get_packages_node and get_containers_node per node
         artifacts.extend([JenkinsError()]*(3*2))
         artifacts.extend([services])
@@ -1277,7 +1313,8 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(topologies[2]),
                 get_yaml_overcloud(ip_versions[2], releases[2],
                                    "ceph", "geneve", False,
-                                   False, "path/to/ovb")])
+                                   False, "path/to/ovb"),
+                JenkinsError])  # mock test.yaml
         # one call to get_packages_node and get_containers_node per node
         artifacts.extend([JenkinsError()]*(4*2))
         artifacts.extend([services])
@@ -1384,29 +1421,29 @@ tripleo_ironic_conductor.service loaded    active     running
 
     def test_get_deployment_spec_correct_call(self):
         """ Test get_deployment call with --spec and one job."""
-        job_names = ['test_17.3_ipv4_job']
-        ip_versions = ['4']
-        releases = ['17.3']
-        topologies = ["compute:2,controller:3"]
+        job_name = 'test_17.3_ipv4_job'
+        ip = '4'
+        release = '17.3'
+        topology = "compute:2,controller:3"
 
         response = {'jobs': [{'_class': 'folder'}]}
         logs_url = 'href="link">Browse logs'
-        for job_name in job_names:
-            response['jobs'].append({'_class': 'org.job.WorkflowJob',
-                                     'name': job_name, 'url': 'url',
-                                     'lastCompletedBuild': {'description':
-                                                            logs_url}})
+        response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                 'name': job_name, 'url': 'url',
+                                 'lastCompletedBuild': {'description':
+                                                        logs_url}})
         # ensure that all deployment properties are found in the artifact so
         # that it does not fallback to reading values from job name
         artifacts = [
-                get_yaml_from_topology_string(topologies[0]),
-                get_yaml_overcloud(ip_versions[0], releases[0],
+                get_yaml_from_topology_string(topology),
+                get_yaml_overcloud(ip, release,
                                    "ceph", "geneve", False,
                                    False, "path/to/ovb",
                                    ironic_inspector=False, ml2_driver="ovs",
                                    cleaning_network=True,
                                    security_group="openvswitch",
-                                   overcloud_templates=["a", "b"])]
+                                   overcloud_templates=["a", "b"]),
+                get_yaml_tests(["designate", "neutron"])]
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -1415,93 +1452,101 @@ tripleo_ironic_conductor.service loaded    active     running
 
         jobs = self.jenkins.get_deployment(spec=spec, jobs=jobs)
         self.assertEqual(len(jobs), 1)
-        for job_name, ip, release, topology in zip(job_names, ip_versions,
-                                                   releases, topologies):
-            job = jobs[job_name]
-            deployment = job.deployment.value
-            self.assertEqual(job.name.value, job_name)
-            self.assertEqual(job.url.value, "url")
-            self.assertEqual(len(job.builds.value), 0)
-            self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
-            self.assertEqual(deployment.topology.value, topology)
-            self.assertEqual(deployment.storage_backend.value, "ceph")
-            self.assertEqual(deployment.network_backend.value, "geneve")
-            self.assertEqual(deployment.dvr.value, "False")
-            self.assertEqual(deployment.tls_everywhere.value, "False")
-            self.assertEqual(deployment.infra_type.value, "ovb")
-            self.assertEqual(deployment.ml2_driver.value, "ovs")
-            self.assertEqual(deployment.ironic_inspector.value, "False")
-            self.assertEqual(deployment.cleaning_network.value, "True")
-            self.assertEqual(deployment.security_group.value, "openvswitch")
-            self.assertEqual(deployment.overcloud_templates.value,
-                             set(["a", "b"]))
-            for component in topology.split(","):
-                role, amount = component.split(":")
-                for i in range(int(amount)):
-                    node_name = role+f"-{i}"
-                    node = Node(node_name, role)
-                    node_found = deployment.nodes[node_name]
-                    self.assertEqual(node_found.name, node.name)
-                    self.assertEqual(node_found.role, node.role)
-            services = deployment.services
-            self.assertEqual(len(services), 0)
+        job = jobs[job_name]
+        deployment = job.deployment.value
+        self.assertEqual(job.name.value, job_name)
+        self.assertEqual(job.url.value, "url")
+        self.assertEqual(len(job.builds.value), 0)
+        self.assertEqual(deployment.release.value, release)
+        self.assertEqual(deployment.ip_version.value, ip)
+        self.assertEqual(deployment.topology.value, topology)
+        self.assertEqual(deployment.storage_backend.value, "ceph")
+        self.assertEqual(deployment.network_backend.value, "geneve")
+        self.assertEqual(deployment.dvr.value, "False")
+        self.assertEqual(deployment.tls_everywhere.value, "False")
+        self.assertEqual(deployment.infra_type.value, "ovb")
+        self.assertEqual(deployment.ml2_driver.value, "ovs")
+        self.assertEqual(deployment.ironic_inspector.value, "False")
+        self.assertEqual(deployment.cleaning_network.value, "True")
+        self.assertEqual(deployment.security_group.value, "openvswitch")
+        self.assertEqual(deployment.overcloud_templates.value,
+                         set(["a", "b"]))
+        for component in topology.split(","):
+            role, amount = component.split(":")
+            for i in range(int(amount)):
+                node_name = role+f"-{i}"
+                node = Node(node_name, role)
+                node_found = deployment.nodes[node_name]
+                self.assertEqual(node_found.name, node.name)
+                self.assertEqual(node_found.role, node.role)
+        services = deployment.services
+        self.assertEqual(len(services), 0)
+        test_collection = deployment.test_collection.value
+        tests = test_collection.tests.value
+        self.assertEqual(len(tests), 2)
+        self.assertIn("designate", tests)
+        self.assertIn("neutron", tests)
+        self.assertIsNone(test_collection.setup.value)
 
     def test_get_deployment_spec_correct_call_no_jobs(self):
         """ Test get_deployment call with --spec and one job without using the
         jobs argument."""
-        job_names = ['test_17.3_ipv4_job']
-        ip_versions = ['4']
-        releases = ['17.3']
-        topologies = ["compute:2,controller:3"]
+        job_name = 'test_17.3_ipv4_job'
+        ip = '4'
+        release = '17.3'
+        topology = "compute:2,controller:3"
 
         response = {'jobs': [{'_class': 'folder'}]}
         logs_url = 'href="link">Browse logs'
-        for job_name in job_names:
-            response['jobs'].append({'_class': 'org.job.WorkflowJob',
-                                     'name': job_name, 'url': 'url',
-                                     'lastCompletedBuild': {'description':
-                                                            logs_url}})
+        response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                 'name': job_name, 'url': 'url',
+                                 'lastCompletedBuild': {'description':
+                                                        logs_url}})
         # ensure that all deployment properties are found in the artifact so
         # that it does not fallback to reading values from job name
         artifacts = [
-                get_yaml_from_topology_string(topologies[0]),
-                get_yaml_overcloud(ip_versions[0], releases[0],
+                get_yaml_from_topology_string(topology),
+                get_yaml_overcloud(ip, release,
                                    "ceph", "geneve", False,
-                                   False, "path/to/ovb", ml2_driver="ovn")]
+                                   False, "path/to/ovb", ml2_driver="ovn"),
+                get_yaml_tests(["designate", "neutron"], setup="rpm")]
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
         spec = Argument("spec", str, "", value=["test_17.3_ipv4_job"])
         jobs = self.jenkins.get_deployment(spec=spec)
         self.assertEqual(len(jobs), 1)
-        for job_name, ip, release, topology in zip(job_names, ip_versions,
-                                                   releases, topologies):
-            job = jobs[job_name]
-            deployment = job.deployment.value
-            self.assertEqual(job.name.value, job_name)
-            self.assertEqual(job.url.value, "url")
-            self.assertEqual(len(job.builds.value), 0)
-            self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
-            self.assertEqual(deployment.topology.value, topology)
-            self.assertEqual(deployment.storage_backend.value, "ceph")
-            self.assertEqual(deployment.network_backend.value, "geneve")
-            self.assertEqual(deployment.dvr.value, "False")
-            self.assertEqual(deployment.ml2_driver.value, "ovn")
-            self.assertEqual(deployment.tls_everywhere.value, "False")
-            self.assertEqual(deployment.infra_type.value, "ovb")
-            self.assertEqual(deployment.security_group.value, "native ovn")
-            for component in topology.split(","):
-                role, amount = component.split(":")
-                for i in range(int(amount)):
-                    node_name = role+f"-{i}"
-                    node = Node(node_name, role)
-                    node_found = deployment.nodes[node_name]
-                    self.assertEqual(node_found.name, node.name)
-                    self.assertEqual(node_found.role, node.role)
-            services = deployment.services
-            self.assertEqual(len(services), 0)
+        job = jobs[job_name]
+        deployment = job.deployment.value
+        self.assertEqual(job.name.value, job_name)
+        self.assertEqual(job.url.value, "url")
+        self.assertEqual(len(job.builds.value), 0)
+        self.assertEqual(deployment.release.value, release)
+        self.assertEqual(deployment.ip_version.value, ip)
+        self.assertEqual(deployment.topology.value, topology)
+        self.assertEqual(deployment.storage_backend.value, "ceph")
+        self.assertEqual(deployment.network_backend.value, "geneve")
+        self.assertEqual(deployment.dvr.value, "False")
+        self.assertEqual(deployment.ml2_driver.value, "ovn")
+        self.assertEqual(deployment.tls_everywhere.value, "False")
+        self.assertEqual(deployment.infra_type.value, "ovb")
+        self.assertEqual(deployment.security_group.value, "native ovn")
+        for component in topology.split(","):
+            role, amount = component.split(":")
+            for i in range(int(amount)):
+                node_name = role+f"-{i}"
+                node = Node(node_name, role)
+                node_found = deployment.nodes[node_name]
+                self.assertEqual(node_found.name, node.name)
+                self.assertEqual(node_found.role, node.role)
+        services = deployment.services
+        self.assertEqual(len(services), 0)
+        test_collection = deployment.test_collection.value
+        tests = test_collection.tests.value
+        self.assertEqual(len(tests), 2)
+        self.assertIn("designate", tests)
+        self.assertIn("neutron", tests)
+        self.assertEqual(test_collection.setup.value, "rpm")
 
     def test_get_deployment_spec_no_overcloud_info(self):
         """ Test get_deployment call with --spec and missing overcloud info."""
@@ -1519,7 +1564,8 @@ tripleo_ironic_conductor.service loaded    active     running
         # that it does not fallback to reading values from job name
         artifacts = [
                 get_yaml_from_topology_string(topologies[0]),
-                JenkinsError]
+                JenkinsError,
+                JenkinsError]  # mock test.yaml
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -1563,7 +1609,8 @@ tripleo_ironic_conductor.service loaded    active     running
         # that it does not fallback to reading values from job name
         artifacts = [
                 get_yaml_from_topology_string(topologies[0]),
-                JenkinsError]
+                JenkinsError,
+                JenkinsError]  # mock test.yaml
 
         self.jenkins.send_request = Mock(side_effect=[response]+artifacts)
 
@@ -1612,7 +1659,8 @@ tripleo_ironic_conductor.service loaded    active     running
                 get_yaml_from_topology_string(topologies[0]),
                 get_yaml_overcloud(ip_versions[0], releases[0],
                                    "ceph", "geneve", False,
-                                   False, "path/to/ovb")]
+                                   False, "path/to/ovb"),
+                JenkinsError()]  # mock test.yaml
         # two call to get_packages_node and get_containers_node per node
         for _ in range(5):
             artifacts.append(containers)

--- a/tests/unit/plugins/openstack/test_deployment.py
+++ b/tests/unit/plugins/openstack/test_deployment.py
@@ -19,6 +19,7 @@ from cibyl.plugins.openstack.deployment import Deployment
 from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.package import Package
 from cibyl.plugins.openstack.service import Service
+from cibyl.plugins.openstack.test_collection import TestCollection
 
 
 class TestOpenstackDeployment(TestCase):
@@ -124,3 +125,32 @@ class TestOpenstackDeployment(TestCase):
         self.assertEqual(node.role.value, node.role.value)
         self.assertEqual(node.packages['package'].name,
                          node_to_add.packages['package'].name)
+
+    def test_merge_method_existing_test_collection(self):
+        """Test merge method of Deployment class."""
+        test_collection = TestCollection(set(["test1", "test2"]))
+        test_collection2 = TestCollection(set(["test3"]))
+        deployment = Deployment(self.release, self.infra, {}, {},
+                                test_collection=test_collection)
+        deployment2 = Deployment(self.release, self.infra, {}, {},
+                                 test_collection=test_collection2)
+        deployment2.merge(deployment)
+        test_collection = deployment2.test_collection.value
+        tests = test_collection.tests.value
+        self.assertEqual(len(tests), 3)
+        self.assertIn("test1", tests)
+        self.assertIn("test2", tests)
+        self.assertIn("test3", tests)
+
+    def test_merge_method_non_existing_test_collection(self):
+        """Test merge method of Deployment class."""
+        test_collection = TestCollection(set(["test1", "test2"]))
+        deployment = Deployment(self.release, self.infra, {}, {},
+                                test_collection=test_collection)
+        deployment2 = Deployment(self.release, self.infra, {}, {})
+        deployment2.merge(deployment)
+        test_collection = deployment2.test_collection.value
+        tests = test_collection.tests.value
+        self.assertEqual(len(tests), 2)
+        self.assertIn("test1", tests)
+        self.assertIn("test2", tests)

--- a/tests/unit/plugins/openstack/test_test_collection.py
+++ b/tests/unit/plugins/openstack/test_test_collection.py
@@ -1,0 +1,42 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.plugins.openstack.test_collection import TestCollection
+
+
+class TestOpenstackTestCollection(TestCase):
+    """Test openstack TestCollection model."""
+    def setUp(self):
+        self.tests = set(["test1", "test2"])
+        self.tests2 = set(["test4", "test3"])
+        self.all_tests = self.tests.union(self.tests2)
+        self.setup = 'rhos-release'
+        self.collection = TestCollection(self.tests)
+        self.collection2 = TestCollection(self.tests2, self.setup)
+
+    def test_merge(self):
+        """Test TestCollection merge method when both models have tests."""
+        self.collection.merge(self.collection2)
+        self.assertEqual(self.setup, self.collection.setup.value)
+        self.assertEqual(self.all_tests, self.collection.tests.value)
+
+    def test_merge_no_tests(self):
+        """Test TestCollection merge method when only one model has tests."""
+        other_collection = TestCollection()
+        other_collection.merge(self.collection)
+        self.assertIsNone(other_collection.setup.value)
+        self.assertEqual(self.tests, other_collection.tests.value)

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -15,7 +15,7 @@
 """
 from unittest import TestCase
 
-from cibyl.utils.files import get_first_available_file
+from cibyl.utils.files import get_file_name_from_path, get_first_available_file
 
 
 class TestGetFirstAvailableFile(TestCase):
@@ -49,3 +49,49 @@ class TestGetFirstAvailableFile(TestCase):
             ),
             expected_file
         )
+
+
+class TestGetFileNameFromPath(TestCase):
+    """Test cases for the 'get_file_name_from_path' function.
+    """
+    def test_file_name(self):
+        """Checks that the file name is extracted from a path and the extension
+        is stripped."""
+        file_path = 'path/to/expected/file.txt'
+        file_name = get_file_name_from_path(file_path)
+        self.assertEqual(file_name, "file")
+
+    def test_file_name_abs_path(self):
+        """Checks that the file name is extracted from a path and the extension
+        is stripped."""
+        file_path = '/path/to/expected/file.txt'
+        file_name = get_file_name_from_path(file_path)
+        self.assertEqual(file_name, "file")
+
+    def test_file_name_no_extension(self):
+        """Checks that the file name is extracted from a path with no
+        extension."""
+        file_path = 'path/to/expected/file'
+        file_name = get_file_name_from_path(file_path)
+        self.assertEqual(file_name, "file")
+
+    def test_file_name_no_leading_path(self):
+        """Checks that the file name is extracted from a path with no parent
+        folders and the extension is stripped."""
+        file_path = 'file.txt'
+        file_name = get_file_name_from_path(file_path)
+        self.assertEqual(file_name, "file")
+
+    def test_file_name_windows_path(self):
+        """Checks that the file name is extracted from a path and the extension
+        is stripped."""
+        file_path = r'C:\path\expected\file.txt'
+        file_name = get_file_name_from_path(file_path)
+        self.assertEqual(file_name, "file")
+
+    def test_file_name_windows_path_no_extension(self):
+        """Checks that the file name is extracted from a path with no
+        extension."""
+        file_path = 'C:\\path\\expected\\file'
+        file_name = get_file_name_from_path(file_path)
+        self.assertEqual(file_name, "file")


### PR DESCRIPTION
Add to the spec the test suite ran in the deployment as well as the
source of packages. This information is stored in a TestCollection model
which is part of Deployment.
