### PR TITLE
Adding the bare minimum for Zuul to work with OpenStack plugin

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul.py
+++ b/cibyl/plugins/openstack/sources/zuul.py
@@ -1,0 +1,28 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from cibyl.models.attribute import AttributeDictValue
+from cibyl.models.ci.zuul.tenant import Tenant
+from cibyl.sources.source import speed_index
+
+
+class Zuul:
+    @speed_index({'base': 2})
+    def get_deployment(self, **kwargs):
+        return AttributeDictValue(
+            name='tenants',
+            attr_type=Tenant,
+            value={}
+        )

--- a/cibyl/sources/source_factory.py
+++ b/cibyl/sources/source_factory.py
@@ -50,8 +50,10 @@ class SourceFactory:
             source_class = Jenkins
         elif source.__name__ == 'ElasticSearch':
             source_class = ElasticSearch
+        elif source.__name__ == 'Zuul':
+            source_class = Zuul
         else:
-            LOG.warning(f"Ignoring source extension: {source_class}")
+            LOG.warning(f"Ignoring source extension for class: {source}")
 
         if source_class:
             for attr_name in [a for a in dir(source)

--- a/tests/unit/plugins/openstack/sources/test_zuul.py
+++ b/tests/unit/plugins/openstack/sources/test_zuul.py
@@ -1,0 +1,35 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.models.ci.zuul.tenant import Tenant
+from cibyl.plugins.openstack.sources.zuul import Zuul
+
+
+class TestGetDeployment(TestCase):
+    """Tests for :meth:`Zuul.get_deployment`.
+    """
+
+    def test_returned_type(self):
+        """Checks that the returned attribute is of 'Tenant' type.
+        """
+
+        source = Zuul()
+
+        result = source.get_deployment()
+
+        self.assertEqual(result.name, 'tenants')
+        self.assertEqual(result.attr_type, Tenant)

--- a/tests/unit/plugins/openstack/sources/test_zuul.py
+++ b/tests/unit/plugins/openstack/sources/test_zuul.py
@@ -26,7 +26,6 @@ class TestGetDeployment(TestCase):
     def test_returned_type(self):
         """Checks that the returned attribute is of 'Tenant' type.
         """
-
         source = Zuul()
 
         result = source.get_deployment()

--- a/tests/unit/sources/test_source_factory.py
+++ b/tests/unit/sources/test_source_factory.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 from unittest import TestCase
+from unittest.mock import Mock
 
 from cibyl.exceptions.config import NonSupportedSourceType
 from cibyl.sources.elasticsearch.api import ElasticSearch
@@ -68,3 +69,22 @@ class TestSourceFactory(TestCase):
         self.assertRaises(NonSupportedSourceType,
                           SourceFactory.create_source,
                           "unknown", "zuul_source")
+
+
+class TestExtendSource(TestCase):
+    """Tests for :func:`SourceFactory.extend_source`."""
+
+    def test_extend_zuul_source(self):
+        """Checks that a Zuul source gets extended.
+        """
+        source = Mock()
+        source.__name__ = 'Zuul'
+        source.__test = Mock()
+        source.test = Mock()
+
+        SourceFactory.extend_source(source)
+
+        self.assertFalse(hasattr(Zuul, '__test'))
+
+        self.assertTrue(hasattr(Zuul, 'test'))
+        self.assertEqual(Zuul.test, source.test)


### PR DESCRIPTION
Just added an empty 'get_deployment' function and got it installed on the Zuul source if the OpenStack plugin is enabled. The function of course fetches nothing, but at least the --spec command will not crash anymore.