### PR TITLE
Add more granular configuration exceptions

### DIFF
--- a/cibyl/exceptions/config.py
+++ b/cibyl/exceptions/config.py
@@ -21,16 +21,6 @@ CHECK_DOCS_MSG = f"Check the documentation at {CONFIG_DOCS_URL} \
 for more information"
 
 
-class InvalidConfiguration(CibylException):
-    """Invalid configuration exception"""
-
-    def __init__(self):
-        self.message = f"""Invalid Configuration.
-A valid configuration should specify an environment, its system(s) and at \
-least one source for each system.\n\n{CHECK_DOCS_MSG}"""
-        super().__init__(self.message)
-
-
 class ConfigurationNotFound(CibylException):
     """Configuration file not found exception"""
 
@@ -79,8 +69,8 @@ is not supported: {key}\n\n{CHECK_DOCS_MSG}"""
 class NonSupportedSystemKey(CibylException):
     """Configuration section key is not supported."""
 
-    def __init__(self, source_type, key):
-        self.message = f"""The following key in "{source_type}" system type \
+    def __init__(self, system_type, key):
+        self.message = f"""The following key in "{system_type}" system type \
 is not supported: {key}\n\n{CHECK_DOCS_MSG}"""
 
         super().__init__(self.message)
@@ -103,7 +93,18 @@ class MissingSourceKey(CibylException):
     def __init__(self, source_type, key):
         colored_key = Colors.blue(key)
         self.message = f"""The following key in "{source_type}" source type \
-is missing and required for the source to become operational: {colored_key}."""
+is missing and required for the source to become operational: {colored_key}"""
+
+        super().__init__(self.message)
+
+
+class MissingSystemKey(CibylException):
+    """System configuration is incomplete and missing a key."""
+
+    def __init__(self, system_name, key):
+        colored_key = Colors.blue(key)
+        self.message = f"""The following key in "{system_name}" system \
+is missing and required for the system to become operational: {colored_key}"""
 
         super().__init__(self.message)
 
@@ -116,4 +117,59 @@ class MissingSourceType(CibylException):
         self.message = f"""Missing 'driver: <TYPE>' for source {source_name}
 Use one of the following source types:\n  {types}"""
 
+        super().__init__(self.message)
+
+
+class MissingSystemType(CibylException):
+    """Configuration system type isn't specified."""
+
+    def __init__(self, system_name, system_types):
+        types = Colors.blue("\n  ".join([t for t in system_types]))
+        self.message = f"""Missing 'system_type: <TYPE>' for system {system_name}
+Use one of the following system types:\n  {types}"""
+
+        super().__init__(self.message)
+
+
+class MissingSystemSources(CibylException):
+    """Configuration system sources aren't specified."""
+
+    def __init__(self, system_name):
+        self.message = f"""Missing sources for system \
+'{system_name}'
+
+    environments:
+        <ENVIRONMENT_NAME>:
+            <SYSTEM_NAME>:
+                sources:
+                    driver: <SOURCE_TYPE>\n\n{CHECK_DOCS_MSG}"""
+
+        super().__init__(self.message)
+
+
+class MissingEnvironments(CibylException):
+    """Configuration doesn't include any environments."""
+
+    def __init__(self):
+        self.message = f"""No environments defined in the configuration file. \
+
+Configure environments with the "environments" mapping:
+
+    environments:
+        <ENVIRONMENT_NAME>\n\n{CHECK_DOCS_MSG}"""
+        super().__init__(self.message)
+
+
+class MissingSystems(CibylException):
+    """An environment in the configuration doesn't include any systems."""
+
+    def __init__(self, env_name):
+        self.message = f"""No systems defined in the configuration file \
+for the environment '{env_name}'
+
+Configure systems by including them under the relevant environment name
+
+    environments:
+        <ENVIRONMENT_NAME>:
+            <SYSTEM_NAME>\n\n{CHECK_DOCS_MSG}"""
         super().__init__(self.message)

--- a/cibyl/exceptions/source.py
+++ b/cibyl/exceptions/source.py
@@ -36,10 +36,15 @@ class NoValidSources(CibylException):
             sources = Colors.blue('\n  '.join(sources))
             sources = f"Available sources:\n  {sources}"
         if system:
