### PR TITLE
Refine mechanism for features definition

### DIFF
--- a/cibyl/plugins/openstack/features/network.py
+++ b/cibyl/plugins/openstack/features/network.py
@@ -16,12 +16,13 @@
 import logging
 
 from cibyl.cli.argument import Argument
+from cibyl.features import FeatureDefinition
 from cibyl.plugins.openstack.features import OpenstackFeatureTemplate
 
 LOG = logging.getLogger(__name__)
 
 
-class HA(OpenstackFeatureTemplate):
+class HA(OpenstackFeatureTemplate, FeatureDefinition):
     """Highly available Openstack deployment with at least 2 controllers."""
     def __init__(self):
         super().__init__("HA")
@@ -36,7 +37,7 @@ class HA(OpenstackFeatureTemplate):
         return {'controllers': ha_arg}
 
 
-class IPV4(OpenstackFeatureTemplate):
+class IPV4(OpenstackFeatureTemplate, FeatureDefinition):
     """Openstack deployment using IPv4."""
     def __init__(self):
         super().__init__("IPV4")
@@ -51,7 +52,7 @@ class IPV4(OpenstackFeatureTemplate):
         return {'ip_version': ip_arg}
 
 
-class IPV6(OpenstackFeatureTemplate):
+class IPV6(OpenstackFeatureTemplate, FeatureDefinition):
     """Openstack deployment using IPv6."""
     def __init__(self):
         super().__init__("IPV6")

--- a/cibyl/utils/files.py
+++ b/cibyl/utils/files.py
@@ -34,6 +34,7 @@ class FileSearch:
         self._directory = directory
         self._recursive = False
         self._extensions = []
+        self._excluded = []
 
     def with_recursion(self):
         """Extends the search to the folders inside the directory and beyond.
@@ -56,6 +57,19 @@ class FileSearch:
         :rtype: :class:`FileSearch`
         """
         self._extensions.append(extension)
+        return self
+
+    def with_excluded(self, excluded):
+        """Limits the search to files that are not in the excluded list. If this
+        is called more than once, then the filters are joined together
+        following an 'OR' approach.
+
+        :param excluded: The file names to filter by.
+        :type excluded: list
+        :return: The instance.
+        :rtype: :class:`FileSearch`
+        """
+        self._excluded.extend(excluded)
         return self
 
     def get(self):
@@ -82,6 +96,9 @@ class FileSearch:
                 if self._extensions:
                     if get_file_extension(path) not in self._extensions:
                         continue
+                if self._excluded:
+                    if get_file_name_from_path(path) in self._excluded:
+                        continue
 
                 result.append(path)
 
@@ -101,6 +118,7 @@ class FileSearch:
 
         other._recursive = self._recursive
         other._extensions = self._extensions
+        other._excluded = self._excluded
 
         return other
 

--- a/cibyl/utils/reflection.py
+++ b/cibyl/utils/reflection.py
@@ -38,12 +38,23 @@ def load_module(path):
     return module
 
 
-def get_classes_in(__module):
+def get_classes_in(__module, predicate=None, return_name=False):
     """Gets all class symbols stored within a Python module.
 
     :param __module: The module to get the classes from.
     :type __module: :class:`types.ModuleType`
+    :param predicate: A callable to pass to inspect.getmembers to filter the
+    symbols found
+    :type predicate: callable
+    :param return_name: Whether to return the name of the classes found, as
+    inpect.getmembers does
+    :type return_name: bool
     :return: List of all classes stored in the module.
     :rtype: list[type]
     """
-    return [cls for _, cls in inspect.getmembers(__module, inspect.isclass)]
+    if predicate is None:
+        predicate = inspect.isclass
+    if return_name:
+        return inspect.getmembers(__module, predicate)
+    else:
+        return [cls for _, cls in inspect.getmembers(__module, predicate)]

--- a/docs/source/development/features.rst
+++ b/docs/source/development/features.rst
@@ -2,8 +2,12 @@ Features
 ========
 
 In cibyl we define *features*, which are classes containing a query method that
-can run a custom query using python code. There is a FeatureTemplate class that
-can be used to quickly define simple features. The query method of this class
+can run a custom query using python code. A feature is defined as a class that
+inherits from the *FeatureDefinition* class, defined in
+cibyl/features/__init__.py.
+
+There is a FeatureTemplate class that can be used to quickly define simple features.
+The query method of this class
 will select the most appropiate source considering the speed_index and the
 method to query in the source. To define a new feature using this template, one
 only needs to define a class that inherits from FeatureTemplate, set the
