### PR TITLE
[DNM] Call setup for a source only when it'll be called

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -114,7 +114,6 @@ def main():
         # from the CI models
         orchestrator.parser.parse()
         orchestrator.validate_environments()
-        orchestrator.setup_sources()
         features = orchestrator.load_features()
         orchestrator.query_and_publish(arguments["output_style"],
                                        features=features)

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -36,7 +36,8 @@ from cibyl.models.ci.system_factory import SystemType
 from cibyl.models.ci.zuul.system import ZuulSystem
 from cibyl.models.product.feature import Feature
 from cibyl.publisher import Publisher
-from cibyl.sources.source import (select_source_method,
+from cibyl.sources.source import (get_source_instance_from_method,
+                                  select_source_method,
                                   source_information_from_method)
 from cibyl.sources.source_factory import SourceFactory
 from cibyl.utils.dicts import intersect_models
@@ -150,15 +151,6 @@ class Orchestrator:
         validator = Validator(self.parser.ci_args)
         self.environments = validator.validate_environments(self.environments)
 
-    def setup_sources(self):
-        """Setup all enabled sources present in the environment."""
-        for env in self.environments:
-            if env.enabled:
-                for system in env.systems:
-                    for source in system.sources:
-                        if source.enabled:
-                            source.setup()
-
     def load_features(self):
         """Read user-requested features and setup the right argument to query
         the information for them."""
@@ -258,6 +250,8 @@ class Orchestrator:
                             continue
                     source_info = source_information_from_method(
                             source_method)
+                    source_obj = get_source_instance_from_method(source_method)
+                    source_obj.ensure_source_setup()
                     start_time = time.time()
                     LOG.info(f"Performing query on system {system.name}")
                     LOG.debug("Running %s and speed index %d",

--- a/cibyl/sources/source.py
+++ b/cibyl/sources/source.py
@@ -76,9 +76,21 @@ class Source(AttrDict):
 
     def __init__(self, name: str = None, driver: str = None, **kwargs):
         kwargs.setdefault('enabled', True)
+        kwargs.setdefault('_setup', False)
         kwargs.setdefault('priority', 0)
 
         super().__init__(name=name, driver=driver, **kwargs)
+
+    def is_setup(self):
+        """Return wether the source has been setup."""
+        return self._setup
+
+    def ensure_source_setup(self):
+        """Ensure that setup is called for the source. If setup was previously
+        called, do nothing."""
+        if not self.is_setup():
+            self._setup = True
+            self.setup()
 
     @abstractmethod
     def setup(self):
@@ -218,3 +230,14 @@ def select_source_method(system, method, **kwargs):
                              [source.name for source in system.sources])
     return get_source_method(system.name.value, system_sources,
                              method, args=kwargs)
+
+
+def get_source_instance_from_method(source_method):
+    """Obtain the source object from a method that belongs to said object.
+
+    :param source_method: Source method that is used
+    :type source_method: method
+    :returns: source instance the input method belongs to
+    :rtype: :class:`.Source`
+    """
+    return source_method.__self__

--- a/tests/intr/sources/zuuld/test_git_api.py
+++ b/tests/intr/sources/zuuld/test_git_api.py
@@ -39,7 +39,8 @@ class TestZuulGitAPI(TestCase):
         data = {'name': 'git',
                 'driver': None,
                 'enabled': True,
-                'priority': 0}
+                'priority': 0,
+                '_setup': False}
         self.assertEqual(data, ZuulLocal(REPOS))
 
     def test_zuuld_repos_with_valid_repo(self):

--- a/tests/unit/sources/elasticsearch/test_api.py
+++ b/tests/unit/sources/elasticsearch/test_api.py
@@ -280,6 +280,17 @@ class TestElasticSearch(TestCase):
         es_api.setup()
         mock_client.assert_called_with("https://example.com", 9200)
 
