### PR TITLE
Rewriting the job commons module to accept any kind of model.

### DIFF
--- a/cibyl/outputs/cli/ci/system/common/models.py
+++ b/cibyl/outputs/cli/ci/system/common/models.py
@@ -24,21 +24,21 @@ from cibyl.utils.strings import IndentedTextBuilder
 LOG = logging.getLogger(__name__)
 
 
-def has_plugin_section(job):
-    """Checks whether a job is worth having a plugins' section for.
+def has_plugin_section(model):
+    """Checks whether a model is worth having a plugins' section for.
 
-    :param job: The job to check.
-    :type job: :class:`cibyl.models.ci.base.job.Job`
-    :return: True if the job has enough data to build a plugins' section with,
-        False if not.
+    :param model: The model to check.
+    :type model: :class:`cibyl.models.model.Model`
+    :return: True if the model has enough data to build
+        a plugins' section with, False if not.
     :rtype: bool
     """
-    if not job.plugin_attributes:
+    if not model.plugin_attributes:
         return False
     has_plugin_attribute = False
-    for plugin_attribute in job.plugin_attributes:
+    for plugin_attribute in model.plugin_attributes:
         # Plugins install some attributes as part of the model
-        attribute = getattr(job, plugin_attribute)
+        attribute = getattr(model, plugin_attribute)
 
         # Check if the attribute is populated
         if not attribute.value:
@@ -47,8 +47,8 @@ def has_plugin_section(job):
     return has_plugin_attribute
 
 
-def get_plugin_section(printer, job):
-    """Gets the text describing the plugins that affect a job.
+def get_plugin_section(printer, model):
+    """Gets the text describing the plugins that affect a model.
 
     ..  seealso::
         See :func:`has_plugin_section`.
@@ -56,21 +56,21 @@ def get_plugin_section(printer, job):
     :param printer: The printer the text will be based on. The output of
         this function will follow the styling of this.
     :type printer: :class:`cibyl.outputs.cli.printer.ColoredPrinter`
-    :param job: The job get the description for.
-    :type job: :class:`cibyl.models.ci.base.job.Job`
+    :param model: The model to get the description for.
+    :type model: :class:`cibyl.models.model.Model`
     :return: The description.
     :rtype: str
-    :raises ValueError: If the job does not have enough data to build the
+    :raises ValueError: If the model does not have enough data to build the
         section.
     """
-    if not has_plugin_section(job):
+    if not has_plugin_section(model):
         raise ValueError('Job is missing plugin attributes.')
 
     text = IndentedTextBuilder()
 
-    for plugin_attribute in job.plugin_attributes:
+    for plugin_attribute in model.plugin_attributes:
         # Plugins install some attributes as part of the model
-        attribute = getattr(job, plugin_attribute)
+        attribute = getattr(model, plugin_attribute)
 
         # Check if the attribute is populated
         if not attribute.value:

--- a/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
@@ -18,8 +18,8 @@ from overrides import overrides
 from cibyl.cli.query import QueryType
 from cibyl.outputs.cli.ci.system.common.builds import (get_duration_section,
                                                        get_status_section)
-from cibyl.outputs.cli.ci.system.common.jobs import (get_plugin_section,
-                                                     has_plugin_section)
+from cibyl.outputs.cli.ci.system.common.models import (get_plugin_section,
+                                                       has_plugin_section)
 from cibyl.outputs.cli.ci.system.common.stages import print_stage
 from cibyl.outputs.cli.ci.system.printer import CISystemPrinter
 from cibyl.outputs.cli.printer import ColoredPrinter

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -20,8 +20,8 @@ from overrides import overrides
 from cibyl.cli.query import QueryType
 from cibyl.outputs.cli.ci.system.common.builds import (get_duration_section,
                                                        get_status_section)
-from cibyl.outputs.cli.ci.system.common.jobs import (get_plugin_section,
-                                                     has_plugin_section)
+from cibyl.outputs.cli.ci.system.common.models import (get_plugin_section,
+                                                       has_plugin_section)
 from cibyl.outputs.cli.ci.system.impls.base.colored import \
     ColoredBaseSystemPrinter
 from cibyl.outputs.cli.printer import ColoredPrinter

--- a/tests/unit/outputs/cli/ci/system/common/test_models.py
+++ b/tests/unit/outputs/cli/ci/system/common/test_models.py
@@ -16,8 +16,8 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from cibyl.outputs.cli.ci.system.common.jobs import (get_plugin_section,
-                                                     has_plugin_section)
+from cibyl.outputs.cli.ci.system.common.models import (get_plugin_section,
+                                                       has_plugin_section)
 
 
 class TestHasPluginSection(TestCase):
@@ -25,46 +25,47 @@ class TestHasPluginSection(TestCase):
     """
 
     def test_attributes_is_none(self):
-        """Checks result is false if the plugins attributes of a job is none.
+        """Checks result is false if the plugins attributes of a model is none.
         """
-        job = Mock()
-        job.plugin_attributes = None
+        model = Mock()
+        model.plugin_attributes = None
 
-        self.assertFalse(has_plugin_section(job))
+        self.assertFalse(has_plugin_section(model))
 
     def test_attributes_is_empty(self):
-        """Checks result is false if the plugins attributes of a job is empty.
+        """Checks result is false if the plugins attributes of a model is
+        empty.
         """
-        job = Mock()
-        job.plugin_attributes = {}
+        model = Mock()
+        model.plugin_attributes = {}
 
-        self.assertFalse(has_plugin_section(job))
+        self.assertFalse(has_plugin_section(model))
 
     def test_attributes_is_filled(self):
-        """Checks result is true if the plugins attributes of a job is
+        """Checks result is true if the plugins attributes of a model is
         filled with data.
         """
-        job = Mock()
-        job.plugin_attributes = {
+        model = Mock()
+        model.plugin_attributes = {
             'plugin1': {}
         }
 
-        self.assertTrue(has_plugin_section(job))
+        self.assertTrue(has_plugin_section(model))
 
 
 class TestGetPluginSection(TestCase):
     """Tests for :func:`get_plugin_section`.
     """
 
-    @patch('cibyl.outputs.cli.ci.system.common.jobs.has_plugin_section')
+    @patch('cibyl.outputs.cli.ci.system.common.models.has_plugin_section')
     def test_error_if_no_attributes(self, check_mock):
-        """Checks that an error is thrown if the job has no plugins to
+        """Checks that an error is thrown if the model has no plugins to
         describe.
         """
         check_mock.return_value = False
 
         printer = Mock()
-        job = Mock()
+        model = Mock()
 
         with self.assertRaises(ValueError):
-            get_plugin_section(printer, job)
+            get_plugin_section(printer, model)


### PR DESCRIPTION
I have noticed that the module holding utilities which is shared by the sources and is dedicated to jobs does not need to be specific to them. The utilities on this module will work with any kind of model and considering that I will need to use them with job variants, I am taking my time here to make them more generic.