### PR TITLE
Adding E2E tests step to GitHub Actions

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -11,9 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.9']
+        python-version: [ '3.6', '3.9' ]
     steps:
-      - uses: actions/checkout@v1
+      - name: "Install SSH key"
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.RHOS_INFRA_PRIVATE_KEY }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS }}
+          if_key_exists: replace
+      - name: "Checkout repo"
+        uses: actions/checkout@v1
       - name: "Setup Python"
         uses: actions/setup-python@v2
         with:
@@ -23,4 +30,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
       - name: "Run tox"
-        run: tox
+        run: tox -e linters,unit,intr,e2e,coverage,docs


### PR DESCRIPTION
With this change, end-to-end tests will start running on GitHub Actions as part of the "Run Tox" task.