+    @patch('cibyl.sources.elasticsearch.api.ElasticSearchClient')
+    def test_ensure_setup(self, mock_client):
+        """Test ensure_setup method of ElasticSearch"""
+        es_api = ElasticSearch(elastic_client=None,
+                               url="https://example.com:9200")
+        client = mock_client.return_value
+        client.connect.side_effect = None
+        es_api.ensure_source_setup()
+        self.assertTrue(es_api.is_setup())
+        mock_client.assert_called_with("https://example.com", 9200)
+
 
 class TestElasticSearchOpenstackPlugin(OpenstackPluginWithJobSystem):
     """Test cases for :class:`ElasticSearch` with openstack plugin."""

--- a/tests/unit/sources/test_sources.py
+++ b/tests/unit/sources/test_sources.py
@@ -17,7 +17,8 @@ from unittest import TestCase
 from unittest.mock import Mock, patch
 
 from cibyl.exceptions.source import NoSupportedSourcesFound, NoValidSources
-from cibyl.sources.source import (Source, get_source_method, is_source_valid,
+from cibyl.sources.source import (Source, get_source_instance_from_method,
+                                  get_source_method, is_source_valid,
                                   select_source_method,
                                   source_information_from_method)
 from cibyl.sources.source_factory import SourceFactory
@@ -124,3 +125,43 @@ class TestGetSourceMethod(TestCase):
         expected = "source: 'source' of type: 'driver'"
         output = source_information_from_method(source.setup)
         self.assertEqual(expected, output)
+
+
+class TestGetSourceInstanceFromMethod(TestCase):
+    """Test the get_source_instance_from_method function from source module."""
+    def test_get_source_methods_get_builds(self):
+        """Test that get_source_method returns the correct ordering after
+        asking for get_builds method."""
+        source = SourceFactory.create_source("zuul", "zuul", url="url")
+
+        source_out = get_source_instance_from_method(source.get_builds)
+
+        self.assertTrue(source_out, source)
+
+
+class TestSourceSetup(TestCase):
+    """Test that setup functionality for Source class."""
+    def setUp(self):
+        self.source = Source()
+
+    def test_default_setup_false(self):
+        """Test that is_setup return False by default."""
+        self.assertFalse(self.source.is_setup())
+
+    @patch.object(Source, 'setup')
+    def test_setup(self, setup_mock):
+        """Test that ensure_source_setup calls setup and sets the right value
+        for _setup attribute."""
+        self.source.ensure_source_setup()
+        self.assertTrue(self.source.is_setup())
+        setup_mock.assert_called_once()
+
+    @patch.object(Source, 'setup')
+    def test_setup_multiple_calls(self, setup_mock):
+        """Test that multiple calls to ensure_source_setup calls setup
+        just once and sets the right value for _setup attribute."""
+        self.source.ensure_source_setup()
+        self.source.ensure_source_setup()
+        self.source.ensure_source_setup()
+        self.assertTrue(self.source.is_setup())
+        setup_mock.assert_called_once()

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -14,7 +14,7 @@
 #    under the License.
 """
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import cibyl.orchestrator
 from cibyl.config import Config
@@ -216,15 +216,6 @@ class TestOrchestrator(TestCase):
         self.assertEqual(len(env.systems.value), 1)
         self.assertEqual(env.name.value, 'env4')
         self.assertEqual(env.systems[0].name.value, 'system1')
-
-    @patch("cibyl.sources.elasticsearch.api.ElasticSearch.setup")
-    def test_setup_sources(self, patched_setup):
-        """Test that setup_sources calls the setup method of the sources
-        enabled in the environment."""
-        self.orchestrator.config.data = self.valid_env_sources_disabled
-        self.orchestrator.create_ci_environments()
-        self.orchestrator.setup_sources()
-        patched_setup.assert_called_once_with()
 
     def test_not_supported_system_key_jobs_system(self):
         """Test that a NonSupportedSystemKey is raised if the configuration


### PR DESCRIPTION
Instead of calling the setup method for all enabled sources, call it
just before a source will be queried. That way we avoid setting up
sources that could be used but are not, for example due to having
a lower speed index.

This is a duplicate of #299, but from a branch within the repository to test whether the CI there is failing because it comes from a repoe.