### PR TITLE
Reworked how plugin sources are found.

### DIFF
--- a/cibyl/plugins/__init__.py
+++ b/cibyl/plugins/__init__.py
@@ -18,7 +18,11 @@ import logging
 import os
 
 from cibyl.exceptions.plugin import MissingPlugin
+from cibyl.sources.plugins import SourceExtension
 from cibyl.sources.source_factory import SourceFactory
+from cibyl.utils.files import FileSearch
+from cibyl.utils.filtering import apply_filters
+from cibyl.utils.reflection import get_classes_in, load_module
 
 LOG = logging.getLogger(__name__)
 
@@ -46,15 +50,25 @@ def is_plugin_class(class_obj):
             "sources" in class_obj.__module__
 
 
-def extend_source(plugin_name, plugin_module_path):
-    plugin_sources = []
-    for py in [f[:-3] for f in os.listdir(plugin_module_path)
-               if f.endswith('.py') and f != '__init__.py']:
-        mod = __import__('.'.join(
-            [f"cibyl.plugins.{plugin_name}.sources", py]), fromlist=[py])
-        plugin_sources.extend([source_tuple[1] for source_tuple in
-                               inspect.getmembers(mod, is_plugin_class)])
-    for plugin_source in plugin_sources:
+def get_plugin_sources(plugin_module_path):
+    result = []
+
+    file_search = FileSearch(plugin_module_path)
+    file_search.with_recursion()
+    file_search.with_extension('.py')
+
+    for module_path in file_search.get():
+        result += apply_filters(
+            get_classes_in(load_module(module_path)),
+            lambda cls: issubclass(cls, SourceExtension),
+            lambda cls: cls is not SourceExtension
+        )
+
+    return result
+
+
+def extend_source(plugin_module_path):
+    for plugin_source in get_plugin_sources(plugin_module_path):
         SourceFactory.extend_source(plugin_source)
 
 
@@ -66,5 +80,5 @@ def enable_plugins(plugins: list = None):
             plugin_module = get_plugin_module(plugin)
             plugin_module.Plugin().extend_models()
             plugin_module_path = get_plugin_module_path(plugin_module)
-            extend_source(plugin, plugin_module_path)
+            extend_source(plugin_module_path)
             plugin_module.Plugin().extend_query_types()

--- a/cibyl/plugins/__init__.py
+++ b/cibyl/plugins/__init__.py
@@ -45,11 +45,6 @@ def get_plugin_module_path(plugin_module):
         plugin_module.__file__)), 'sources')
 
 
-def is_plugin_class(class_obj):
-    return inspect.isclass(class_obj) and \
-            "sources" in class_obj.__module__
-
-
 def get_plugin_sources(plugin_module_path):
     result = []
 

--- a/cibyl/plugins/__init__.py
+++ b/cibyl/plugins/__init__.py
@@ -13,7 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-import inspect
 import logging
 import os
 

--- a/cibyl/plugins/openstack/sources/elasticsearch.py
+++ b/cibyl/plugins/openstack/sources/elasticsearch.py
@@ -19,13 +19,14 @@ import logging
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.base.job import Job
 from cibyl.plugins.openstack.deployment import Deployment
+from cibyl.sources.plugins import SourceExtension
 from cibyl.sources.source import speed_index
 from cibyl.utils.filtering import IP_PATTERN
 
 LOG = logging.getLogger(__name__)
 
 
-class ElasticSearch:
+class ElasticSearch(SourceExtension):
     """Elasticsearch Source"""
 
     @speed_index({'base': 2})

--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -34,6 +34,7 @@ from cibyl.plugins.openstack.service import Service
 from cibyl.plugins.openstack.test_collection import TestCollection
 from cibyl.plugins.openstack.utils import translate_topology_string
 from cibyl.sources.jenkins import detect_job_info_regex, filter_jobs
+from cibyl.sources.plugins import SourceExtension
 from cibyl.sources.source import speed_index
 from cibyl.utils.dicts import subset
 from cibyl.utils.files import get_file_name_from_path
