### PR TITLE
Improve error message when no feature are found

### DIFF
--- a/cibyl/features/__init__.py
+++ b/cibyl/features/__init__.py
@@ -115,9 +115,14 @@ def get_feature(name_feature):
     try:
         feature_class = all_features[name_feature.lower()]
     except KeyError as err:
-        msg = f"No feature {name_feature}. Choose one of the following "
-        msg += "features:\n"
-        msg += get_string_all_features()
+        features_string = get_string_all_features()
+        if features_string:
+            msg = f"No feature {name_feature}. Choose one of the following "
+            msg += "features:\n"
+            msg += features_string
+        else:
+            msg = "No features were found, please make sure that the plugin "
+            msg += "that provides the requested feature is added."
         raise InvalidArgument(msg) from err
     return feature_class()
 

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -169,9 +169,14 @@ class Orchestrator:
         if user_features and not user_features.value:
             # throw error in case cibyl is called with --features argument but
             # without any specified feature
-            msg = "No feature specified. Choose one of the following "
-            msg += "features:"
-            msg += get_string_all_features()
+            features_string = get_string_all_features()
+            if features_string:
+                msg = "No feature specified. Choose one of the following "
+                msg += "features:"
+                msg += features_string
+            else:
+                msg = "No features were found, please make sure that the "
+                msg += "plugin that provides the requested feature is added."
             raise InvalidArgument(msg)
         return [get_feature(feature_name)
                 for feature_name in user_features.value]


### PR DESCRIPTION
If the user passes the --features flag in an environment where no
features are found (e.g no plugins used) use a more descriptive message
to provide better feedback
