### PR TITLE
Add type hints

### DIFF
--- a/cibyl/cli/argument.py
+++ b/cibyl/cli/argument.py
@@ -13,7 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from typing import Union
+import argparse
+from typing import List, Type, Union
 
 from cibyl.cli.ranged_argument import (EXPRESSION_PATTERN, RANGE_OPERATORS,
                                        VALID_OPS, Range)
@@ -24,12 +25,13 @@ class Argument():
     """Represents Parser's argument"""
 
     # pylint: disable=too-many-arguments,too-many-instance-attributes
-    def __init__(self, name: str, arg_type: object, description: str,
-                 nargs: Union[str, int] = 1, func: str = None,
-                 populated: bool = False, level: int = 0,
-                 ranged: bool = False,
-                 value: object = None, default: object = None):
+    def __init__(self, name: str, arg_type: Union[Type, argparse.FileType],
+                 description: str, nargs: Union[str, int] = 1,
+                 func: str = None, populated: bool = False, level: int = 0,
+                 ranged: bool = False, value: List[str] = None,
+                 default: object = None):
         self.name = name
+
         self.arg_type = arg_type
         self.description = description
         self.nargs = nargs
@@ -43,7 +45,7 @@ class Argument():
             self.value = value
         self.default = default
 
-    def parse_ranges(self, expressions):
+    def parse_ranges(self, expressions: List[str]) -> List[Range]:
         parsed_expressions = []
         if not isinstance(expressions, list):
             raise InvalidArgument(f"Argument '{self.name}' should accept "

--- a/cibyl/cli/interactions.py
+++ b/cibyl/cli/interactions.py
@@ -15,14 +15,12 @@
 """
 
 
-def ask_yes_no_question(question):
+def ask_yes_no_question(question: str) -> bool:
     """Prints a question on the CLI that the user must respond
     with a yes or no.
 
     :param question: Text of the question. Include question mark on it.
-    :type question: str
     :return: Whether the user said 'y' (True) or 'n' (False).
-    :rtype: bool
     """
     answer = ''
 

--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -15,6 +15,7 @@
 """
 import logging
 import sys
+from typing import List
 
 from cibyl.cli.output import OutputStyle
 from cibyl.exceptions import CibylException
@@ -28,12 +29,11 @@ from cibyl.utils.logger import configure_logging
 LOG = logging.getLogger(__name__)
 
 
-def raw_parsing(arguments):
+def raw_parsing(arguments: List[str]) -> dict:
     """Returns config file path if one was passed with --config argument
 
     :param arguments: A list of strings representing the arguments and their
                       values, defaults to None
-    :type arguments: str, optional
     """
     args = {'config_file_path': None, 'help': False,
             "log_file": "cibyl_output.log", "log_mode": "both",
@@ -68,7 +68,7 @@ def raw_parsing(arguments):
     return args
 
 
-def setup_output_format(args):
+def setup_output_format(args: dict) -> None:
     """Parse the OutputStyle specified by the user."""
     user_output_format = args["output_style"]
     try:
@@ -78,7 +78,7 @@ def setup_output_format(args):
         raise InvalidArgument(msg) from None
 
 
-def main():
+def main() -> None:
     """CLI main entry."""
     # We parse it from sys.argv instead of argparse parser because we want
     # to run the app parser only once, after we update it with the loaded

--- a/cibyl/cli/output.py
+++ b/cibyl/cli/output.py
@@ -27,7 +27,7 @@ class OutputStyle(Enum):
     """A machine-readable text based format."""
 
     @staticmethod
-    def from_key(key):
+    def from_key(key: str) -> 'OutputStyle':
         """Parses a key into an :class:`OutputStyle`.
 
         Map of known keys:
@@ -36,9 +36,7 @@ class OutputStyle(Enum):
             * 'json' -> OutputStyle.JSON
 
         :param key: The key to get the style for.
-        :type key: Any
         :return: The correspondent style.
-        :rtype: :class:`OutputStyle`
         :raise NotImplementedError: If no style is present for the
         given key.
         """

--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -15,6 +15,7 @@
 """
 import argparse
 import logging
+from typing import Callable, List
 
 from cibyl.cli.argument import Argument
 
@@ -26,8 +27,8 @@ class CustomAction(argparse.Action):
     whether an argument data is populated, the function associated
     with the argument and the level in the models.
     """
-    def __init__(self, *args, func=None, populated=False, level=-1,
-                 ranged=False, **kwargs):
+    def __init__(self, *args, func: Callable = None, populated: bool = False,
+                 level: int = -1, ranged: bool = False, **kwargs):
         """
         argparse custom action.
         :param func: the function the argument is associated with
@@ -38,7 +39,9 @@ class CustomAction(argparse.Action):
         self.ranged = ranged
         super().__init__(*args, **kwargs)
 
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, parser: argparse.ArgumentParser,
+                 namespace: argparse.Namespace, values: List[str],
+                 option_string: str = None):
         if self.default and not values:
             values = self.default
         setattr(namespace, self.dest, Argument(
@@ -91,19 +94,18 @@ class Parser:
             help="Causes Cibyl to print more debug messages. "
                  "Adding multiple -v will increase the verbosity.")
 
-    def print_help(self):
+    def print_help(self) -> None:
         """Call argparse's print_help method to show the help message with the
         arguments that are currently added."""
         self.argument_parser.print_help()
 
-    def parse(self, arguments=None):
+    def parse(self, arguments: List[Argument] = None) -> None:
         """Parse application and CI models arguments.
 
         Sets the attributes ci_args and app_args with dictionaries
         including the parsed arguments.
 
         :param arguments: Arguments to parse
-        :type arguments: list
         """
         arguments = vars(self.argument_parser.parse_args(arguments))
         # Keep only the used arguments
@@ -113,15 +115,13 @@ class Parser:
                          arguments.items() if arg_value is not None and not
                          isinstance(arg_value, Argument)}
 
-    def get_group(self, group_name: str):
+    def get_group(self, group_name: str) -> argparse._ArgumentGroup:
         """Returns the argument parser group based on a given group_name
 
         :param group_name: The name of the group
-        :type group_name: str
 
         :return: An argparse argument group if it exists and matches
                  the given group name, otherwise returns None
-        :rtype: argparse._ArgumentGroup
         """
         # pylint: disable=protected-access
         # Access the private member '_action_groups' to check
@@ -131,13 +131,13 @@ class Parser:
                 return action_group
         return None
 
-    def extend(self, arguments: list, group_name: str, level: int = 0):
+    def extend(self, arguments: List[Argument], group_name: str,
+               level: int = 0) -> None:
         """Adds arguments to a specific argument parser group.
 
         :param arguments: A list of argument objects
-        :type arguments: list[argument]
         :param group_name: The name of the argument parser group
-        :type group_name: str
+        :param level: The level of the arguments in models
         """
         group = self.get_group(group_name)
         # If the group doesn't exists, we would like to add it

--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -44,7 +44,7 @@ class QuerySelector:
     both core argument and plugin provided ones."""
     query_selector_functions = []
 
-    def get_query_type_core(self, **kwargs):
+    def get_query_type_core(self, **kwargs) -> QueryType:
         """Deduces the type of query from a set of arguments related to cibyl
         core ci models.
 
@@ -57,7 +57,6 @@ class QuerySelector:
         :return: The lowest query level possible. For example,
             if both 'tenants' and 'builds' are requested, this will choose
             'builds' over 'tenants'.
-        :rtype: :class:`QueryType`
         """
 
         result = QueryType.NONE
@@ -87,7 +86,7 @@ class QuerySelector:
 
         return result
 
-    def get_type_query(self, **kwargs):
+    def get_type_query(self, **kwargs) -> QueryType:
         """Deduce the type of query from the given arguments, taking into
         account arguments provided by the plugins, if present. It will return
         the largest query type provided by either the core types or the
@@ -100,7 +99,7 @@ class QuerySelector:
         return max(core_query, plugins_query)
 
 
-def get_query_type(**kwargs):
+def get_query_type(**kwargs) -> QueryType:
     """Deduces the type of query from a set of arguments.
 
     :param kwargs: The arguments.
@@ -112,7 +111,6 @@ def get_query_type(**kwargs):
     :return: The lowest query level possible. For example,
         if both 'tenants' and 'builds' are requested, this will choose
         'builds' over 'tenants'.
-    :rtype: :class:`QueryType`
     """
     query_selector = QuerySelector()
     return query_selector.get_type_query(**kwargs)

--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -16,6 +16,7 @@
 import logging
 import os
 from collections import UserDict
+from typing import Callable
 
 import rfc3987
 
@@ -30,7 +31,7 @@ from cibyl.utils.net import DownloadError, download_file
 LOG = logging.getLogger(__name__)
 
 
-def _ask_user_for_overwrite():
+def _ask_user_for_overwrite() -> bool:
     """Prints a question on the command line asking whether the user would
     like to continue with a file overwrite or not.
 
@@ -51,9 +52,8 @@ class Config(UserDict):
     and the app.
 
     :param data: configuration data
-    :type data: dict
     """
-    def __init__(self, data: object = None):
+    def __init__(self, data: dict = None):
         """Config Constructor"""
         if data:
             self.data = data
@@ -72,21 +72,21 @@ class Config(UserDict):
 class AppConfig(Config):
     """Representation of a Cybil's configuration file"""
 
-    def __init__(self, data: object = None):
+    def __init__(self, data: dict = None):
         """AppConfig Constructor"""
         Config.__init__(self, data=data)
 
     @property
-    def environments(self):
+    def environments(self) -> dict:
         """dict: environments section from the configuration data."""
         return self.data.get('environments', {})
 
     @property
-    def plugins(self):
+    def plugins(self) -> list:
         """dict: plugins section from the configuration data."""
         return self.data.get('plugins', [])
 
-    def load(self, path=None):
+    def load(self, path: str = None) -> None:
         """Loads the content of a configuration file/object and creates
         a reference to environments.
 
@@ -97,7 +97,7 @@ class AppConfig(Config):
         """
         super().load_from_path(path)
 
-    def verify(self):
+    def verify(self) -> None:
         """Verifies the configuration content by the context of the
         application (using concepts like environments, systems and sources.
 
@@ -140,9 +140,7 @@ class AppConfig(Config):
         """Checks whether a given system includes definition of sources.
 
         :param system_name: The name of a given system
-        :type system_name: str
         :param system_data: The configuration dict of a system
-        :type system_data: dict
         :raise MissingSystemSources: If sources are not defined for a system
         """
         if 'sources' not in system_data:
@@ -170,15 +168,13 @@ class ConfigFactory:
     """
 
     @staticmethod
-    def from_path(path):
+    def from_path(path: str) -> dict:
         """Build a configuration from a random path. This path may be a URL,
         a file path or any other. If the path is 'None', then this will look
         for the first definition available among the default paths.
 
         :param path: The path to get the definition from.
-        :type path: str or None
         :return: The configuration instance.
-        :rtype: :class:`Config`
         :raise ConfigurationNotFound: If no definition could be retrieved.
         :raise EmptyConfiguration: If configuration file is empty.
         """
@@ -191,13 +187,11 @@ class ConfigFactory:
         return ConfigFactory.from_file(path)
 
     @staticmethod
-    def from_file(file):
+    def from_file(file: str) -> dict:
         """Builds a configuration from a file located on the local filesystem.
 
         :param file: Path to the configuration definition.
-        :type file: str
         :return: The configuration instance
-        :rtype: :class:`Config`
         :raise ConfigurationNotFound: If the file does not exist.
         """
         if not is_file_available(file):
@@ -212,12 +206,11 @@ class ConfigFactory:
         return data
 
     @staticmethod
-    def from_search():
+    def from_search() -> dict:
         """Builds a configuration from the first available definition found
         between the default paths.
 
         :return: The configuration instance
-        :rtype: :class:`Config`
         :raise ConfigurationNotFound: If no definition could be found.
         """
         paths = ConfigFactory.DEFAULT_FILE_PATHS
@@ -229,9 +222,10 @@ class ConfigFactory:
         return ConfigFactory.from_file(file)
 
     @staticmethod
-    def from_url(url,
-                 dest=DEFAULT_USER_PATH,
-                 overwrite_call=_ask_user_for_overwrite):
+    def from_url(
+            url: str, dest: str = DEFAULT_USER_PATH,
+            overwrite_call: Callable[[], bool] = _ask_user_for_overwrite
+    ) -> dict:
         """Builds a configuration from a definition located on a remote
         host. The definition is accessed and downloaded into the provided path.
 
@@ -251,14 +245,11 @@ class ConfigFactory:
             )
 
         :param url: The URL where the file is located at.
-        :type url: str
         :param dest: Path where the definition will be downloaded
             into. Must contain name of the file.
-        :type dest: str
         :param overwrite_call: The function used to ask the user if they
             may overwrite the file. Change to avoid blocker.
         :return: The configuration instance
-        :rtype: :class:`Config`
         :raise ConfigurationNotFound: If the definition could not
             be downloaded.
         """


### PR DESCRIPTION
Add type hints to functions according to PEP-484 [1] in:
-  files in the cli subpackage,
-  config.py and
-  orchestrator.py.

This patch also removes now redundant type hints from
docstrings in the modified files.

[1] https://peps.python.org/pep-0484/