### PR TITLE
Reuse spec jobs check in elasticsearch

### DIFF
--- a/cibyl/exceptions/source.py
+++ b/cibyl/exceptions/source.py
@@ -56,3 +56,13 @@ class MissingArgument(SourceException):
         """Constructor.
         """
         super().__init__(message)
+
+
+class InvalidArgument(SourceException):
+    """Represents an invalid combination of arguments inside a source
+    method call."""
+
+    def __init__(self, message='Invalid argument passed.'):
+        """Constructor.
+        """
+        super().__init__(message)

--- a/cibyl/plugins/openstack/sources/elasticsearch.py
+++ b/cibyl/plugins/openstack/sources/elasticsearch.py
@@ -16,7 +16,6 @@
 
 import logging
 
-from cibyl.exceptions.elasticsearch import ElasticSearchError
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.base.job import Job
 from cibyl.plugins.openstack.deployment import Deployment
@@ -40,6 +39,7 @@ class ElasticSearch(SourceExtension):
         :rtype: :class:`AttributeDictValue`
         """
         jobs_found = self.get_jobs(**kwargs)
+        self.check_jobs_for_spec(jobs_found, **kwargs)
 
         query_body = {
             # We don't want results in the main hits
@@ -131,12 +131,6 @@ class ElasticSearch(SourceExtension):
         ]
 
         if 'spec' in kwargs:
-            if len(jobs_found) > 1:
-                raise ElasticSearchError(
-                    "Full Openstack specification can be shown "
-                    "only for one job, please restrict the "
-                    "query."
-                )
             for spec_field in available_spec_fields:
                 append_exists_field_to_query(spec_field)
                 append_get_specific_field(spec_field)

--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -237,24 +237,10 @@ class Jenkins(SourceExtension):
         spec = "spec" in kwargs
 
         jobs_found = filter_jobs(jobs_found, **kwargs)
+        if spec:
+            self.check_jobs_for_spec(jobs_found, **kwargs)
 
         use_artifacts = True
-        if spec:
-            spec_value = kwargs["spec"].value
-            jobs_args = kwargs.get("jobs")
-            # if user called cibyl just with --spec without value and no --jobs
-            # argument, we have not enough information to pull the spec
-            spec_missing_input = not bool(spec_value) and (jobs_args is None)
-            if len(jobs_found) == 0 or spec_missing_input:
-                msg = "No job was found, please pass --spec job-name with an "
-                msg += " exact match or --jobs job-name with a valid job name "
-                msg += "or pattern."
-                raise JenkinsError(msg)
-
-            if len(jobs_found) > 1:
-                raise JenkinsError("Full Openstack specification can be shown "
-                                   "only for one job, please restrict the "
-                                   "query.")
         if len(jobs_found) > 12:
             LOG.warning("Requesting deployment information for %d jobs \
 will be based on the job name and approximate, restrict the query for more \

--- a/cibyl/plugins/openstack/sources/server.py
+++ b/cibyl/plugins/openstack/sources/server.py
@@ -1,0 +1,48 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import logging
+
+from cibyl.exceptions.source import InvalidArgument
+from cibyl.sources.plugins import SourceExtension
+
+LOG = logging.getLogger(__name__)
+
+
+class ServerSource(SourceExtension):
+    """A class representation of a source that must connect to a server
+    instance."""
+
+    def check_jobs_for_spec(self, jobs_found, **kwargs):
+        """Ensure that only one job was found if using the --spec argument,
+        raise a different exception in the cases where no job is found, and
+        multiple jobs are found."""
+        spec = "spec" in kwargs
+        if spec:
+            spec_value = kwargs["spec"].value
+            jobs_args = kwargs.get("jobs")
+            # if user called cibyl just with --spec without value and no --jobs
+            # argument, we have not enough information to pull the spec
+            spec_missing_input = not bool(spec_value) and (jobs_args is None)
+            if len(jobs_found) == 0 or spec_missing_input:
+                msg = "No job was found, please pass --spec job-name with an "
+                msg += " exact match or --jobs job-name with a valid job name "
+                msg += "or pattern."
+                raise InvalidArgument(msg)
+
+            if len(jobs_found) > 1:
+                msg = "Full Openstack specification can be shown only for "
+                msg += " one job, please restrict the query."
+                raise InvalidArgument(msg)

--- a/cibyl/sources/source_factory.py
+++ b/cibyl/sources/source_factory.py
@@ -23,6 +23,7 @@ from cibyl.exceptions.config import (MissingSourceKey, MissingSourceType,
 from cibyl.sources.elasticsearch.api import ElasticSearch
 from cibyl.sources.jenkins import Jenkins
 from cibyl.sources.jenkins_job_builder import JenkinsJobBuilder
+from cibyl.sources.server import ServerSource
 from cibyl.sources.zuul.source import Zuul
 from cibyl.sources.zuuld.source import ZuulD
 
@@ -52,6 +53,8 @@ class SourceFactory:
             source_class = ElasticSearch
         elif source.__name__ == 'Zuul':
             source_class = Zuul
+        elif source.__name__ == 'ServerSource':
+            source_class = ServerSource
         else:
             LOG.warning(f"Ignoring source extension for class: {source}")
 

--- a/tests/unit/plugins/openstack/sources/test_jenkins.py
+++ b/tests/unit/plugins/openstack/sources/test_jenkins.py
@@ -22,6 +22,7 @@ import yaml
 
 from cibyl.cli.argument import Argument
 from cibyl.exceptions.jenkins import JenkinsError
+from cibyl.exceptions.source import InvalidArgument
 from cibyl.plugins.openstack.container import Container
 from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.service import Service
@@ -1381,7 +1382,8 @@ tripleo_ironic_conductor.service loaded    active     running
         self.jenkins.send_request = Mock(side_effect=[response])
 
         spec = Argument("spec", str, "", value=job_names)
-        self.assertRaises(JenkinsError, self.jenkins.get_deployment, spec=spec)
+        self.assertRaises(InvalidArgument, self.jenkins.get_deployment,
+                          spec=spec)
 
     def test_get_deployment_spec_one_job_no_builds(self):
         """ Test that get_deployment fails if --spec is used with a job that