-            system = f"defined for the system {system}."
-        self.message = f"""No valid source found {system}. \
-Please ensure the specified sources with --source argument are present in \
-the configuration.\n{sources}"""
+            system = f"defined for the system {system.name.value}"
+        self.message = f"""No valid source found {system}.
+
+Define sources for the system with the "sources" mapping
+
+  <ENVIRONMENT_NAME>:
+      <SYSTEM_NAME>:
+          sources:
+              <SOURCE_NAME>"""
 
         super().__init__(self.message)
 

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -26,7 +26,6 @@ from cibyl.cli.query import get_query_type
 from cibyl.cli.validator import Validator
 from cibyl.config import Config, ConfigFactory
 from cibyl.exceptions.cli import InvalidArgument
-from cibyl.exceptions.config import NonSupportedSystemKey
 from cibyl.exceptions.source import NoSupportedSourcesFound, SourceException
 from cibyl.features import get_feature, get_string_all_features, load_features
 from cibyl.models.attribute import AttributeDictValue
@@ -96,37 +95,50 @@ class Orchestrator:
             re_result = re.search(r'unexpected keyword argument (.*)',
                                   ex.args[0])
             if re_result:
-                raise NonSupportedSystemKey(system_name, re_result.group(1))
+                raise conf_exc.NonSupportedSystemKey(
+                    system_name, re_result.group(1))
+            re_missing_arg = re.search(r'required positional argument: (.*)',
+                                       ex.args[0])
+            if re_missing_arg:
+                raise conf_exc.MissingSystemKey(
+                    system_name, re_missing_arg.group(1))
+            raise
 
     def create_ci_environments(self) -> None:
         """Creates CI environment entities based on loaded configuration."""
-        try:
-            if self.config.data:
-                env_data = self.config.data.get('environments', {}).items()
-            else:
-                env_data = {}
+        env_data = self.config.data.get('environments', {})
 
-            for env_name, systems_dict in env_data:
+        if isinstance(env_data, str):
+            raise conf_exc.MissingSystems(env_data)
+        if not env_data:
+            raise conf_exc.MissingEnvironments()
+
+        for env_name, systems_dict in env_data.items():
+            if isinstance(systems_dict, str):
+                raise conf_exc.MissingSystemType(systems_dict, SystemType)
+            try:
                 enabled = systems_dict.get('enabled', True)
                 if not enabled:
                     continue
-                environment = Environment(name=env_name, enabled=enabled)
+            except AttributeError:
+                raise conf_exc.MissingSystems(env_name)
+            environment = Environment(name=env_name, enabled=enabled)
 
-                for system_name, single_system in systems_dict.items():
+            for system_name, single_system in systems_dict.items():
+                try:
                     sources_dict = single_system.pop('sources', {})
                     sources = []
-
                     for source_name, source_data in sources_dict.items():
                         sources.append(
                             self.get_source(source_name, source_data))
+                except AttributeError:
+                    raise conf_exc.MissingSystemSources(system_name)
 
-                    self.add_system_to_environment(environment, system_name,
-                                                   sources, single_system)
+                self.add_system_to_environment(environment, system_name,
+                                               sources, single_system)
 
-                self.environments.append(environment)
-            self.set_system_api()
-        except (AttributeError, TypeError) as exception:
-            raise conf_exc.InvalidConfiguration from exception
+            self.environments.append(environment)
+        self.set_system_api()
 
     def set_system_api(self):
         """Modify the System API depending on the type of systems present in

--- a/cibyl/outputs/cli/ci/colored.py
+++ b/cibyl/outputs/cli/ci/colored.py
@@ -46,7 +46,7 @@ class CIColoredPrinter(ColoredPrinter, CIPrinter):
 
         return printer.build()
 
-    def print_system(self, system, indent=1):
+    def print_system(self, system, indent=0):
         """
         :param system: The system.
         :type system: :class:`cibyl.models.ci.base.system.System`

--- a/cibyl/outputs/cli/ci/system/impls/base/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/colored.py
@@ -42,7 +42,7 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
 
         if self.query in (QueryType.FEATURES_JOBS, QueryType.FEATURES):
             for feature in system.features.values():
-                printer.add(self.print_feature(feature), 1)
+                printer.add(self.print_feature(feature), indent+1)
 
         return printer.build()
 

--- a/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
@@ -37,18 +37,18 @@ class ColoredJobsSystemPrinter(ColoredBaseSystemPrinter):
         printer = IndentedTextBuilder()
 
         # Begin with the text common to all systems
-        printer.add(super().print_system(system, indent=indent), indent)
+        printer.add(super().print_system(system, indent=indent), indent+1)
 
         if self.query != QueryType.NONE:
             for job in system.jobs.values():
-                printer.add(self.print_job(job), indent+1)
+                printer.add(self.print_job(job), indent+2)
 
             if not system.is_queried():
