### PR TITLE
Use logger from core jenkins source in plugin extension

### DIFF
--- a/cibyl/plugins/openstack/sources/elasticsearch.py
+++ b/cibyl/plugins/openstack/sources/elasticsearch.py
@@ -14,8 +14,6 @@
 #    under the License.
 """
 
-import logging
-
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.base.job import Job
 from cibyl.plugins.openstack.deployment import Deployment
@@ -23,8 +21,6 @@ from cibyl.sources.plugins import SourceExtension
 from cibyl.sources.source import speed_index
 from cibyl.utils.dicts import chunk_dictionary_into_lists
 from cibyl.utils.filtering import IP_PATTERN
-
-LOG = logging.getLogger(__name__)
 
 
 class ElasticSearch(SourceExtension):

--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -14,7 +14,6 @@
 #    under the License.
 """
 
-import logging
 import os
 import re
 from functools import partial
@@ -33,7 +32,7 @@ from cibyl.plugins.openstack.package import Package
 from cibyl.plugins.openstack.service import Service
 from cibyl.plugins.openstack.test_collection import TestCollection
 from cibyl.plugins.openstack.utils import translate_topology_string
-from cibyl.sources.jenkins import detect_job_info_regex, filter_jobs
+from cibyl.sources.jenkins import LOG, detect_job_info_regex, filter_jobs
 from cibyl.sources.plugins import SourceExtension
 from cibyl.sources.source import speed_index
 from cibyl.utils.dicts import subset
@@ -46,7 +45,6 @@ from cibyl.utils.filtering import (DEPLOYMENT_PATTERN, DVR_PATTERN_NAME,
                                    satisfy_case_insensitive_match,
                                    satisfy_exact_match)
 
-LOG = logging.getLogger(__name__)
 # shorthand for the type that will hold the job information obtained from the
 # Jenkins API response
 JenkinsJob = Dict[str, Union[dict, str]]


### PR DESCRIPTION
Due to the way the plugin source extensions are loaded, the loggers
defined there would not inherit the logger configuration defined for the
application. This change importes the logger from the core source in the
extension to ensure they have the same formatting. It also removes the
defined logger from the elasticsearch extension since it would have the
same problem but was not used. If logging is required there, it should
follow the same pattern and import the one from the core source.
