### PR TITLE
Remove multiple OS args and add them as features

### DIFF
--- a/cibyl/features/__init__.py
+++ b/cibyl/features/__init__.py
@@ -84,8 +84,8 @@ def load_features(feature_paths: list = None):
                                       return_name=True)
             module_name = module.__name__
             for feature_name, feature in features:
-                all_features[feature_name.lower()] = feature
-                features_by_category[module_name].append(feature_name)
+                all_features[feature.name.lower()] = feature
+                features_by_category[module_name].append(feature.name)
 
 
 def get_string_all_features():
@@ -93,7 +93,7 @@ def get_string_all_features():
     an exception message."""
     msg = ""
     for category, features_names in features_by_category.items():
-        msg += f"\n{Colors.blue(category.title())}:"
+        msg += f"\n\n{Colors.blue(category.title())}:"
         for feature_name in features_names:
             feature = all_features[feature_name.lower()]
             docstring = getattr(feature, "__doc__", "")

--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -84,13 +84,6 @@ class Deployment(Model):
                                    description="Topology used in the "
                                                "deployment")]
         },
-        'dvr': {
-            'attr_type': str,
-            'arguments': [Argument(name='--dvr', arg_type=str,
-                                   func='get_deployment', nargs='*',
-                                   description="Whether dvr is used in the "
-                                               "deployment")]
-        },
         'ml2_driver': {
             'attr_type': str,
             'arguments': [Argument(name='--ml2-driver', arg_type=str,
@@ -98,22 +91,16 @@ class Deployment(Model):
                                    description="ML2 driver used in the "
                                                "deployment")]
         },
+        'cleaning_network': {
+            'arguments': []
+        },
+        'dvr': {
+            'arguments': []
+        },
         'tls_everywhere': {
-            'attr_type': str,
-            'arguments': [Argument(name='--tls-everywhere', arg_type=str,
-                                   func='get_deployment', nargs='*',
-                                   description="Whether tls-everywhere is "
-                                               "used in the deployment")]
+            'arguments': []
         },
         'ironic_inspector': {
-            'attr_type': str,
-            'arguments': [Argument(name='--ironic-inspector', arg_type=str,
-                                   func='get_deployment', nargs='*',
-                                   description="Whether ironic inspector is "
-                                               "used in the deployment "
-                                               "overcloud")]
-        },
-        'cleaning_network': {
             'arguments': []
         },
         'security_group': {

--- a/cibyl/plugins/openstack/features/__init__.py
+++ b/cibyl/plugins/openstack/features/__init__.py
@@ -23,5 +23,8 @@ LOG = logging.getLogger(__name__)
 class OpenstackFeatureTemplate(FeatureTemplate):
     """Skeleton for an openstack specific feature."""
 
+    def __init__(self, name: str):
+        self.name = name
+
     def get_method_to_query(self):
         return "get_deployment"

--- a/cibyl/plugins/openstack/features/ironic.py
+++ b/cibyl/plugins/openstack/features/ironic.py
@@ -1,0 +1,39 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import logging
+
+from cibyl.cli.argument import Argument
+from cibyl.features import FeatureDefinition
+from cibyl.plugins.openstack.features import OpenstackFeatureTemplate
+
+LOG = logging.getLogger(__name__)
+
+
+class Inspector(OpenstackFeatureTemplate, FeatureDefinition):
+    """Discovering hardware properties for a node managed by Ironic"""
+
+    name = "ironic-inspector"
+
+    def __init__(self):
+        super().__init__(self.name)
+
+    def get_template_args(self):
+        """Get the arguments necessary to obtain the information that defines
+        the feature."""
+        inspector_arg = Argument("ironic_inspector", arg_type=str,
+                                 description="Ironic Inspector",
+                                 func="get_deployment")
+        return {'ironic_inspector': inspector_arg}

--- a/cibyl/plugins/openstack/features/network.py
+++ b/cibyl/plugins/openstack/features/network.py
@@ -24,8 +24,11 @@ LOG = logging.getLogger(__name__)
 
 class HA(OpenstackFeatureTemplate, FeatureDefinition):
     """Highly available Openstack deployment with at least 2 controllers."""
+
+    name = "HA"
+
     def __init__(self):
-        super().__init__("HA")
+        super().__init__(self.name)
 
     def get_template_args(self):
         """Get the arguments necessary to obtain the information that defines
@@ -39,8 +42,11 @@ class HA(OpenstackFeatureTemplate, FeatureDefinition):
 
 class IPV4(OpenstackFeatureTemplate, FeatureDefinition):
     """Openstack deployment using IPv4."""
+
+    name = "IPV4"
+
     def __init__(self):
-        super().__init__("IPV4")
+        super().__init__(self.name)
 
     def get_template_args(self):
         """Get the arguments necessary to obtain the information that defines
@@ -54,8 +60,11 @@ class IPV4(OpenstackFeatureTemplate, FeatureDefinition):
 
 class IPV6(OpenstackFeatureTemplate, FeatureDefinition):
     """Openstack deployment using IPv6."""
+
+    name = "IPV6"
+
     def __init__(self):
-        super().__init__("IPV6")
+        super().__init__(self.name)
 
     def get_template_args(self):
         """Get the arguments necessary to obtain the information that defines
