### PR TITLE
Changing output of the ReleaseFinder class.

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/actions.py
+++ b/cibyl/plugins/openstack/sources/zuul/actions.py
@@ -142,9 +142,11 @@ class DeploymentGenerator:
 
         def get_release():
             if any(term in kwargs for term in ('spec', 'release')):
-                return release_finder.find_release_for(variant)
+                release = release_finder.find_release_for(variant)
 
-            # Nothing means to ignore this field.
+                return release if release else 'N/A'
+
+            # Nothing means to not output this field.
             return ''
 
         release_finder = self._tools.release_finder

--- a/cibyl/plugins/openstack/sources/zuul/release.py
+++ b/cibyl/plugins/openstack/sources/zuul/release.py
@@ -58,8 +58,8 @@ class ReleaseFinder:
 
         :param variant: The variant to consult.
         :type variant: :class:`cibyl.sources.zuul.transactions.VariantResponse`
-        :return: The release if it was found, 'N/A' if not.
-        :rtype: str
+        :return: The release if it was found, None if not.
+        :rtype: str or None
         """
         LOG.debug("Searching for release on variant: '%s'.", variant.name)
 
@@ -69,4 +69,4 @@ class ReleaseFinder:
             if search_term in variables:
                 return str(variables[search_term])
 
-        return 'N/A'
+        return None

--- a/tests/unit/plugins/openstack/sources/zuul/test_release.py
+++ b/tests/unit/plugins/openstack/sources/zuul/test_release.py
@@ -95,7 +95,7 @@ class TestReleaseFinder(TestCase):
         finder = ReleaseFinder(search_terms=[])
 
         self.assertEqual(
-            'N/A',
+            None,
             finder.find_release_for(variant)
         )
 


### PR DESCRIPTION
Just a small change I rescued from a branch I had. Not much value by itself, the idea is to not force the 'N/A' value in case the release is not found. In the branch I had there were other classes similar to this one that followed this same approach.