@@ -1416,8 +1418,8 @@ tripleo_ironic_conductor.service loaded    active     running
         msg = "No job was found, please pass --spec job-name with an "
         msg += " exact match or --jobs job-name with a valid job name "
         msg += "or pattern."
-        self.assertRaises(JenkinsError, self.jenkins.get_deployment, spec=spec,
-                          msg=msg)
+        self.assertRaises(InvalidArgument, self.jenkins.get_deployment,
+                          spec=spec, msg=msg)
 
     def test_get_deployment_spec_correct_call(self):
         """ Test get_deployment call with --spec and one job."""

--- a/tests/unit/sources/elasticsearch/test_api.py
+++ b/tests/unit/sources/elasticsearch/test_api.py
@@ -19,8 +19,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 from cibyl.cli.argument import Argument
-from cibyl.exceptions.elasticsearch import ElasticSearchError
-from cibyl.exceptions.source import MissingArgument
+from cibyl.exceptions.source import InvalidArgument, MissingArgument
 from cibyl.sources.elasticsearch.api import ElasticSearch
 from tests.utils import OpenstackPluginWithJobSystem
 
@@ -424,8 +423,11 @@ class TestElasticSearchOpenstackPlugin(OpenstackPluginWithJobSystem):
 
     def test_spec_deployment(self: object):
         self.es_api.get_jobs = Mock(side_effect=self.job_hits)
-        with self.assertRaises(ElasticSearchError):
-            self.es_api.get_deployment(spec=True)
+        spec = MagicMock()
+        spec_value = PropertyMock(return_value=[])
+        type(spec).value = spec_value
+        with self.assertRaises(InvalidArgument):
+            self.es_api.get_deployment(spec=spec)
 
     @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
     def test_deployment_filtering(self: object,


### PR DESCRIPTION
This change introduces a new change to the ServerSource via the
openstack plugin to ensure that all three sources that will implement
the option show the same behaviour. The method checks that only one job
is provided, either with the --spec option or the --jobs one. If there
is more than one option an exception is raised. If there are no matching
jobs, a different exception is raised. The method is not added to the
Zuul source since the get_deployment method is still under development.
