### PR TITLE
Alphabetically sorting jobs by their name

### DIFF
--- a/cibyl/outputs/cli/ci/system/impls/base/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/colored.py
@@ -38,6 +38,11 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
                  verbosity=0,
                  palette=DefaultPalette(),
                  job_sorter=BubbleSortAlgorithm(SortJobsByName())):
+        """Constructor. See parent for more information.
+
+        :param job_sorter: Determines the order on which jobs are printed.
+        :rtype job_sorter: :class:`cibyl.utils.sorting.Comparator`
+        """
         super().__init__(query, verbosity, palette)
 
         self._job_sorter = job_sorter
@@ -54,7 +59,7 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
 
         if self.query in (QueryType.FEATURES_JOBS, QueryType.FEATURES):
             for feature in system.features.values():
-                printer.add(self.print_feature(feature), indent + 1)
+                printer.add(self.print_feature(feature), indent+1)
 
         return printer.build()
 

--- a/cibyl/outputs/cli/ci/system/impls/base/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/colored.py
@@ -19,7 +19,10 @@ from overrides import overrides
 
 from cibyl.cli.query import QueryType
 from cibyl.outputs.cli.ci.system.printer import CISystemPrinter
+from cibyl.outputs.cli.ci.system.sorting.jobs import SortJobsByName
 from cibyl.outputs.cli.printer import ColoredPrinter
+from cibyl.utils.colors import DefaultPalette
+from cibyl.utils.sorting import BubbleSortAlgorithm
 from cibyl.utils.strings import IndentedTextBuilder
 
 LOG = logging.getLogger(__name__)
@@ -29,6 +32,15 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
     """Default printer for all system models. This one is decorated with
     colors for easier read.
     """
+
+    def __init__(self,
+                 query=QueryType.NONE,
+                 verbosity=0,
+                 palette=DefaultPalette(),
+                 job_sorter=BubbleSortAlgorithm(SortJobsByName())):
+        super().__init__(query, verbosity, palette)
+
+        self._job_sorter = job_sorter
 
     @overrides
     def print_system(self, system, indent=0):
@@ -42,7 +54,7 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
 
         if self.query in (QueryType.FEATURES_JOBS, QueryType.FEATURES):
             for feature in system.features.values():
-                printer.add(self.print_feature(feature), indent+1)
+                printer.add(self.print_feature(feature), indent + 1)
 
         return printer.build()
 

