### PR TITLE
Print all features when passing --features

### DIFF
--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -167,10 +167,10 @@ class Orchestrator:
         """Read user-requested features and setup the right argument to query
         the information for them."""
         user_features = self.parser.ci_args.get('features')
-        if not user_features:
+        if user_features is None:
             return []
         load_features()
-        if user_features and not user_features.value:
+        if not user_features.value:
             # throw error in case cibyl is called with --features argument but
             # without any specified feature
             features_string = get_string_all_features()


### PR DESCRIPTION
The code that checked whether the user had passed --features without
specifying any feature relied on the truthiness of the argument. Due to
the incorporation of a __bool__ method that uses its value, this check
was not producing the same output. This change makes the check more
explicit by only check if the argument is None (that is, if the user has
not passed --features argument) and returning early, displaying
again the error message with the list of all features.
