### PR TITLE
Filter jobs without builds in Jenkins when needed

### DIFF
--- a/cibyl/sources/server.py
+++ b/cibyl/sources/server.py
@@ -29,7 +29,7 @@ class ServerSource(Source):
     def check_builds_for_test(self, **kwargs):
         """Ensure that some build information is passed when requesting
         tests."""
-        if not kwargs.get('builds') and not kwargs.get('last_build'):
+        if not any(arg in kwargs for arg in ('builds', 'last_build')):
             raise MissingArgument('Please specify some builds (--builds) \
 to get the tests from. Or use (--last-build) to get the tests from the last \
 one')


### PR DESCRIPTION
When querying for builds in Jenkins source with some filtering
(--build-status FAILURE, for example) filter the jobs that have no
builds matching the criteria. If the user passes no filters, for example
running cibyl --builds, then all jobs will be kept, even those without
any builds