@@ -132,7 +133,7 @@ def filter_models_set_field(job: dict, user_input: Argument,
     return bool(job[field_to_check])
 
 
-class Jenkins:
+class Jenkins(SourceExtension):
     """A class representation of Jenkins client."""
 
     deployment_attr = ["topology", "release",

--- a/cibyl/sources/plugins.py
+++ b/cibyl/sources/plugins.py
@@ -13,17 +13,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from cibyl.models.attribute import AttributeDictValue
-from cibyl.models.ci.zuul.tenant import Tenant
-from cibyl.sources.plugins import SourceExtension
-from cibyl.sources.source import speed_index
 
 
-class Zuul(SourceExtension):
-    @speed_index({'base': 2})
-    def get_deployment(self, **kwargs):
-        return AttributeDictValue(
-            name='tenants',
-            attr_type=Tenant,
-            value={}
-        )
+class SourceExtension:
+    """Flag that indicates that the class is meant to extend one of Cibyl's
+    sources.
+    """

--- a/cibyl/utils/files.py
+++ b/cibyl/utils/files.py
@@ -156,4 +156,16 @@ def get_file_name_from_path(path):
 
 
 def get_file_extension(path):
+    """Gets the dot-prefixed extension from the path to a file.
+
+    :param path: Path to the file to get the extension from.
+    :type path: str
+    :return: The file's extension.
+    :rtype: str
+
+    Examples
+    --------
+    >>> get_file_extension('/home/user/file.txt')
+    '.txt'
+    """
     return Path(path).suffix

--- a/cibyl/utils/reflection.py
+++ b/cibyl/utils/reflection.py
@@ -1,0 +1,49 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import importlib.util
+import inspect
+
+from cibyl.utils.files import get_file_name_from_path
+
+
+def load_module(path):
+    """Loads a Python module given its location.
+
+    :param path: Absolute path to the module to be loaded.
+    :type path: str
+    :return: The loaded module.
+    :rtype: :class:`ModuleType`
+    """
+    spec = importlib.util.spec_from_file_location(
+        get_file_name_from_path(path), path
+    )
+
+    module = importlib.util.module_from_spec(spec)
+
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def get_classes_in(__module):
+    """Gets all class symbols stored within a Python module.
+
+    :param __module: The module to get the classes from.
+    :type __module: :class:`types.ModuleType`
+    :return: List of all classes stored in the module.
+    :rtype: list[type]
+    """
+    return [cls for _, cls in inspect.getmembers(__module, inspect.isclass)]

--- a/tests/intr/test_orchestrator.py
+++ b/tests/intr/test_orchestrator.py
@@ -48,8 +48,9 @@ class TestOrchestrator(TestCase):
     @patch.object(SourceMethodsStore, '_method_information_tuple')
     @patch.object(Jenkins, 'get_jobs', side_effect=JenkinsError)
     @patch.object(OSPJenkins, 'get_deployment', side_effect=JenkinsError)
-    def test_args_level(self, jenkins_deployment, jenkins_jobs, store_mock,
-                        _):
+    @patch('cibyl.plugins.get_classes_in', return_value=[OSPJenkins])
+    def test_args_level(self, _get_classes_mock, jenkins_deployment,
+                        jenkins_jobs, store_mock, _):
         """Test that the args level is updated properly in run_query."""
         store_mock.side_effect = [("jenkins", "get_deployment"),
                                   ("jenkins", "get_deployment"),

--- a/tests/unit/utils/test_files.py
+++ b/tests/unit/utils/test_files.py
@@ -13,9 +13,196 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+import os
+import os.path
 from unittest import TestCase
+from unittest.mock import Mock, call
 
-from cibyl.utils.files import get_file_name_from_path, get_first_available_file
+from cibyl.utils.files import (FileSearch, get_file_name_from_path,
+                               get_first_available_file)
+
+
+class TestFileSearch(TestCase):
+    """Tests for :class:`FileSearch`.
+    """
+
+    def test_list_files_in_directory(self):
+        """Checks that all files in a directory can be listed.
+        """
+        directory = 'path/to/dir'
+
+        file1 = 'file1.txt'
+        file2 = 'file2.txt'
+
+        os.listdir = Mock()
+        os.listdir.return_value = [file1, file2]
+
+        search = FileSearch(directory)
+
+        self.assertEqual(
+            [
+                f'{directory}/{file1}',
+                f'{directory}/{file2}'
+            ],
+            search.get()
+        )
+
+        os.listdir.assert_called_once_with(directory)
+
+    def test_filter_by_extension(self):
+        """Checks that files can be filtered by an extension.
+        """
+        directory = 'path/to/dir'
+
+        file1 = 'file1.py'
+        file2 = 'file2.txt'
+
+        os.listdir = Mock()
+        os.listdir.return_value = [file1, file2]
+
+        search = FileSearch(directory) \
+            .with_extension('.py')
+
+        self.assertEqual(
+            [
+                f'{directory}/{file1}'
+            ],
+            search.get()
+        )
+
+        os.listdir.assert_called_once_with(directory)
+
+    def test_filter_by_extensions(self):
+        """Checks that files can be filtered by more than one extension.
+        """
+        directory = 'path/to/dir'
+
+        file1 = 'file1.py'
+        file2 = 'file2.txt'
+
+        os.listdir = Mock()
+        os.listdir.return_value = [file1, file2]
+
+        search = FileSearch(directory) \
+            .with_extension('.py') \
+            .with_extension('.txt')
+
+        self.assertEqual(
+            [
+                f'{directory}/{file1}',
+                f'{directory}/{file2}'
+            ],
+            search.get()
+        )
+
+        os.listdir.assert_called_once_with(directory)
+
+    def test_recursive(self):
+        """Checks that it is possible to recurse over subdirectories
+        to find more files.
+        """
+
+        def listdir(__dir):
+            if __dir == directory:
+                return [file1, file2, subdirectory]
+            elif __dir == f'{directory}/{subdirectory}':
+                return [file3, file4]
+
+            raise NotImplementedError
+
+        def isdir(__dir):
+            if __dir == f'{directory}/{subdirectory}':
+                return True
+
+            return False
+
+        directory = 'path/to/dir'
+
+        file1 = 'file1.py'
+        file2 = 'file2.txt'
+
+        subdirectory = 'subdir'
+
+        file3 = 'file3.md'
+        file4 = 'file4.rst'
+
+        os.listdir = Mock()
+        os.listdir.side_effect = listdir
+
+        os.path.isdir = Mock()
+        os.path.isdir.side_effect = isdir
+
+        search = FileSearch(directory) \
+            .with_recursion()
+
+        self.assertEqual(
+            [
+                f'{directory}/{file1}',
+                f'{directory}/{file2}',
+                f'{directory}/{subdirectory}/{file3}',
+                f'{directory}/{subdirectory}/{file4}',
+            ],
+            search.get()
+        )
+
+        os.listdir.assert_has_calls(
+            [
+                call(directory),
+                call(f'{directory}/{subdirectory}')
+            ]
+        )
+
+    def test_recursion_and_extensions(self):
+        """Checks that it is possible to combine the two filters.
+        """
+
+        def listdir(__dir):
+            if __dir == directory:
+                return [file1, file2, subdirectory]
+            elif __dir == f'{directory}/{subdirectory}':
+                return [file3, file4]
+
+            raise NotImplementedError
+
+        def isdir(__dir):
+            if __dir == f'{directory}/{subdirectory}':
+                return True
+
+            return False
+
+        directory = 'path/to/dir'
+
+        file1 = 'file1.py'
+        file2 = 'file2.txt'
+
+        subdirectory = 'subdir'
+
+        file3 = 'file3.md'
+        file4 = 'file4.rst'
+
+        os.listdir = Mock()
+        os.listdir.side_effect = listdir
+
+        os.path.isdir = Mock()
+        os.path.isdir.side_effect = isdir
+
+        search = FileSearch(directory) \
+            .with_recursion() \
+            .with_extension('.md')
+
+        self.assertEqual(
+            [
+                f'{directory}/{subdirectory}/{file3}'
+            ],
+            search.get()
+        )
+
+        os.listdir.assert_has_calls(
+            [
+                call(directory),
+                call(f'{directory}/{subdirectory}')
+            ]
+        )
 
 
 class TestGetFirstAvailableFile(TestCase):
@@ -54,6 +241,7 @@ class TestGetFirstAvailableFile(TestCase):
 class TestGetFileNameFromPath(TestCase):
     """Test cases for the 'get_file_name_from_path' function.
     """
+
     def test_file_name(self):
         """Checks that the file name is extracted from a path and the extension
         is stripped."""

--- a/tests/unit/utils/test_reflection.py
+++ b/tests/unit/utils/test_reflection.py
@@ -1,0 +1,89 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import importlib.util
+from unittest import TestCase
+from unittest.mock import Mock
+
+import cibyl.utils.files
+from cibyl.utils.reflection import get_classes_in, load_module
+
+
+class TestLoadModule(TestCase):
+    def test_three_steps_are_made(self):
+        """Checks that the three-step process to load a module is performed.
+        """
+        spec = Mock()
+        spec.loader.exec_module = Mock()
+
+        module = Mock()
+
+        name = 'module'
+        path = 'some/path'
+
+        cibyl.utils.reflection.get_file_name_from_path = Mock()
+        cibyl.utils.reflection.get_file_name_from_path.return_value = name
+
+        importlib.util.spec_from_file_location = Mock()
+        importlib.util.spec_from_file_location.return_value = spec
+
+        importlib.util.module_from_spec = Mock()
+        importlib.util.module_from_spec.return_value = module
+
+        result = load_module(path)
+
+        self.assertEqual(module, result)
+
+        cibyl.utils.reflection.get_file_name_from_path.assert_called_once_with(
+            path
+        )
+
+        importlib.util.spec_from_file_location.assert_called_once_with(
+            name, path
+        )
+
+        importlib.util.module_from_spec.assert_called_once_with(
+            spec
+        )
+
+        spec.loader.exec_module.assert_called_once_with(
+            module
+        )
+
+
+class TestGetClassesIn(TestCase):
+    """Tests for :func:`get_classes_in`.
+    """
+
+    class TestClass:
+        """Used as a sample for a class symbol.
+        """
+
+    @staticmethod
+    def test_function():
+        """Used a sample for a function symbol.
+        """
+
+    def test_gets_classes_in_module(self):
+        """Checks that the function lists the class symbols found on the
+        given module.
+        """
+        module = Mock()
+        module.cls = TestGetClassesIn.TestClass
+        module.func = TestGetClassesIn.test_function
+
+        result = get_classes_in(module)
+
+        self.assertEqual([TestGetClassesIn.TestClass], result)


### PR DESCRIPTION
I have been facing a problem where I could not get the Zuul source to be extended with the 'get_deployment' function, and the reason for it is that the way source extensions are defined is really strict. I want to define a new folder where the '__init__.py' holds the 'get_deployment' function and then have other modules on that folder that help the source achieve the data it desires. Thing is that this is not supported by the current OpenStack plugin, everything has to be stored on a single 'zuul.py' file.

In order to fix this, I have removed the need for the classes to be on a precise structure and used a flag to identify the extensions. Classes meant to extend a source have to inherit the 'SourceExtension' flag. Cibyl will then take care of recursively searching in a folder for all classes that inherit from that. Those will then continue to the 'extend_source' function.

Additionally, I have added a set of tools to made this task easier:
- FileSearch: Allows for search of files that meet certain requirements, like having a particular extension.
- utils/reflection.py: Allows to load a module from a file and then get the classes inside it.