### PR TITLE
Indicate if no builds exist

### DIFF
--- a/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
@@ -74,9 +74,13 @@ class ColoredJobsSystemPrinter(ColoredBaseSystemPrinter):
             # if features are used, do not print further below
             return printer.build()
 
-        if job.builds.value:
-            for build in job.builds.values():
-                printer.add(self.print_build(build), 1)
+        if self.query >= QueryType.BUILDS:
+            if job.builds.value:
+                for build in job.builds.values():
+                    printer.add(self.print_build(build), 1)
+            else:
+                msg = 'No builds in query.'
+                printer.add(self.palette.red(msg), 1)
 
         if has_plugin_section(job):
             printer.add(get_plugin_section(self, job), 1)


### PR DESCRIPTION
If the query type is build:

- If there are builds print them.
- In other case print there are no builds for that job