-                printer.add(self.palette.blue('No query performed'), indent+1)
+                printer.add(self.palette.blue('No query performed'), indent+2)
             elif self.query != QueryType.FEATURES:
                 header = 'Total jobs found in query: '
 
-                printer.add(self.palette.blue(header), indent+1)
+                printer.add(self.palette.blue(header), indent+2)
                 printer[-1].append(len(system.jobs))
 
         return printer.build()

--- a/docs/source/config_samples/minimal_configuration.rst
+++ b/docs/source/config_samples/minimal_configuration.rst
@@ -4,7 +4,7 @@
 
   environments:                 # List of CI/CD environments
     production:                 # An environment called "production"
-      production_jenkins        # A single system called "production_jenkins"
+      production_jenkins:       # A single system called "production_jenkins"
         system_type: jenkins    # The type of the system (jenkins or zuul)
         sources:                # List of sources belong to "production_jenkins" system
           jenkins_api:          # The name of the source which belongs to "production_jenkins" system

--- a/tests/intr/output/test_output_colored_openstack.py
+++ b/tests/intr/output/test_output_colored_openstack.py
@@ -48,10 +48,10 @@ class TestOutputJobsSystemWithOpenstackPlugin(OpenstackPluginWithJobSystem):
         # check that output is five lines long(system line, one line per job
         # and the line for total number of jobs)
         self.assertEqual(5, len(output.split("\n")))
-        expected = "System: test-system"
+        expected = "  System: test-system"
         for i in range(3):
-            expected += f"\n  Job: job-name-{i}"
-        expected += "\n  Total jobs found in query: 3"
+            expected += f"\n    Job: job-name-{i}"
+        expected += "\n    Total jobs found in query: 3"
         self.assertEqual(output, expected)
 
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -18,8 +18,7 @@ from unittest.mock import Mock, patch
 
 import cibyl.orchestrator
 from cibyl.config import Config
-from cibyl.exceptions.config import (CHECK_DOCS_MSG, InvalidConfiguration,
-                                     NonSupportedSystemKey)
+from cibyl.exceptions.config import CHECK_DOCS_MSG, NonSupportedSystemKey
 from cibyl.orchestrator import Orchestrator
 
 
@@ -29,10 +28,11 @@ class TestOrchestrator(TestCase):
     def setUp(self):
         self.orchestrator = Orchestrator()
 
-        self.invalid_config_data = {
+        self.missing_envs_config = {'environments': {}}
+
+        self.missing_system_type_config = {
             'environments': {
-                'env1': {
-                    'system1'}}}
+                'env1': 'system'}}
 
         self.valid_single_env_config_data = {
             'environments': {
@@ -134,18 +134,24 @@ class TestOrchestrator(TestCase):
 
         factory_call.assert_called_once_with(path_to_config)
 
-    def test_orchestrator_create_ci_environments(self):
-        """Testing Orchestartor query method"""
-        # No Environments
-        self.assertEqual(self.orchestrator.create_ci_environments(), None)
-        self.assertEqual(self.orchestrator.environments, [])
-
-        # Invalid configuration
+    def test_orchestrator_create_ci_envs_missing_envs(self):
+        """Testing orchestrator environments creation by using configuration
+        with missing environments."""
         self.orchestrator.config = Mock(Config())
-        self.orchestrator.config.data = self.invalid_config_data
-        with self.assertRaises(InvalidConfiguration):
+        self.orchestrator.config.data = self.missing_envs_config
+        with self.assertRaises(cibyl.exceptions.config.MissingEnvironments):
             self.orchestrator.create_ci_environments()
 
+    def test_orchestrator_create_ci_envs_missing_system_type(self):
+        """Testing orchestrator environments creation by using configuration
+        with missing system type."""
+        self.orchestrator.config = Mock(Config())
+        self.orchestrator.config.data = self.missing_system_type_config
+        with self.assertRaises(cibyl.exceptions.config.MissingSystemType):
+            self.orchestrator.create_ci_environments()
+
+    def test_orchestrator_create_ci_environments(self):
+        """Testing orchestrator environments creation."""
         # Single environment configuration
         self.orchestrator.config.data = self.valid_single_env_config_data
         self.orchestrator.environments = []


### PR DESCRIPTION
* Add exception for empty 'environments' mapping
* Add exception for empty system mapping (e.g. missing system type)
* Fix indention - system and job are printed with the same
  indention level instead of job being indent under a system
* Fix a bug where missing system_type continues execution
  instead of raising an exception
