### PR TITLE
Refactor Configuration Handling

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -91,7 +91,8 @@ def main():
 
     try:
         try:
-            orchestrator.load_configuration(arguments.get('config_file_path'))
+            orchestrator.config.load(path=arguments.get('config_file_path'))
+            orchestrator.config.verify()
         except (ConfigurationNotFound, EmptyConfiguration) as ex:
             # Check if the error is to be ignored
             if not arguments.get('help', False):
@@ -101,7 +102,7 @@ def main():
         if not plugins:
             # if user has not specified any plugins,
             # read them from configuration
-            plugins = orchestrator.config.data.get('plugins', [])
+            plugins = orchestrator.config.plugins
         # add plugins after the environments are created, since the environment
         # might modify some of the models APIs
         if plugins:

--- a/tests/intr/cli/test_openstack_plugin.py
+++ b/tests/intr/cli/test_openstack_plugin.py
@@ -60,6 +60,7 @@ class TestOpenstackCLI(RestoreAPIs):
             config_file.write(b"  env:\n")
             config_file.write(b"    system:\n")
             config_file.write(b"      system_type: zuul\n")
+            config_file.write(b"      sources: {}\n")
             config_file.seek(0)
             sys.argv = ['-h', '-p', 'openstack', '--config', config_file.name]
 
@@ -75,6 +76,7 @@ class TestOpenstackCLI(RestoreAPIs):
             config_file.write(b"  env:\n")
             config_file.write(b"    system:\n")
             config_file.write(b"      system_type: jenkins\n")
+            config_file.write(b"      sources: {}\n")
             config_file.seek(0)
             sys.argv = ['-h', '-p', 'openstack', '--config', config_file.name]
 
@@ -90,8 +92,10 @@ class TestOpenstackCLI(RestoreAPIs):
             config_file.write(b"  env:\n")
             config_file.write(b"    system:\n")
             config_file.write(b"      system_type: zuul\n")
+            config_file.write(b"      sources: {}\n")
             config_file.write(b"    system2:\n")
             config_file.write(b"      system_type: jenkins\n")
+            config_file.write(b"      sources: {}\n")
             config_file.seek(0)
             sys.argv = ['-h', '-p', 'openstack', '--config', config_file.name]
 
@@ -107,8 +111,10 @@ class TestOpenstackCLI(RestoreAPIs):
             config_file.write(b"  env:\n")
             config_file.write(b"    system:\n")
             config_file.write(b"      system_type: jenkins\n")
+            config_file.write(b"      sources: {}\n")
             config_file.write(b"    system2:\n")
             config_file.write(b"      system_type: zuul\n")
+            config_file.write(b"      sources: {}\n")
             config_file.seek(0)
             sys.argv = ['-h', '-p', 'openstack', '--config', config_file.name]
 
@@ -125,6 +131,7 @@ class TestOpenstackCLI(RestoreAPIs):
             config_file.write(b"  env:\n")
             config_file.write(b"    system:\n")
             config_file.write(b"      system_type: zuul\n")
+            config_file.write(b"      sources: {}\n")
             config_file.write(b"plugins:\n")
             config_file.write(b"  - openstack\n")
             config_file.seek(0)

