### PR TITLE
Consider all openstack arguments for query type

### DIFF
--- a/cibyl/plugins/openstack/__init__.py
+++ b/cibyl/plugins/openstack/__init__.py
@@ -21,8 +21,14 @@ from cibyl.models.ci.zuul.job import Job as ZuulJob
 from cibyl.plugins.openstack.deployment import Deployment
 from cibyl.utils.dicts import subset
 
+PLUGIN_ARGUMENTS = ('release', 'spec', 'infra_type', 'nodes', 'controllers',
+                    'computes', 'node_name', 'role', 'containers',
+                    'container_image', 'packages', 'services', 'ip_version',
+                    'topology', 'dvr', 'ml2_driver', 'tls_everywhere',
+                    'ironic_inspector', 'network_backend', 'storage_backend')
 
-def add_deployment(self, deployment: Deployment):
+
+def add_deployment(self, deployment: Deployment) -> None:
     """Add a deployment to the job.
 
     :param deployment: Deployment to add to the job
@@ -31,19 +37,11 @@ def add_deployment(self, deployment: Deployment):
     self.deployment.value = deployment
 
 
-def get_query_openstack(**kwargs):
+def get_query_openstack(**kwargs) -> QueryType:
     """Deduce the query type from openstack cli arguments."""
     result = QueryType.NONE
-    possible_deployment_args = []
-    for attr_options in Deployment.API.values():
-        for cli_arg in attr_options.get('arguments', []):
-            # remove leading '-' in cli argument
-            cli_arg_name = cli_arg.name.strip("-")
-            # replace separator '-' by '_', since that is the way the parser
-            # stores the arguments
-            possible_deployment_args.append(cli_arg_name.replace("-", "_"))
 
-    deployment_args = subset(kwargs, possible_deployment_args)
+    deployment_args = subset(kwargs, PLUGIN_ARGUMENTS)
     if deployment_args:
         result = QueryType.JOBS
 

--- a/cibyl/plugins/openstack/service.py
+++ b/cibyl/plugins/openstack/service.py
@@ -16,7 +16,6 @@
 
 from typing import Dict
 
-from cibyl.cli.argument import Argument
 from cibyl.models.model import Model
 
 # pylint: disable=no-member
@@ -28,13 +27,11 @@ class Service(Model):
     API = {
         'name': {
             'attr_type': str,
-            'arguments': [Argument(name='--service-name', arg_type=str,
-                                   description="Service name")]
+            'arguments': []
         },
         'configuration': {
             'attr_type': dict,
-            'arguments': [Argument(name='--service-config', arg_type=str,
-                                   description="Service configuration")]
+            'arguments': []
         }
     }
 

--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -322,7 +322,7 @@ accurate results", len(jobs_found))
                             user_input=input_overcloud_templates)
             checks_to_apply.append(check)
 
-        for attribute in ['containers', 'packages']:
+        for attribute in ('containers', 'packages'):
             input_attr = kwargs.get(attribute)
             if input_attr and input_attr.value:
                 checks_to_apply.append(partial(filter_nodes,

--- a/tests/unit/cli/test_query.py
+++ b/tests/unit/cli/test_query.py
@@ -295,3 +295,39 @@ class TestGetQueryTypeOpenstackPlugin(OpenstackPluginWithJobSystem):
         }
 
         self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_spec_packages(self):
+        """Checks that "Jobs" is returned for "--packages" if the
+        openstack plugin is added and is run in combination of arguments like
+        --tenants.
+        """
+        args = {
+            'tenants': None,
+            'packages': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_spec_services(self):
+        """Checks that "Jobs" is returned for "--services" if the
+        openstack plugin is added and is run in combination of arguments like
+        --tenants.
+        """
+        args = {
+            'tenants': None,
+            'services': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+
+    def test_get_spec_containers(self):
+        """Checks that "Jobs" is returned for "--containers" if the
+        openstack plugin is added and is run in combination of arguments like
+        --tenants.
+        """
+        args = {
+            'tenants': None,
+            'containers': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))


### PR DESCRIPTION
When determining the query type (which is used by the printers to
determine the amount of information to output), not all arguments
included by the openstack plugin where consider. This change includes
all of them, so that commands like cibyl --packages prints the
corresponding output.
