### PR TITLE
Filter dvr and tls_everywhere true by default

### DIFF
--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -43,6 +43,7 @@ from cibyl.utils.filtering import (DEPLOYMENT_PATTERN, DVR_PATTERN_NAME,
                                    RELEASE_PATTERN, SERVICES_PATTERN,
                                    STORAGE_BACKEND_PATTERN, TOPOLOGY_PATTERN,
                                    apply_filters, filter_topology,
+                                   satisfy_case_insensitive_match,
                                    satisfy_exact_match)
 
 LOG = logging.getLogger(__name__)
@@ -279,6 +280,12 @@ accurate results", len(jobs_found))
         for attribute in self.deployment_attr:
             # check for user provided that should have an exact match
             input_attr = kwargs.get(attribute)
+            if attribute in ('dvr', 'tls_everywhere') and input_attr:
+                checks_to_apply.append(partial(satisfy_case_insensitive_match,
+                                       user_input=input_attr,
+                                       field_to_check=attribute,
+                                       default_user_value=['True']))
+                continue
             if input_attr and input_attr.value:
                 checks_to_apply.append(partial(satisfy_exact_match,
                                        user_input=input_attr,

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -15,7 +15,7 @@
 """
 import re
 import sre_constants
-from typing import Dict, Pattern
+from typing import Dict, List, Pattern
 
 from cibyl.cli.argument import Argument
 from cibyl.cli.ranged_argument import RANGE_OPERATORS
@@ -75,7 +75,8 @@ def satisfy_exact_match(model: Dict[str, str], user_input: Argument,
 
 
 def satisfy_case_insensitive_match(model: Dict[str, str], user_input: Argument,
-                                   field_to_check: str):
+                                   field_to_check: str,
+                                   default_user_value: List[str] = None):
     """Check whether model should be included according to the user input. The
     model should be added if the information provided field_to_check
     (the model name or url for example) is an exact case-insensitive match to
@@ -86,13 +87,19 @@ def satisfy_case_insensitive_match(model: Dict[str, str], user_input: Argument,
     :param user_input: input argument specified by the user
     :type model_urls: :class:`.Argument`
     :param field_to_check: Job field to perform the check
-    :param field_to_check: str
+    :type field_to_check: str
+    :param default_user_value: Default value to use if the user input contains
+    no value
+    :type default_user_value: list
     :returns: Whether the model satisfies user input
     :rtype: bool
     """
     if model[field_to_check] is None:
         return False
-    lowercase_input = [status.lower() for status in user_input.value]
+    value = user_input.value
+    if not value and default_user_value:
+        value = default_user_value
+    lowercase_input = [status.lower() for status in value]
     return model[field_to_check].lower() in lowercase_input
 
 

--- a/tests/unit/features/test_features.py
+++ b/tests/unit/features/test_features.py
@@ -98,14 +98,19 @@ class TestFeaturesLoader(RestoreAPIs):
         self.assertIn(self.feature_path, features.features_locations)
         features.features_locations = deepcopy(original_location)
 
+    @patch('cibyl.features.get_source_instance_from_method')
+    @patch('cibyl.features.source_information_from_method')
     @patch.object(Jenkins, 'get_jobs')
-    def test_query(self, jenkins_jobs):
+    def test_query(self, jenkins_jobs, source_information_patched,
+                   get_source_instance_patched):
         """Test a successful query using the query method of the
         FeatureTemplate class."""
         job = Job('job')
         jenkins_jobs.return_value = AttributeDictValue('jobs',
                                                        value={'job': job})
+        source_information_patched.return_value = ""
         source = Jenkins(url='url')
+        get_source_instance_patched.return_value = source
         system = JobsSystem('test', 'test-type', sources=[source])
         feature1 = get_feature("Feature1")
         result = feature1.query(system)
@@ -129,14 +134,18 @@ class TestFeaturesLoader(RestoreAPIs):
         feature1 = get_feature("Feature1")
         self.assertIsNone(feature1.query(system))
 
-    @patch('cibyl.features.source_information_from_method',
-           return_value="")
+    @patch('cibyl.features.get_source_instance_from_method')
+    @patch('cibyl.features.source_information_from_method')
     @patch.object(Jenkins, 'get_jobs')
-    def test_query_sources_exception(self, jenkins_jobs, _):
+    def test_query_sources_exception(self, jenkins_jobs,
+                                     source_information_patched,
+                                     get_source_instance_patched):
         """Test that query method of the FeatureTemplate class returns None if
         all sources raises errors when queried."""
         source = Jenkins(url='url')
         jenkins_jobs.side_effect = JenkinsError
+        source_information_patched.return_value = ""
+        get_source_instance_patched.return_value = source
         system = JobsSystem('test', 'test-type', sources=[source])
         feature1 = get_feature("Feature1")
         self.assertIsNone(feature1.query(system))


### PR DESCRIPTION
In Jenkins source, the --tls-everywhere and --dvr arguments will by
default a value of True. So using them without any value will print only
those jobs that have tls_everywhere or dvr, respectively. They still
support passing a value, so runing with --dvr False will show only the
jobs that do not use dvr.
