### PR TITLE
Let each model class have their own set of plugins

### DIFF
--- a/cibyl/models/model.py
+++ b/cibyl/models/model.py
@@ -16,11 +16,16 @@
 from cibyl.models.attribute import AttributeValue
 
 
-class Model:
-    """Represents a base class inherited by CI and product models."""
+class ModelMeta(type):
+    def __init__(cls, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-    API = {}
-    plugin_attributes = {}
+        cls.API = {}
+        cls.plugin_attributes = {}
+
+
+class Model(metaclass=ModelMeta):
+    """Represents a base class inherited by CI and product models."""
 
     def __init__(self, attributes):
         for attribute_name, attribute_dict in self.API.items():

--- a/cibyl/models/model.py
+++ b/cibyl/models/model.py
@@ -17,11 +17,20 @@ from cibyl.models.attribute import AttributeValue
 
 
 class ModelMeta(type):
-    def __init__(cls, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __new__(mcs, *args, **kwargs):
+        # Get information on the class signature
+        name = args[0]
+        bases = args[1]
+        attrs = args[2]
 
-        cls.API = {}
-        cls.plugin_attributes = {}
+        # Let each model class have their own API and plugins
+        if 'API' not in attrs:
+            attrs['API'] = {}
+
+        if 'plugin_attributes' not in attrs:
+            attrs['plugin_attributes'] = {}
+
+        return super().__new__(mcs, *args, **kwargs)
 
 
 class Model(metaclass=ModelMeta):

--- a/cibyl/models/model.py
+++ b/cibyl/models/model.py
@@ -19,8 +19,6 @@ from cibyl.models.attribute import AttributeValue
 class ModelMeta(type):
     def __new__(mcs, *args, **kwargs):
         # Get information on the class signature
-        name = args[0]
-        bases = args[1]
         attrs = args[2]
 
         # Let each model class have their own API and plugins

--- a/tests/unit/plugins/test_plugin.py
+++ b/tests/unit/plugins/test_plugin.py
@@ -15,10 +15,10 @@
 """
 
 from cibyl.exceptions.plugin import MissingPlugin
-from cibyl.plugins import enable_plugins
-from cibyl.plugins.openstack import Plugin
 from cibyl.models.ci.base.job import Job
 from cibyl.models.ci.zuul.job import Job as ZuulJob
+from cibyl.plugins import enable_plugins
+from cibyl.plugins.openstack import Plugin
 from tests.utils import RestoreAPIs
 
 

--- a/tests/unit/plugins/test_plugin.py
+++ b/tests/unit/plugins/test_plugin.py
@@ -16,6 +16,9 @@
 
 from cibyl.exceptions.plugin import MissingPlugin
 from cibyl.plugins import enable_plugins
+from cibyl.plugins.openstack import Plugin
+from cibyl.models.ci.base.job import Job
+from cibyl.models.ci.zuul.job import Job as ZuulJob
 from tests.utils import RestoreAPIs
 
 
@@ -31,3 +34,30 @@ class TestPlugin(RestoreAPIs):
         self.assertRaises(MissingPlugin,
                           enable_plugins,
                           ["nonExistingPlugin"])
+
+    def test_extends_jenkins_job(self):
+        """Checks that the plugin extends the base job model.
+        """
+        plugin = Plugin()
+        plugin.extend_models()
+
+        # Plugin's of model are empty
+        self.assertIn('deployment', Job.plugin_attributes)
+
+    def test_extends_variant(self):
+        """Checks that the plugin extends the zuul variant model.
+        """
+        plugin = Plugin()
+        plugin.extend_models()
+
+        # Plugin's of model are empty
+        self.assertIn('deployment', ZuulJob.Variant.plugin_attributes)
+
+    def test_do_not_extend_zuul_job(self):
+        """Checks that the plugin does not extend a model it should not do.
+        """
+        plugin = Plugin()
+        plugin.extend_models()
+
+        # Plugin's of model are empty
+        self.assertFalse(ZuulJob.plugin_attributes)


### PR DESCRIPTION
This fixes a bug where Cibyl crashed when it tried to access a plugin on a model that should have never had it in the first place. With this change, each class that inherits from Model gets its own set of plugins, which means that the Zuul job will remain pluginless and will fail no more.