### PR TITLE
Fixing conflicting file on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,20 @@ WORKDIR $INSTALL_PATH
 ENV VIRTUAL_ENV=./venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip3 install --upgrade pip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install wheel
 
 # Install Cibyl
-COPY $CIBYL_ROOT .
-RUN pip3 install .
+COPY $CIBYL_ROOT/.git ./.git
+
+COPY $CIBYL_ROOT/README.rst .
+COPY $CIBYL_ROOT/setup.py .
+COPY $CIBYL_ROOT/setup.cfg .
+COPY $CIBYL_ROOT/requirements.txt .
+
+COPY $CIBYL_ROOT/cibyl ./cibyl
+
+RUN python3 -m pip install .
 
 # Install configuration file
 COPY $CONFIG_FILE /etc/cibyl/cibyl.yaml


### PR DESCRIPTION
With the introduction of pbr, it was made so that Cibyl's Dockerfile copied all files on the repository into the container in order to use those to install Cibyl in it. Problem is, ignored files on the repository are also copied over and cause problems on the container. On my case, I was not able to build the image because Tox's virtual environments where clashing with the virtual environment set up by the Dockerfile, making the container's path a mess.

On this pull request I have limited the files that are copied into the container, so that only the bare minimum are.