### PR TITLE
Print help message with configuration error

### DIFF
--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -91,6 +91,11 @@ class Parser:
             help="Causes Cibyl to print more debug messages. "
                  "Adding multiple -v will increase the verbosity.")
 
+    def print_help(self):
+        """Call argparse's print_help method to show the help message with the
+        arguments that are currently added."""
+        self.argument_parser.print_help()
+
     def parse(self, arguments=None):
         """Parse application and CI models arguments.
 

--- a/tests/intr/cli/test_config.py
+++ b/tests/intr/cli/test_config.py
@@ -15,6 +15,7 @@
 """
 
 import sys
+from io import StringIO
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
@@ -37,3 +38,56 @@ class TestConfig(TestCase):
             ]
 
             self.assertRaises(EmptyConfiguration, main)
+
+
+class TestConfigHelp(TestCase):
+    """Test that configuration is read and the help message is displayed when
+    calling cibyl with the help option."""
+
+    def setUp(self):
+        self._stdout = StringIO()
+        sys.stdout = self._stdout
+
+    @property
+    def stdout(self):
+        """
+        :return: What the app wrote to stdout.
+        :rtype: str
+        """
+        return self._stdout.getvalue()
+
+    def test_empty_config_help(self):
+        """Test that the help message is printed when calling cibyl with an
+        empty configuration and the --help flag.
+        """
+        with NamedTemporaryFile() as config_file:
+            sys.argv = [
+                'cibyl',
+                '--config', config_file.name,
+                '--help'
+            ]
+            self.assertRaises(SystemExit, main)
+        self.assertIn("usage: cibyl [-h]", self.stdout)
+
+    def test_valid_config_help(self):
+        """Test that the help message is printed when calling cibyl with an
+        empty configuration and the --help flag.
+        """
+        with NamedTemporaryFile() as config_file:
+            config_file.write(b"environments:\n")
+            config_file.write(b"  env:\n")
+            config_file.write(b"    system:\n")
+            config_file.write(b"      system_type: jenkins\n")
+            config_file.write(b"      sources:\n")
+            config_file.write(b"        jenkins:\n")
+            config_file.write(b"          driver: jenkins\n")
+            config_file.write(b"          url: url\n")
+            config_file.seek(0)
+            sys.argv = [
+                'cibyl',
+                '--config', config_file.name,
+                '--jobs',
+                '--help'
+            ]
+            self.assertRaises(SystemExit, main)
+        self.assertIn("usage: cibyl [-h]", self.stdout)


### PR DESCRIPTION
If there is some exception but the help argument is passed, print the help
message and exit. If the configuration could not be read, only the basic
arguments will be shown. If the configuration is valid, then after
parsing the arguments the parser will already call the print_help
function of argparser and show the same message. This change ensures
that whenever the user passes the --help argument, the help message is
displayed.