--- a/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
@@ -23,6 +23,7 @@ from cibyl.outputs.cli.ci.system.common.models import (get_plugin_section,
 from cibyl.outputs.cli.ci.system.common.stages import print_stage
 from cibyl.outputs.cli.ci.system.impls.base.colored import \
     ColoredBaseSystemPrinter
+from cibyl.utils.sorting import sort
 from cibyl.utils.strings import IndentedTextBuilder
 from cibyl.utils.time import as_minutes
 
@@ -40,7 +41,7 @@ class ColoredJobsSystemPrinter(ColoredBaseSystemPrinter):
         printer.add(super().print_system(system, indent=indent), indent+1)
 
         if self.query != QueryType.NONE:
-            for job in system.jobs.values():
+            for job in sort(system.jobs.values(), self._job_sorter):
                 printer.add(self.print_job(job), indent+2)
 
             if not system.is_queried():

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -26,6 +26,7 @@ from cibyl.outputs.cli.ci.system.impls.base.colored import \
     ColoredBaseSystemPrinter
 from cibyl.outputs.cli.printer import ColoredPrinter
 from cibyl.utils.filtering import apply_filters
+from cibyl.utils.sorting import sort
 from cibyl.utils.strings import IndentedTextBuilder
 
 LOG = logging.getLogger(__name__)
@@ -287,7 +288,7 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
             result.add(self.palette.blue('Jobs: '), 1)
 
             if tenant.jobs.value:
-                for job in tenant.jobs.values():
+                for job in sort(tenant.jobs.values(), self._job_sorter):
                     result.add(create_printer().print_job(job), 2)
 
                 result.add(

--- a/cibyl/outputs/cli/ci/system/sorting/__init__.py
+++ b/cibyl/outputs/cli/ci/system/sorting/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/cibyl/outputs/cli/ci/system/sorting/jobs.py
+++ b/cibyl/outputs/cli/ci/system/sorting/jobs.py
@@ -17,14 +17,14 @@ from cibyl.utils.sorting import Comparator
 
 
 class SortJobsByName(Comparator):
-    def compare(self, left, right):
-        """
+    """Sorts jobs in alphabetical order based on their name.
+    """
 
-        :param left:
+    def compare(self, left, right):
+        """See parent function for more information.
+
         :type left: :class:`cibyl.models.ci.base.job.Job`
-        :param right:
         :type right: :class:`cibyl.models.ci.base.job.Job`
-        :return:
         """
         name_left = left.name.value.lower()
         name_right = right.name.value.lower()

--- a/cibyl/outputs/cli/ci/system/sorting/jobs.py
+++ b/cibyl/outputs/cli/ci/system/sorting/jobs.py
@@ -1,0 +1,32 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from cibyl.utils.sorting import Comparator
+
+
+class SortJobsByName(Comparator):
+    def compare(self, left, right):
+        """
+
+        :param left:
+        :type left: :class:`cibyl.models.ci.zuul.job.Job`
+        :param right:
+        :type right: :class:`cibyl.models.ci.zuul.job.Job`
+        :return:
+        """
+        if left.name == right.name:
+            return 0
+
+        return -1 if left.name < right.name else 1

--- a/cibyl/outputs/cli/ci/system/sorting/jobs.py
+++ b/cibyl/outputs/cli/ci/system/sorting/jobs.py
@@ -21,12 +21,15 @@ class SortJobsByName(Comparator):
         """
 
         :param left:
-        :type left: :class:`cibyl.models.ci.zuul.job.Job`
+        :type left: :class:`cibyl.models.ci.base.job.Job`
         :param right:
-        :type right: :class:`cibyl.models.ci.zuul.job.Job`
+        :type right: :class:`cibyl.models.ci.base.job.Job`
         :return:
         """
-        if left.name == right.name:
+        name_left = left.name.value.lower()
+        name_right = right.name.value.lower()
+
+        if name_left == name_right:
             return 0
 
-        return -1 if left.name < right.name else 1
+        return -1 if name_left < name_right else 1

--- a/cibyl/utils/sorting.py
+++ b/cibyl/utils/sorting.py
@@ -1,0 +1,72 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from abc import ABC, abstractmethod
+
+from overrides import overrides
+
+
+class Comparator(ABC):
+    @abstractmethod
+    def compare(self, left, right):
+        raise NotImplementedError
+
+
+class NativeComparator(Comparator):
+    @overrides
+    def compare(self, left, right):
+        if left == right:
+            return 0
+
+        return -1 if left < right else 1
+
+
+class SortingAlgorithm(ABC):
+    def __init__(self, comparator=NativeComparator()):
+        self._comparator = comparator
+
+    @abstractmethod
+    def sort(self, iterable):
+        raise NotImplementedError
+
+
+class BubbleSortAlgorithm(SortingAlgorithm):
+    @overrides
+    def sort(self, iterable):
+        def compare(lft, rght):
+            return self._comparator.compare(lft, rght)
+
+        result = list(iterable)  # Do not affect the original list
+
+        for i in range(len(result)):
+            for j in range(0, len(result) - i - 1):
+                if compare(result[j], result[j + 1]) > 0:
+                    temp = result[j]
+
+                    # Swap the two cells
+                    result[j] = result[j + 1]
+                    result[j + 1] = temp
+
+        return result
+
+
+def sort(iterable, algorithm=BubbleSortAlgorithm()):
+    return algorithm.sort(iterable)
+
+
+def nsort(iterable, algorithm=BubbleSortAlgorithm()):
+    result = sort(iterable, algorithm)
+    result.reverse()
+    return result

--- a/cibyl/utils/sorting.py
+++ b/cibyl/utils/sorting.py
@@ -19,12 +19,31 @@ from overrides import overrides
 
 
 class Comparator(ABC):
+    """A comparison function, used to impose a total ordering on some
+    collection of objects. Comparators can be passed to sorting algorithms
+    to control the order of iterable collections.
+    """
+
     @abstractmethod
     def compare(self, left, right):
+        """Compares the two arguments for order.
+
+        :param left: First object to be compared.
+        :type left: Any
+        :param right: Second object to be compared.
+        :type right: Any
+        :return: A negative integer, zero or a positive integer as the left
+            argument is less than, equal to or greater than the right one.
+        :rtype: int
+        """
         raise NotImplementedError
 
 
 class NativeComparator(Comparator):
+    """Implements a comparison function using Python's native resources.
+    This is, comparison of two objects will be performed through their
+    '__eq__' and '__lt__' methods."""
+
     @overrides
     def compare(self, left, right):
         if left == right:
@@ -34,15 +53,38 @@ class NativeComparator(Comparator):
 
 
 class SortingAlgorithm(ABC):
+    """Base class for a sorting algorithms. These algorithms are used to
+    reorder the elements of a collection following a set of certain rules.
+    These rules are defines by the comparator in use.
+    """
+
     def __init__(self, comparator=NativeComparator()):
+        """Constructor.
+
+        :param comparator: Comparison function this uses to determine order.
+        :type comparator: :class:`Comparator`
+        """
         self._comparator = comparator
 
     @abstractmethod
     def sort(self, iterable):
+        """Sorts the given collection in ascending order. The original
+        collection remains untouched, instead, a sorted copy of it is returned.
+
+        :param iterable: The collection to be sorted.
+        :type iterable: :class:`typing.Iterable`
+        :return: The same collection, sorted following this algorithm's
+            comparator.
+        :rtype: list
+        """
         raise NotImplementedError
 
 
 class BubbleSortAlgorithm(SortingAlgorithm):
+    """Implementation of the Bubble-Sort algorithm. See more at:
+    https://en.wikipedia.org/wiki/Bubble_sort
+    """
+
     @overrides
     def sort(self, iterable):
         def compare(lft, rght):
@@ -63,10 +105,23 @@ class BubbleSortAlgorithm(SortingAlgorithm):
 
 
 def sort(iterable, algorithm=BubbleSortAlgorithm()):
+    """Shortcut for sorting the elements of a collection.
+
+    :param iterable: The collection to sort.
+    :type iterable: :class:`typing.Iterable`
+    :param algorithm: The algorithm that will be used to sort the collection.
+        Contains the comparator used to determine order.
+    :type algorithm: :class:`SortingAlgorithm`
+    :return: A copy of the input collection, sorted by the algorithm.
+    :rtype: list
+    """
     return algorithm.sort(iterable)
 
 
 def nsort(iterable, algorithm=BubbleSortAlgorithm()):
+    """Same as :func:`sort`, but this one reverses the collection before
+    returning it. Use this function to get sorting in descending order.
+    """
     result = sort(iterable, algorithm)
     result.reverse()
     return result

--- a/tests/e2e/test_jenkins.py
+++ b/tests/e2e/test_jenkins.py
@@ -16,6 +16,7 @@
 import sys
 
 from cibyl.cli.main import main
+from cibyl.utils.strings import IndentedTextBuilder
 from tests.e2e.containers.jenkins import JenkinsContainer
 from tests.e2e.fixtures import EndToEndTest
 
@@ -42,3 +43,28 @@ class TestJenkins(EndToEndTest):
             main()
 
             self.assertIn('Total jobs found in query: 2', self.stdout)
+
+    def test_jobs_are_alphabetically_ordered(self):
+        """Checks that jobs are printed following an alphabetical order.
+        """
+        with JenkinsContainer() as jenkins:
+            jenkins.add_job('this-is-a-job')
+            jenkins.add_job('a-job')
+            jenkins.add_job('job-x')
+
+            sys.argv = [
+                '',
+                '--config', 'tests/e2e/data/configs/jenkins.yaml',
+                '-f', 'text',
+                '--jobs'
+            ]
+
+            main()
+
+            expected = IndentedTextBuilder()
+            expected.add('Job: a-job', 2)
+            expected.add('Job: job-x', 2)
+            expected.add('Job: this-is-a-job', 2)
+            expected.add('Total jobs found in query: 3', 2)
+
+            self.assertIn(expected.build(), self.stdout)

--- a/tests/e2e/test_zuul.py
+++ b/tests/e2e/test_zuul.py
@@ -514,3 +514,41 @@ class TestDefaults(EndToEndTest):
         self.assertIn('Tenant: example-tenant', self.stdout)
         self.assertIn('Tenant: example-tenant-2', self.stdout)
         self.assertIn('Total tenants found in query: 2', self.stdout)
+
+
+class TestOthers(EndToEndTest):
+    """Tests miscellaneous behaviours of the Zuul source.
+    """
+    zuul = OpenDevZuulContainer()
+
+    @classmethod
+    def setUpClass(cls):
+        cls.zuul.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.zuul.stop()
+
+    def test_jobs_are_alphabetically_ordered(self):
+        """Checks that when printed, jobs are alphabetically ordered.
+        """
+        sys.argv = [
+            '',
+            '--config', 'tests/e2e/data/configs/zuul.yaml',
+            '-f', 'text',
+            '--jobs', '^nodejs-.*'
+        ]
+
+        main()
+
+        expected = IndentedTextBuilder()
+        expected.add('Job: nodejs-npm', 3)
+        expected.add('Job: nodejs-npm-run-docs', 3)
+        expected.add('Job: nodejs-npm-run-lint', 3)
+        expected.add('Job: nodejs-npm-run-test', 3)
+        expected.add('Job: nodejs-run-docs', 3)
+        expected.add('Job: nodejs-run-lint', 3)
+        expected.add('Job: nodejs-run-test', 3)
+        expected.add('Job: nodejs-run-test-browser', 3)
+
+        self.assertIn(expected.build(), self.stdout)

--- a/tests/intr/utils/test_sorting.py
+++ b/tests/intr/utils/test_sorting.py
@@ -1,0 +1,120 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.utils.sorting import NativeComparator, BubbleSortAlgorithm, sort, \
+    nsort
+
+
+class TestNativeComparator(TestCase):
+    """Tests for :class:`NativeComparator`.
+    """
+
+    class TestClass:
+        def __init__(self, value):
+            self._value = value
+
+        @property
+        def value(self):
+            return self._value
+
+        def __eq__(self, other):
+            return self.value == other.value
+
+        def __lt__(self, other):
+            return self.value <= other.value
+
+    def test_are_equal(self):
+        """Checks that two objects are equal if their __eq__ said so.
+        """
+        object1 = TestNativeComparator.TestClass(1)
+        object2 = TestNativeComparator.TestClass(1)
+
+        comparator = NativeComparator()
+
+        self.assertEqual(0, comparator.compare(object1, object2))
+
+    def test_is_less_than(self):
+        """Checks that an object is less that another if their __lt__ said
+        so.
+        """
+        object1 = TestNativeComparator.TestClass(0)
+        object2 = TestNativeComparator.TestClass(1)
+
+        comparator = NativeComparator()
+
+        self.assertEqual(-1, comparator.compare(object1, object2))
+
+    def test_is_greater_than(self):
+        """Checks that an object is greater that another if their __lt__ said
+        so.
+        """
+        object1 = TestNativeComparator.TestClass(2)
+        object2 = TestNativeComparator.TestClass(1)
+
+        comparator = NativeComparator()
+
+        self.assertEqual(1, comparator.compare(object1, object2))
+
+
+class TestBubbleSortAlgorithm(TestCase):
+    """Tests for :class:`BubbleSortAlgorithm`.
+    """
+
+    def test_sorts_from_lesser_to_greater(self):
+        """Checks that the sorter sorts properly going from the lowest
+        value to the highest.
+        """
+        unsorted = [13, 3, -8, 7, -2]
+
+        sorter = BubbleSortAlgorithm()
+
+        self.assertEqual(
+            [-8, -2, 3, 7, 13],
+            sorter.sort(unsorted)
+        )
+
+
+class TestSort(TestCase):
+    """Tests for :func:`sort`.
+    """
+
+    def test_sorts_from_lesser_to_greater(self):
+        """Checks that the function sorts properly going from the lowest
+        value to the highest.
+        """
+        unsorted = [13, 3, -8, 7, -2]
+
+        self.assertEqual(
+            [-8, -2, 3, 7, 13],
+            sort(unsorted)
+        )
+
+
+class TestNSort(TestCase):
+    """Tests for :func:`nsort`.
+    """
+
+    def test_sorts_from_greater_to_lessed(self):
+        """Checks that the function sorts properly going from the highest
+        value to the lowest.
+        """
+        unsorted = [13, 3, -8, 7, -2]
+
+        self.assertEqual(
+            [13, 7, 3, -2, -8],
+            nsort(unsorted)
+        )

--- a/tests/intr/utils/test_sorting.py
+++ b/tests/intr/utils/test_sorting.py
@@ -15,8 +15,8 @@
 """
 from unittest import TestCase
 
-from cibyl.utils.sorting import NativeComparator, BubbleSortAlgorithm, sort, \
-    nsort
+from cibyl.utils.sorting import (BubbleSortAlgorithm, NativeComparator, nsort,
+                                 sort)
 
 
 class TestNativeComparator(TestCase):

--- a/tests/unit/outputs/cli/ci/system/sorting/__init__.py
+++ b/tests/unit/outputs/cli/ci/system/sorting/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/unit/outputs/cli/ci/system/sorting/test_jobs.py
+++ b/tests/unit/outputs/cli/ci/system/sorting/test_jobs.py
@@ -27,10 +27,10 @@ class TestSortJobsByName(TestCase):
         """Checks that two jobs are equal if they share the same name.
         """
         job1 = Mock()
-        job1.name = 'job'
+        job1.name.value = 'job'
 
         job2 = Mock()
-        job2.name = 'job'
+        job2.name.value = 'job'
 
         comparator = SortJobsByName()
 
@@ -43,10 +43,10 @@ class TestSortJobsByName(TestCase):
         """Checks that the comparator will sort jobs in alphabetical order.
         """
         job1 = Mock()
-        job1.name = 'A'
+        job1.name.value = 'A'
 
         job2 = Mock()
-        job2.name = 'B'
+        job2.name.value = 'B'
 
         comparator = SortJobsByName()
 

--- a/tests/unit/outputs/cli/ci/system/sorting/test_jobs.py
+++ b/tests/unit/outputs/cli/ci/system/sorting/test_jobs.py
@@ -1,0 +1,61 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.outputs.cli.ci.system.sorting.jobs import SortJobsByName
+
+
+class TestSortJobsByName(TestCase):
+    """Tests for :class:`SortJobsByName`.
+    """
+
+    def test_names_are_equal(self):
+        """Checks that two jobs are equal if they share the same name.
+        """
+        job1 = Mock()
+        job1.name = 'job'
+
+        job2 = Mock()
+        job2.name = 'job'
+
+        comparator = SortJobsByName()
+
+        self.assertEqual(
+            0,
+            comparator.compare(job1, job2)
+        )
+
+    def test_alphabetical_order(self):
+        """Checks that the comparator will sort jobs in alphabetical order.
+        """
+        job1 = Mock()
+        job1.name = 'A'
+
+        job2 = Mock()
+        job2.name = 'B'
+
+        comparator = SortJobsByName()
+
+        self.assertEqual(
+            -1,
+            comparator.compare(job1, job2)
+        )
+
+        self.assertEqual(
+            1,
+            comparator.compare(job2, job1)
+        )


### PR DESCRIPTION
On this pull request:
- Adding a set of utilities to sort lists of objects.
- Adding a sorter that sorts jobs alphabetically based on their name.
- Integrating that sorter on both Jenkins and Zuul printers.