### PR TITLE
Allowing 'json' as an option for --output-format

### DIFF
--- a/cibyl/cli/output.py
+++ b/cibyl/cli/output.py
@@ -23,6 +23,8 @@ class OutputStyle(Enum):
     """A human-readable text based format."""
     COLORIZED = 1
     """Same as :attr:`TEXT` but colored for easier read."""
+    JSON = 2
+    """A machine-readable text based format."""
 
     @staticmethod
     def from_key(key):
@@ -31,6 +33,7 @@ class OutputStyle(Enum):
         Map of known keys:
             * 'text' -> OutputStyle.TEXT
             * 'colorized' -> OutputStyle.COLORIZED
+            * 'json' -> OutputStyle.JSON
 
         :param key: The key to get the style for.
         :type key: Any
@@ -43,5 +46,7 @@ class OutputStyle(Enum):
             return OutputStyle.TEXT
         elif key == 'colorized':
             return OutputStyle.COLORIZED
+        elif key == 'json':
+            return OutputStyle.JSON
         else:
             raise NotImplementedError(f'Unknown format: {key}')

--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -80,7 +80,7 @@ class Parser:
             choices=("terminal", "file", "both"),
             help='Where to write the output, default is both')
         self.argument_parser.add_argument(
-            '--output-format', '-f', choices=("text", "colorized"),
+            '--output-format', '-f', choices=("text", "colorized", "json"),
             dest="output_style", default="colorized",
             help="Sets the output format."
         )

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -14,11 +14,9 @@
 #    under the License.
 """
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-import cibyl
-from cibyl.cli.main import raw_parsing
-from cibyl.cli.output import OutputStyle
+from cibyl.cli.main import raw_parsing, OutputStyle
 from cibyl.exceptions.cli import InvalidArgument
 
 
@@ -33,12 +31,12 @@ class TestRawParsing(TestCase):
 
         self.assertTrue(OutputStyle.COLORIZED, args['output_style'])
 
-    def test_f_arg(self):
+    @patch('cibyl.cli.main.OutputStyle.from_key')
+    def test_f_arg(self, parse_call: Mock):
         """Checks that user's input is read.
         """
         style = 'raw'
 
-        parse_call = cibyl.cli.main.OutputStyle.from_key = Mock()
         parse_call.return_value = OutputStyle.TEXT
 
         args = raw_parsing(['', '-f', style])
@@ -47,12 +45,12 @@ class TestRawParsing(TestCase):
 
         parse_call.assert_called_once_with(style)
 
-    def test_output_arg(self):
+    @patch('cibyl.cli.main.OutputStyle.from_key')
+    def test_output_arg(self, parse_call: Mock):
         """Checks that --output-format also works.
         """
         output = 'raw'
 
-        parse_call = cibyl.cli.main.OutputStyle.from_key = Mock()
         parse_call.return_value = OutputStyle.TEXT
 
         args = raw_parsing(['', '--output-format', output])
@@ -61,7 +59,8 @@ class TestRawParsing(TestCase):
 
         parse_call.assert_called_once_with(output)
 
-    def test_invalid_output_arg(self):
+    @patch('cibyl.cli.main.OutputStyle.from_key')
+    def test_invalid_output_arg(self, parse_call: Mock):
         """Checks reaction to unknown style.
         """
 
@@ -70,7 +69,6 @@ class TestRawParsing(TestCase):
 
         output = 'invalid'
 
-        parse_call = cibyl.cli.main.OutputStyle.from_key = Mock()
         parse_call.side_effect = raise_error
 
         with self.assertRaises(InvalidArgument):

--- a/tests/unit/cli/test_output.py
+++ b/tests/unit/cli/test_output.py
@@ -1,0 +1,48 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.cli.output import OutputStyle
+
+
+class TestFromKey(TestCase):
+    """Tests for :func:`OutputStyle.from_key`.
+    """
+
+    def test_text_options(self):
+        """Checks that the keys for the TEXT output option return that option.
+        """
+        self.assertEqual(
+            OutputStyle.TEXT,
+            OutputStyle.from_key('text')
+        )
+
+    def test_colorized_options(self):
+        """Checks that the keys for the COLORIZED output option return that
+        option.
+        """
+        self.assertEqual(
+            OutputStyle.COLORIZED,
+            OutputStyle.from_key('colorized')
+        )
+
+    def test_json_options(self):
+        """Checks that the keys for the JSON output option return that option.
+        """
+        self.assertEqual(
+            OutputStyle.JSON,
+            OutputStyle.from_key('json')
+        )


### PR DESCRIPTION
At this moment the option will end with an exception on the publisher, as there is no printer yet to handle the request. The CLI is ready to accept the value though and everything is parsed for it to be accepted.