### PR TITLE
Removing deprecation warnings from ansible-lint.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+deprecation_warnings = False


### PR DESCRIPTION
The Ansible linter will no longer complain that we are using Python 3.6 and that it will be deprecated in favor of Python 3.8. There is not much we can do about that.