### PR TITLE
Remove --job-url argument

### DIFF
--- a/cibyl/models/ci/base/job.py
+++ b/cibyl/models/ci/base/job.py
@@ -35,9 +35,7 @@ class Job(Model):
         },
         'url': {
             'attr_type': str,
-            'arguments': [Argument(name='--job-url', arg_type=str,
-                                   func='get_jobs',
-                                   description="Job URL")]
+            'arguments': []
         },
         'builds': {
             'attr_type': Build,

--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -75,9 +75,6 @@ class ElasticSearch(ServerSource):
         if 'jobs' in kwargs:
             jobs_to_search = kwargs.get('jobs').value
             key_filter = 'job_name'
-        if 'job_url' in kwargs:
-            jobs_to_search = kwargs.get('job_url').value
-            key_filter = 'job_url'
         jobs_scope_arg = kwargs.get('jobs_scope')
         if jobs_scope_arg:
             jobs_scope_pattern = re.compile(jobs_scope_arg)

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -90,12 +90,6 @@ def filter_jobs(jobs_found: List[Dict], **kwargs):
         checks_to_apply.append(partial(satisfy_regex_match, pattern=pattern,
                                        field_to_check="name"))
 
-    job_urls = kwargs.get('job_url')
-    if job_urls and job_urls.value:
-        checks_to_apply.append(partial(satisfy_exact_match,
-                                       user_input=job_urls,
-                                       field_to_check="url"))
-
     spec_jobs_name_arg = kwargs.get('spec')
     if spec_jobs_name_arg and spec_jobs_name_arg.value:
         checks_to_apply.append(partial(satisfy_exact_match,

--- a/cibyl/sources/zuul/actions.py
+++ b/cibyl/sources/zuul/actions.py
@@ -130,8 +130,6 @@ def handle_query(zuul, **kwargs):
         Name of the tenants to query. Type: AttributeListValue[str].
     :key jobs:
         Name of the jobs to query. Type: AttributeListValue[str].
-    :key job_url:
-        URL of the jobs to query. Type: AttributeListValue[str].
     :key variants:
         Will fetch job variants too. Type: None.
     :key builds:

--- a/cibyl/sources/zuul/queries/jobs.py
+++ b/cibyl/sources/zuul/queries/jobs.py
@@ -38,9 +38,6 @@ def perform_jobs_query(zuul, **kwargs):
             if targets:
                 jobs.with_name(*targets)
 
-        if 'job_url' in kwargs:
-            jobs.with_url(*kwargs['job_url'].value)
-
         result += jobs.get()
 
     return result

--- a/cibyl/utils/source_methods_store.py
+++ b/cibyl/utils/source_methods_store.py
@@ -19,7 +19,7 @@ class SourceMethodsStore:
     """Store the source queries that have been performed. This will allow
     us to avoid sending multiple times the same queries if there are multiple
     arguments that are associated with the same function (for example --builds
-    and --build-status or --jobs and --jobs-url).
+    and --build-status).
     """
     def __init__(self):
         self.cache = {}

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -56,13 +56,6 @@ Arguments Matrix
      - |:ballot_box_with_check:|
      - |:ballot_box_with_check:|
      - |:black_square_button:|
-   * - --job-url
-     - Job URL
-     - |:ballot_box_with_check:|
-     - |:ballot_box_with_check:|
-     - |:ballot_box_with_check:|
-     - |:x:|
-     - |:x:|
    * - --builds
      - | Build numbers
        | Default: all builds

--- a/tests/e2e/test_zuul.py
+++ b/tests/e2e/test_zuul.py
@@ -178,31 +178,6 @@ class TestQueryLevel(EndToEndTest):
             self.stdout
         )
 
-    def test_get_jobs_by_url(self):
-        """Checks retrieved jobs by "--jobs --job-url url" flag.
-        """
-        sys.argv = [
-            '',
-            '--config', 'tests/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
-            '-vv',
-            '--tenants', '^(example-tenant)$',
-            '--jobs', '--job-url',
-            'http://localhost:9000/t/example-tenant/job/build-docker-image'
-        ]
-
-        main()
-
-        self.assertIn(
-            'Job: build-docker-image',
-            self.stdout
-        )
-
-        self.assertIn(
-            "Total jobs found in query for tenant 'example-tenant': 1",
-            self.stdout
-        )
-
     def test_get_job_url(self):
         """Checks that "-v" will print a job's URL.
         """

--- a/tests/intr/sources/zuul/test_query.py
+++ b/tests/intr/sources/zuul/test_query.py
@@ -392,62 +392,6 @@ class TestHandleQuery(TestCase):
             result
         )
 
-    def test_get_jobs_by_url(self):
-        """Checks the '--jobs --job_url pattern1 pattern2" option.
-        """
-        job1 = Mock()
-        job1.name = 'job1'
-        job1.url = 'url1'
-        job1.pipelines = Mock()
-        job1.pipelines.return_value = []
-
-        job2 = Mock()
-        job2.name = 'job2'
-        job2.url = 'url2'
-        job2.pipelines = Mock()
-        job2.pipelines.return_value = []
-
-        job3 = Mock()
-        job3.name = 'job3'
-        job3.url = 'url3'
-        job3.pipelines = Mock()
-        job3.pipelines.return_value = []
-
-        tenant = Mock()
-        tenant.name = 'tenant1'
-        tenant.projects = Mock()
-        tenant.projects.return_value = []
-        tenant.jobs = Mock()
-        tenant.jobs.return_value = [job1, job2, job3]
-
-        api = Mock()
-        api.tenants = Mock()
-        api.tenants.return_value = [tenant]
-
-        job1.tenant = tenant
-        job2.tenant = tenant
-        job3.tenant = tenant
-
-        in_jobs = Mock()
-        in_jobs.value = None
-
-        in_urls = Mock()
-        in_urls.value = [f'({job1.url})']
-
-        result = handle_query(api, jobs=in_jobs, job_url=in_urls)
-
-        self.assertEqual(
-            {
-                tenant.name: Tenant(
-                    tenant.name,
-                    jobs={
-                        job1.name: Job(job1.name, job1.url)
-                    }
-                )
-            },
-            result
-        )
-
     def test_get_pipelines_through_jobs(self):
         """Checks that "--jobs" also returns the pipelines of the jobs.
         """

--- a/tests/unit/cli/test_query.py
+++ b/tests/unit/cli/test_query.py
@@ -98,14 +98,6 @@ class TestGetQueryType(TestCase):
 
         self.assertEqual(QueryType.BUILDS, get_query_type(**args))
 
-    def test_get_job_url(self):
-        """Checks that "Jobs" is returned for "--job-url"."""
-        args = {
-            'job_url': None
-        }
-
-        self.assertEqual(QueryType.JOBS, get_query_type(**args))
-
     def test_get_variants(self):
         """Checks that "Jobs" is returned for "--variants"."""
         args = {

--- a/tests/unit/sources/test_jenkins.py
+++ b/tests/unit/sources/test_jenkins.py
@@ -1135,52 +1135,6 @@ class TestFilters(TestCase):
                     ]
         self.assertEqual(jobs_filtered, expected)
 
-    def test_filter_jobs_job_url(self):
-        """
-            Test that filter_jobs filters the jobs given the user input.
-        """
-        response = [{'_class': 'org..job.WorkflowRun',
-                     'name': "ansible", 'url': 'url1',
-                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
-                    {'_class': 'org..job.WorkflowRun',
-                     'name': "test_jobs", 'url': 'url2',
-                     'lastBuild': {'number': 2, 'result': "FAILURE"}},
-                    {'_class': 'org..job.WorkflowRun',
-                     'name': "ans2", 'url': 'url3',
-                     'lastBuild': {'number': 0, 'result': "FAILURE"}}]
-        jobs = Mock()
-        jobs.value = ["ans2"]
-        job_url = Mock()
-        job_url.value = ["url3"]
-        jobs_filtered = filter_jobs(response, jobs=jobs,
-                                    job_url=job_url)
-        expected = [{'_class': 'org..job.WorkflowRun',
-                     'name': "ans2", 'url': 'url3',
-                     'lastBuild': {'number': 0, 'result': "FAILURE"}}]
-        self.assertEqual(jobs_filtered, expected)
-
-    def test_filter_job_url(self):
-        """
-            Test that filter_jobs filters the jobs given the user input.
-        """
-        response = [{'_class': 'org..job.WorkflowRun',
-                     'name': "ansible", 'url': 'url1',
-                     'lastBuild': {'number': 1, 'result': "SUCCESS"}},
-                    {'_class': 'org..job.WorkflowRun',
-                     'name': "test_jobs", 'url': 'url2',
-                     'lastBuild': {'number': 2, 'result': "FAILURE"}},
-                    {'_class': 'org..job.WorkflowRun',
-                     'name': "ans2", 'url': 'url3',
-                     'lastBuild': {'number': 0, 'result': "FAILURE"}}
-                    ]
-        job_url = Mock()
-        job_url.value = ["url2"]
-        jobs_filtered = filter_jobs(response, job_url=job_url)
-        expected = [{'_class': 'org..job.WorkflowRun',
-                     'name': "test_jobs", 'url': 'url2',
-                     'lastBuild': {'number': 2, 'result': "FAILURE"}}]
-        self.assertEqual(jobs_filtered, expected)
-
     def test_filter_builds_builds_build_id_build_status(self):
         """Test that filter builds filters the builds given the user input."""
         response = [{'_class': 'org..job.WorkflowRun', 'number': 3,


### PR DESCRIPTION
Since no use case was identified for the --job-url argument, this change
removes it. This means removing the argument from the Job API, and the
filter implemented by the Jenkins, Zuul and Elasticsearch sources, as
well as their tests cases.