@@ -20,41 +24,53 @@ This way of implementing a feature gives the developer total freedom, but does
 not provide some functionality like selecting the best sources given the input
 arguments. There could be a mixed implementation, that relies on the
 FeatureTemplate query method but provided a bit more flexibility. Let's say for
-exampla that one wanted a feature called Example that wants to check whether
+example that one wanted a feature called Example that wants to check whether
 a system has any job called 'example' with at least 3 passing builds and runs
 a test called 'test_example'. Such a feature could be implemented for example
 like:
 
 .. code-block:: python
 
-   class Example(FeatureTemplate):
+   class Example(FeatureTemplate, FeatureDefinition):
        def __init__(self):
            self.name = "Example"
 
+       def get_template_args(self):
+           """Get the arguments necessary to obtain the information that defines
+           the feature."""
+           args = {}
+           args['jobs'] = Argument("jobs",  arg_type=str,
+                                   description="jobs",
+                                   value=["example"])
+           args['builds'] = Argument("build", arg_type=str,
+                                     description="build",
+                                     value=[])
+           args['jobs'] = Argument("tests",  arg_type=str,
+                                   description="tests",
+                                   value=["test_example"])
+           return args
+
        def query(self, system, **kwargs):
-           self.method_to_query = "get_builds"
-           self.args['jobs'] = Argument("jobs",  arg_type=str,
-                                        description="jobs",
-                                        value=["example"])
-           self.args['builds'] = Argument("build",  arg_type=str,
-                                        description="build",
-                                        value=[])
+
+           def get_method_to_query(self):
+               return "get_builds"
+            self.get_method_to_query = get_method_to_query
            return_builds = super().query(system, **self.args, **kwargs)
-           self.method_to_query = "get_tests"
-           self.args['jobs'] = Argument("tests",  arg_type=str,
-                                        description="tests",
-                                        value=["test_example"])
+
+           def get_method_to_query(self):
+               return "get_tests"
+           self.get_method_to_query = get_method_to_query
            return_tests = super().query(system, **self.args, **kwargs)
            # more code to combine the the returns and apply the desired
            # conditions
 
-Features are classes defined inside modules in a feature subpackage, like
-cibyl/features or cibyl/plugins/openstack/features. The name of the module is
+Features are classes that inherit from the FeatureDefinition class.
+The name of the module where the feature is defined is
 used as a category for the features it contains. Features are loaded in the
-orchestrator, in the load_features method. There, a FeaturesLoader class is
-created that will look through the paths that are registered by the plugins and
+orchestrator, in the load_features method. There, cibyl will go through
+the paths that are registered by the plugins and
 the default location to look for features. If features are found and requested
-by the user, the the run_features method ir executed. If not, a normal query is
+by the user, the the run_features method is executed. If not, a normal query is
 executed.
 
 As mentioned before, the query method should return an AttributeDictValue with

--- a/tests/unit/features/data/testing.py
+++ b/tests/unit/features/data/testing.py
@@ -15,10 +15,10 @@
 """
 
 from cibyl.cli.argument import Argument
-from cibyl.features import FeatureTemplate
+from cibyl.features import FeatureDefinition, FeatureTemplate
 
 
-class Feature1(FeatureTemplate):
+class Feature1(FeatureTemplate, FeatureDefinition):
     """Feature for testing1"""
 
     def __init__(self):
@@ -36,7 +36,7 @@ class Feature1(FeatureTemplate):
         return {"jobs": jobs}
 
 
-class Feature2(FeatureTemplate):
+class Feature2(FeatureTemplate, FeatureDefinition):
     """Feature for testing2"""
     def __init__(self):
         super().__init__("Feature2")
@@ -53,7 +53,7 @@ class Feature2(FeatureTemplate):
         return {"jobs": jobs}
 
 
-class Feature3(FeatureTemplate):
+class Feature3(FeatureTemplate, FeatureDefinition):
     def __init__(self):
         super().__init__("Feature3")
 


### PR DESCRIPTION
Instead of relying on the subpackage name, features will be defined as
inheriting from a FeatureDefinition class. This allows for a more robust
detection mechanism and reusing the tool on the reflection module
already used for the plugin mechanism.

This PR also includes a few more unit test to increase coverage of the
FeatureTemplate class.