@@ -65,3 +74,20 @@ class IPV6(OpenstackFeatureTemplate, FeatureDefinition):
                           func="get_deployment",
                           value=["6"])
         return {'ip_version': ip_arg}
+
+
+class DVR(OpenstackFeatureTemplate, FeatureDefinition):
+    """Openstack deployment configured with 'Distributed Virtual Router'"""
+
+    name = "DVR"
+
+    def __init__(self):
+        super().__init__(self.name)
+
+    def get_template_args(self):
+        """Get the arguments necessary to obtain the information that defines
+        the feature."""
+        dvr_arg = Argument("dvr", arg_type=str,
+                           description="DVR enabled",
+                           func="get_deployment")
+        return {'dvr': dvr_arg}

--- a/cibyl/plugins/openstack/features/security.py
+++ b/cibyl/plugins/openstack/features/security.py
@@ -1,0 +1,40 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import logging
+
+from cibyl.cli.argument import Argument
+from cibyl.features import FeatureDefinition
+from cibyl.plugins.openstack.features import OpenstackFeatureTemplate
+
+LOG = logging.getLogger(__name__)
+
+
+class TLSEverywhere(OpenstackFeatureTemplate, FeatureDefinition):
+    """TLS for all endpoints in the entire deployment, including the
+    overcloud, undercloud"""
+
+    name = "tls-everywhere"
+
+    def __init__(self):
+        super().__init__(self.name)
+
+    def get_template_args(self):
+        """Get the arguments necessary to obtain the information that defines
+        the feature."""
+        tls_everywhere_arg = Argument("tls_everywhere", arg_type=str,
+                                      description="TLS Everywhere",
+                                      func="get_deployment")
+        return {'tls_everywhere': tls_everywhere_arg}

--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -90,14 +90,6 @@ Arguments Matrix
      - |:black_square_button:|
      - |:black_square_button:|
      - |:black_square_button:|
-   * - --dvr
-     - | Does the deployment use
-       | Distributed Virtual Router
-     - |:ballot_box_with_check:|
-     - |:black_square_button:|
-     - |:ballot_box_with_check:|
-     - |:black_square_button:|
-     - |:black_square_button:|
    * - --ml2-driver
      - | Which ml2 driver does
        | the deployment use
@@ -122,22 +114,6 @@ Arguments Matrix
      - |:ballot_box_with_check:|
      - |:black_square_button:|
      - |:black_square_button:|
-   * - --ironic-inspector
-     - | Does the deployment use
-       | Ironic in the overcloud
-     - |:ballot_box_with_check:|
-     - |:black_square_button:|
-     - |:black_square_button:|
-     - |:black_square_button:|
-     - |:black_square_button:|
-   * - --tls-everywhere
-     - | Does the deployment uses
-       | TLS on all hosts
-     - |:ballot_box_with_check:|
-     - |:black_square_button:|
-     - |:black_square_button:|
-     - |:x:|
-     - |:x:|
    * - --containers
      - | List of containers running
        | on the hosts

--- a/tests/unit/features/data/testing.py
+++ b/tests/unit/features/data/testing.py
@@ -21,8 +21,10 @@ from cibyl.features import FeatureDefinition, FeatureTemplate
 class Feature1(FeatureTemplate, FeatureDefinition):
     """Feature for testing1"""
 
+    name = "Feature1"
+
     def __init__(self):
-        super().__init__("Feature1")
+        super().__init__(self.name)
 
     def get_method_to_query(self):
         return "get_jobs"
@@ -38,8 +40,11 @@ class Feature1(FeatureTemplate, FeatureDefinition):
 
 class Feature2(FeatureTemplate, FeatureDefinition):
     """Feature for testing2"""
+
+    name = "Feature2"
+
     def __init__(self):
-        super().__init__("Feature2")
+        super().__init__(self.name)
 
     def get_method_to_query(self):
         return "get_jobs"
@@ -54,8 +59,11 @@ class Feature2(FeatureTemplate, FeatureDefinition):
 
 
 class Feature3(FeatureTemplate, FeatureDefinition):
+
+    name = "Feature3"
+
     def __init__(self):
-        super().__init__("Feature3")
+        super().__init__(self.name)
 
     def get_method_to_query(self):
         return "get_jobs"

--- a/tests/unit/features/test_features.py
+++ b/tests/unit/features/test_features.py
@@ -81,7 +81,7 @@ class TestFeaturesLoader(RestoreAPIs):
         """Test that get_string_all_features provides the correct string
         representation."""
         output = get_string_all_features()
-        expected = f"\n{Colors.blue('Testing')}:\n"
+        expected = f"\n\n{Colors.blue('Testing')}:\n"
         expected += f"{Colors.red(' * ')}{Colors.blue('Feature1')}"
         expected += f"{Colors.red(' - Feature for testing1')}\n"
         expected += f"{Colors.red(' * ')}{Colors.blue('Feature2')}"


### PR DESCRIPTION
Removed the following arguments in favor of making them features:

  - tls-everywhere
  - ironic inspector
  - DVR

As a rule of thumb anything that can be evaluated to True or False,
should probably become a feature as opposed to ranged or multi-value
arguments like --packages, --controllers, etc.