--- a/tests/intr/models/ci/base/test_system.py
+++ b/tests/intr/models/ci/base/test_system.py
@@ -15,6 +15,7 @@
 """
 from unittest import TestCase
 
+from cibyl.config import AppConfig
 from cibyl.models.ci.base.system import JobsSystem, System
 from cibyl.models.ci.zuul.system import ZuulSystem
 from cibyl.orchestrator import Orchestrator
@@ -27,35 +28,41 @@ class TestAPI(TestCase):
             'environments': {
                 'env3': {
                     'system3': {
-                        'system_type': 'jenkins'},
+                        'system_type': 'jenkins',
+                        'sources': {}},
                     'system4': {
-                        'system_type': 'zuul'}
+                        'system_type': 'zuul',
+                        'sources': {}}
                 }}}
         self.config_reverse = {
             'environments': {
                 'env3': {
                     'system4': {
-                        'system_type': 'zuul'},
+                        'system_type': 'zuul',
+                        'sources': {}},
                     'system3': {
-                        'system_type': 'jenkins'}
+                        'system_type': 'jenkins',
+                        'sources': {}}
                 }}}
         self.config_jenkins = {
             'environments': {
                 'env3': {
                     'system3': {
-                        'system_type': 'jenkins'}}}}
+                        'system_type': 'jenkins',
+                        'sources': {}}}}}
         self.config_zuul = {
             'environments': {
                 'env3': {
                     'system3': {
-                        'system_type': 'zuul'}}}}
+                        'system_type': 'zuul',
+                        'sources': {}}}}}
         self.orchestrator = Orchestrator()
 
     def test_system_api_zuul_jenkins(self):
         """Checks that the creation of multiple types of systems leads to
         the combined API of all of them.
         """
-        self.orchestrator.config.data = self.config
+        self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
         self.assertEqual(System.API, ZuulSystem.API)
 
@@ -63,7 +70,7 @@ class TestAPI(TestCase):
         """Checks that the creation of multiple types of systems leads to
         the combined API of all of them.
         """
-        self.orchestrator.config.data = self.config_reverse
+        self.orchestrator.config = AppConfig(data=self.config_reverse)
         self.orchestrator.create_ci_environments()
         self.assertEqual(System.API, ZuulSystem.API)
 
@@ -71,7 +78,7 @@ class TestAPI(TestCase):
         """Checks that the creation of multiple types of systems leads to
         the combined API of all of them.
         """
-        self.orchestrator.config.data = self.config_zuul
+        self.orchestrator.config = AppConfig(data=self.config_zuul)
         self.orchestrator.create_ci_environments()
         self.assertEqual(System.API, ZuulSystem.API)
 
@@ -79,6 +86,6 @@ class TestAPI(TestCase):
         """Checks that the creation of multiple types of systems leads to
         the combined API of all of them.
         """
-        self.orchestrator.config.data = self.config_jenkins
+        self.orchestrator.config = AppConfig(data=self.config_jenkins)
         self.orchestrator.create_ci_environments()
         self.assertEqual(System.API, JobsSystem.API)

--- a/tests/unit/cli/test_validator.py
+++ b/tests/unit/cli/test_validator.py
@@ -17,6 +17,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from cibyl.cli.validator import Validator
+from cibyl.config import AppConfig
 from cibyl.exceptions.model import (InvalidEnvironment, InvalidSystem,
                                     NoEnabledSystem, NoValidSystem)
 from cibyl.exceptions.source import NoValidSources
@@ -43,9 +44,11 @@ class TestValidator(TestCase):
             'environments': {
                 'env': {
                     'system3': {
-                        'system_type': 'jenkins'},
+                        'system_type': 'jenkins',
+                        'sources': {}},
                     'system4': {
-                        'system_type': 'zuul'}
+                        'system_type': 'zuul',
+                        'sources': {}}
                 },
                 'env1': {
                     'system1': {
@@ -68,9 +71,11 @@ class TestValidator(TestCase):
                 'env': {
                     'system3': {
                         'system_type': 'jenkins',
+                        'sources': {},
                         'enabled': False},
                     'system4': {
                         'system_type': 'zuul',
+                        'sources': {},
                         'enabled': False}
                 },
                 'env1': {
@@ -89,7 +94,7 @@ class TestValidator(TestCase):
 
     def tests_validator_validate_environments(self):
         """Testing Validator validate_environment method."""
-        self.orchestrator.config.data = self.config
+        self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
         self.ci_args["env_name"] = Mock()
         self.ci_args["env_name"].value = ["env"]
@@ -107,7 +112,7 @@ class TestValidator(TestCase):
 
     def tests_validator_validate_environments_systems(self):
         """Testing Validator validate_environment method."""
-        self.orchestrator.config.data = self.config
+        self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
         self.ci_args["env_name"] = Mock()
         self.ci_args["env_name"].value = ["env"]
@@ -126,7 +131,7 @@ class TestValidator(TestCase):
 
     def tests_validator_validate_environments_system_type(self):
         """Testing Validator validate_environment method."""
-        self.orchestrator.config.data = self.config
+        self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
         self.ci_args["env_name"] = Mock()
         self.ci_args["env_name"].value = ["env"]
@@ -145,7 +150,7 @@ class TestValidator(TestCase):
 
     def tests_validator_validate_environments_system_type_no_systems(self):
         """Testing Validator validate_environment method."""
-        self.orchestrator.config.data = self.config
+        self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
         self.ci_args["env_name"] = Mock()
         self.ci_args["env_name"].value = ["env"]
@@ -161,7 +166,7 @@ class TestValidator(TestCase):
 
     def tests_validator_validate_environments_no_envs(self):
         """Testing Validator validate_environment method."""
-        self.orchestrator.config.data = self.config
+        self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
         self.ci_args["envs"] = Mock()
         self.ci_args["envs"].value = ["unknown"]
@@ -177,7 +182,7 @@ class TestValidator(TestCase):
 
     def tests_validator_validate_environments_no_systems(self):
         """Testing Validator validate_environment method."""
-        self.orchestrator.config.data = self.config
+        self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
         self.ci_args["systems"] = Mock()
         self.ci_args["systems"].value = ["unknown"]
@@ -191,7 +196,7 @@ class TestValidator(TestCase):
 
     def test_validator_validate_sources(self):
         """Test Validator validate_environments with sources."""
-        self.orchestrator.config.data = self.config
+        self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
         self.ci_args["sources"] = Mock()
         self.ci_args["sources"].value = ["zuul"]
@@ -213,7 +218,7 @@ class TestValidator(TestCase):
 
     def test_validator_validate_no_sources(self):
         """Test Validator validate_environments with no sources."""
-        self.orchestrator.config.data = self.config
+        self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
         self.ci_args["env_name"] = Mock()
         self.ci_args["env_name"].value = ["env"]
@@ -228,7 +233,7 @@ class TestValidator(TestCase):
 
     def test_validator_validate_no_enabled_system(self):
         """Test Validator validate_environments with no enabled systems."""
-        self.orchestrator.config.data = self.config_enable
+        self.orchestrator.config = AppConfig(data=self.config_enable)
         self.orchestrator.create_ci_environments()
 
         original_envs = self.orchestrator.environments
@@ -239,7 +244,7 @@ class TestValidator(TestCase):
 
     def test_validator_validate_override_no_enabled_system(self):
         """Test Validator validate_environments overriding disabled systems."""
-        self.orchestrator.config.data = self.config_enable
+        self.orchestrator.config = AppConfig(data=self.config_enable)
         self.orchestrator.create_ci_environments()
         self.ci_args["systems"] = Mock()
         self.ci_args["systems"].value = ["system3", "system4"]

--- a/tests/unit/config/__init__.py
+++ b/tests/unit/config/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/unit/config/test_app_config.py
+++ b/tests/unit/config/test_app_config.py
@@ -1,0 +1,51 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+import cibyl.exceptions.config as conf_exc
+from cibyl.config import AppConfig
+
+
+class TestAppConfig(TestCase):
+    """Test cases for the 'AppConfig' class."""
+
+    def test_missing_environments_in_app_config(self):
+        data = {'environments': {}}
+        self.config = AppConfig(data=data)
+        with self.assertRaises(conf_exc.MissingEnvironments):
+            self.config.verify()
+
+    def test_missing_systems_in_app_config(self):
+        data = {'environments': 'env1'}
+        self.config = AppConfig(data=data)
+        with self.assertRaises(conf_exc.MissingSystems):
+            self.config.verify()
+
+    def test_missing_system_type_in_app_config(self):
+        data = {'environments':
+                {'env1': 'system1'}}
+        self.config = AppConfig(data=data)
+        with self.assertRaises(conf_exc.MissingSystemType):
+            self.config.verify()
+
+    def test_missing_system_sources_in_app_config(self):
+        data = {'environments':
+                {'env1':
+                 {'system1':
+                  {'foo': 'bar'}}}}
+        self.config = AppConfig(data=data)
+        with self.assertRaises(conf_exc.MissingSystemSources):
+            self.config.verify()

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -35,29 +35,29 @@ class TestConfig(TestCase):
         """Test that parsing and empty configuration file raises and error."""
         with NamedTemporaryFile() as config_file:
             config = Config()
-            self.assertRaises(EmptyConfiguration, config.load,
-                              config_file.name)
+            self.assertRaises(EmptyConfiguration, config.load_from_path,
+                              path=config_file.name)
 
     def test_contents_are_loaded(self):
         """Checks that the contents of the loaded file are made available by
         the class.
         """
-        file = 'path/to/config/file'
         yaml_return = {
             'node_a': {
                 'name': 'Test',
                 'host': 'test_host'
             }
         }
-        with patch('cibyl.config.yaml') as yaml_patched:
+        with NamedTemporaryFile() as config_file:
+            with patch('cibyl.config.yaml') as yaml_patched:
 
-            yaml_patched.parse.return_value = yaml_return
+                yaml_patched.parse.return_value = yaml_return
 
-            config = Config()
-            config.load(file)
-            yaml_patched.parse.assert_called_with(file)
+                config = Config()
+                config.load_from_path(path=config_file.name)
+                yaml_patched.parse.assert_called_with(config_file.name)
 
-        self.assertEqual(config, yaml_return)
+            self.assertEqual(config, yaml_return)
 
     def test_encrypted_constructor(self):
         self.assertEqual('', encrypted_constructor(yaml.SafeLoader,


### PR DESCRIPTION
 - Create an App Config class that inherits from
  the current Config class. The App Config class will
  handle specific configuration checks like the validity
  of environments, systems and sources sections in the 
  configuration
- Remove configuration checks from orchestrator.
  It should be focused solely on orchestrating the workflow
  of the application
- Remove configuration loading from orchestrator. The loading
  of the configuration should be handled by the config
  class. When it's done with the App Config class it also takes
  care of creating the environments configuration object (note:
  this is not about creating the environments instances themselves)
- Modified unit and integration tests accordingly
- Added tests to test the validation methods
- Enforce specifying sources in a valid configuration, even
  if empty
