### PR TITLE
Proposal to modify the method for query selection in orchestrator

### DIFF
--- a/cibyl/cli/argument.py
+++ b/cibyl/cli/argument.py
@@ -29,7 +29,7 @@ class Argument():
                  description: str, nargs: Union[str, int] = 1,
                  func: str = None, populated: bool = False, level: int = 0,
                  ranged: bool = False, value: List[str] = None,
-                 default: object = None):
+                 default: object = None, parent_func: str = None):
         self.name = name
 
         self.arg_type = arg_type
@@ -44,6 +44,7 @@ class Argument():
         else:
             self.value = value
         self.default = default
+        self.parent_func = parent_func
 
     def parse_ranges(self, expressions: List[str]) -> List[Range]:
         parsed_expressions = []

--- a/cibyl/cli/argument.py
+++ b/cibyl/cli/argument.py
@@ -14,7 +14,7 @@
 #    under the License.
 """
 import argparse
-from typing import List, Type, Union
+from typing import Any, List, Optional, Type, Union
 
 from cibyl.cli.ranged_argument import (EXPRESSION_PATTERN, RANGE_OPERATORS,
                                        VALID_OPS, Range)
@@ -28,8 +28,8 @@ class Argument():
     def __init__(self, name: str, arg_type: Union[Type, argparse.FileType],
                  description: str, nargs: Union[str, int] = 1,
                  func: str = None, populated: bool = False, level: int = 0,
-                 ranged: bool = False, value: List[str] = None,
-                 default: object = None, parent_func: str = None):
+                 ranged: bool = False, value: Optional[List[str]] = None,
+                 default: Any = None, parent_func: Optional[str] = None):
         self.name = name
 
         self.arg_type = arg_type

--- a/cibyl/models/ci/base/build.py
+++ b/cibyl/models/ci/base/build.py
@@ -37,6 +37,7 @@ class Build(Model):
             'attr_type': str,
             'arguments': [Argument(name='--build-status', arg_type=str,
                                    func='get_builds', nargs='*',
+                                   parent_func='get_jobs',
                                    description="Build status")]
         },
         'duration': {
@@ -48,6 +49,7 @@ class Build(Model):
             'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--tests', arg_type=str,
                                    nargs='*', func='get_tests',
+                                   parent_func='get_builds',
                                    description="Job test")]
         },
         'stages': {

--- a/cibyl/models/ci/base/job.py
+++ b/cibyl/models/ci/base/job.py
@@ -42,9 +42,11 @@ class Job(Model):
             'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--builds', arg_type=str,
                                    nargs="*", func="get_builds",
-                                   description="Job builds"),
+                                   description="Job builds",
+                                   parent_func="get_jobs"),
                           Argument(name='--last-build', arg_type=str,
                                    func='get_builds', nargs=0,
+                                   parent_func="get_jobs",
                                    description="Last build for job")]
         }
     }

--- a/cibyl/models/ci/base/test.py
+++ b/cibyl/models/ci/base/test.py
@@ -32,6 +32,7 @@ class Test(Model):
             'attr_type': str,
             'arguments': [Argument(name='--test-result', arg_type=str,
                                    func='get_tests',
+                                   parent_func='get_builds',
                                    nargs='*',
                                    description="Test result")]
         },
@@ -39,6 +40,7 @@ class Test(Model):
             'attr_type': float,
             'arguments': [Argument(name='--test-duration', arg_type=str,
                                    func='get_tests', nargs='*',
+                                   parent_func='get_builds',
                                    ranged=True,
                                    description="Test duration (in seconds)")]
         },

--- a/cibyl/models/ci/zuul/build.py
+++ b/cibyl/models/ci/zuul/build.py
@@ -69,6 +69,7 @@ class Build(BaseBuild):
                 Argument(
                     name='--tests', arg_type=None,
                     nargs=0, func='get_tests',
+                    parent_func='get_builds',
                     description="Fetch build tests"
                 )
             ]

--- a/cibyl/models/ci/zuul/pipeline.py
+++ b/cibyl/models/ci/zuul/pipeline.py
@@ -35,6 +35,7 @@ class Pipeline(Model):
                     name='--jobs',
                     arg_type=str, nargs='*',
                     description='Jobs belonging to pipeline',
+                    parent_func='get_pipelines',
                     func='get_jobs'
                 )
             ]

--- a/cibyl/models/ci/zuul/project.py
+++ b/cibyl/models/ci/zuul/project.py
@@ -39,6 +39,7 @@ class Project(Model):
                     name='--pipelines',
                     arg_type=str, nargs='*',
                     description='Pipelines belonging to project',
+                    parent_func='get_projects',
                     func='get_pipelines'
                 )
             ]

--- a/cibyl/models/ci/zuul/tenant.py
+++ b/cibyl/models/ci/zuul/tenant.py
@@ -36,6 +36,7 @@ class Tenant(Model):
                     name='--projects',
                     arg_type=str, nargs='*',
                     description='Projects belonging to tenant',
+                    parent_func='get_tenants',
                     func='get_projects'
                 )
             ]
@@ -48,6 +49,7 @@ class Tenant(Model):
                     name='--jobs',
                     arg_type=str, nargs='*',
                     description='Jobs belonging to tenant',
+                    parent_func='get_tenants',
                     func='get_jobs'
                 )
             ]

--- a/cibyl/plugins/openstack/container.py
+++ b/cibyl/plugins/openstack/container.py
@@ -35,6 +35,7 @@ class Container(Model):
             'attr_type': str,
             'arguments': [Argument(name='--container-image', arg_type=str,
                                    nargs="*", func="get_deployment",
+                                   parent_func='get_jobs',
                                    description="Container image")]
         },
         'packages': {

--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -34,9 +34,11 @@ class Deployment(Model):
             'attr_type': str,
             'arguments': [Argument(name='--release', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    description="Deployment release version"),
                           Argument(name='--spec', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    description="Print complete openstack"
                                    " deployment")]
         },
@@ -44,6 +46,7 @@ class Deployment(Model):
             'attr_type': str,
             'arguments': [Argument(name='--infra-type', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    description="Infra type")]
         },
         'nodes': {
@@ -54,11 +57,13 @@ class Deployment(Model):
                                    description="Nodes on the deployment"),
                           Argument(name='--controllers', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    ranged=True,
                                    description="Number of controllers used "
                                                "in the deployment"),
                           Argument(name='--computes', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    ranged=True,
                                    description="Number of computes used "
                                                "in the deployment")]
@@ -68,12 +73,14 @@ class Deployment(Model):
             'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--services', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    description="Services in the deployment")]
         },
         'ip_version': {
             'attr_type': str,
             'arguments': [Argument(name='--ip-version', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    description="Ip version used in the "
                                                "deployment")]
         },
@@ -81,6 +88,7 @@ class Deployment(Model):
             'attr_type': str,
             'arguments': [Argument(name='--topology', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    description="Topology used in the "
                                                "deployment")]
         },
@@ -88,6 +96,7 @@ class Deployment(Model):
             'attr_type': str,
             'arguments': [Argument(name='--ml2-driver', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    description="ML2 driver used in the "
                                                "deployment")]
         },
@@ -117,6 +126,7 @@ class Deployment(Model):
             'attr_type': str,
             'arguments': [Argument(name='--network-backend', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    description="Network backend used in the "
                                                "deployment")]
         },
@@ -124,6 +134,7 @@ class Deployment(Model):
             'attr_type': str,
             'arguments': [Argument(name='--cinder-backend', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    description="Cinder backend used in the "
                                                "deployment")]
         },

--- a/cibyl/plugins/openstack/node.py
+++ b/cibyl/plugins/openstack/node.py
@@ -46,6 +46,7 @@ class Node(Model):
             'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--containers', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    description="Containers on the node")]
         },
         'packages': {
@@ -53,6 +54,7 @@ class Node(Model):
             'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--packages', arg_type=str,
                                    func='get_deployment', nargs='*',
+                                   parent_func='get_jobs',
                                    description="Packages in the node")]
         }
     }

--- a/cibyl/plugins/openstack/package.py
+++ b/cibyl/plugins/openstack/package.py
@@ -31,6 +31,7 @@ class Package(Model):
         'origin': {
             'attr_type': str,
             'arguments': [Argument(name='--package-origin', arg_type=str,
+                                   parent_func='get_jobs',
                                    nargs="*", func="get_deployment",
                                    description="Package origin")]
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ dataclasses~=0.8; python_version<='3.6'
 python-dateutil~=2.8.2
 PyGithub~=1.55
 validators~=0.20.0
+networkx==2.5.1; python_version<='3.6'
+networkx~=2.8.4; python_version>'3.6'

--- a/tests/cibyl/unit/test_orchestrator.py
+++ b/tests/cibyl/unit/test_orchestrator.py
@@ -364,7 +364,6 @@ class TestOrchestratorArgsFilter(TestCase):
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(1, len(args))
         self.assertEqual("get_builds", args[0].func)
-        self.assertEqual("get_jobs", args[0].parent_func)
 
     def test_sort_and_filter_args_jobs_system_jobs(self):
         """Test that the sort_and_filter_args returns the only argument with a
@@ -374,7 +373,6 @@ class TestOrchestratorArgsFilter(TestCase):
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(1, len(args))
         self.assertEqual("get_jobs", args[0].func)
-        self.assertIsNone(args[0].parent_func)
 
     def test_sort_and_filter_args_jobs_system_tests(self):
         """Test that the sort_and_filter_args filters multiple arguments with
@@ -385,7 +383,6 @@ class TestOrchestratorArgsFilter(TestCase):
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(1, len(args))
         self.assertEqual("get_tests", args[0].func)
-        self.assertEqual("get_builds", args[0].parent_func)
 
     def test_sort_and_filter_args_zuul_system(self):
         """Test that the sort_and_filter_args filters multiple arguments with
@@ -396,7 +393,6 @@ class TestOrchestratorArgsFilter(TestCase):
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(1, len(args))
         self.assertEqual("get_builds", args[0].func)
-        self.assertEqual("get_jobs", args[0].parent_func)
 
     def test_sort_and_filter_args_zuul_system_tests(self):
         """Test that the sort_and_filter_args filters multiple arguments with
@@ -407,7 +403,6 @@ class TestOrchestratorArgsFilter(TestCase):
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(1, len(args))
         self.assertEqual("get_tests", args[0].func)
-        self.assertEqual("get_builds", args[0].parent_func)
 
     def test_sort_and_filter_args_zuul_system_multiple_paths(self):
         """Test that the sort_and_filter_args filters handles correctly
@@ -433,9 +428,7 @@ class TestOrchestratorArgsFilterOpenstackPlugin(TestOrchestratorArgsFilter,
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(2, len(args))
         self.assertEqual("get_deployment", args[0].func)
-        self.assertEqual("get_jobs", args[0].parent_func)
         self.assertEqual("get_builds", args[1].func)
-        self.assertEqual("get_jobs", args[1].parent_func)
 
     def test_sort_and_filter_args_jobs_system_deployment_tests(self):
         """Test that the sort_and_filter_args filters multiple arguments with
@@ -446,6 +439,4 @@ class TestOrchestratorArgsFilterOpenstackPlugin(TestOrchestratorArgsFilter,
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(2, len(args))
         self.assertEqual("get_deployment", args[0].func)
-        self.assertEqual("get_jobs", args[0].parent_func)
         self.assertEqual("get_tests", args[1].func)
-        self.assertEqual("get_builds", args[1].parent_func)

--- a/tests/cibyl/unit/test_orchestrator.py
+++ b/tests/cibyl/unit/test_orchestrator.py
@@ -269,9 +269,8 @@ class TestOrchestratorArgumentsFiltering(TestOrchestratorSetup):
         arguments with different func attributes."""
         self.orchestrator.parser.parse(["--jobs", "--builds"])
         args = self.orchestrator.sort_and_filter_args()
-        self.assertEqual(len(args), 2)
+        self.assertEqual(len(args), 1)
         self.assertEqual(args[0].name, "builds")
-        self.assertEqual(args[1].name, "jobs")
 
     def test_filter_args_with_no_func(self):
         """Test that sort_and_filter_args handles properly the case with two
@@ -286,9 +285,8 @@ class TestOrchestratorArgumentsFiltering(TestOrchestratorSetup):
         self.orchestrator.parser.parse(["--jobs", "--builds",
                                         "--build-status"])
         args = self.orchestrator.sort_and_filter_args()
-        self.assertEqual(len(args), 2)
+        self.assertEqual(len(args), 1)
         self.assertEqual(args[0].name, "builds")
-        self.assertEqual(args[1].name, "jobs")
 
     def test_multiple_builds_tests_arguments(self):
         """Test that sort_and_filter_args handles properly the case with two
@@ -298,10 +296,8 @@ class TestOrchestratorArgumentsFiltering(TestOrchestratorSetup):
                                         "--build-status", "--tests",
                                         "--test-result"])
         args = self.orchestrator.sort_and_filter_args()
-        self.assertEqual(len(args), 3)
+        self.assertEqual(len(args), 1)
         self.assertEqual(args[0].name, "tests")
-        self.assertEqual(args[1].name, "builds")
-        self.assertEqual(args[2].name, "jobs")
 
 
 class TestArgumentsFilteringOpenstack(OpenstackPluginWithJobSystem,
@@ -311,9 +307,145 @@ class TestArgumentsFilteringOpenstack(OpenstackPluginWithJobSystem,
     def test_multiple_deployment_arguments_different_level(self):
         """Test that sort_and_filter_args handles properly the case with many
         arguments that should query get_deployment with different levels."""
-        self.orchestrator.parser.parse(["--jobs", "--ip-version",
+        self.orchestrator.parser.parse(["--builds", "--ip-version",
                                         "--packages", '--release'])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(len(args), 2)
         self.assertEqual(args[0].name, "packages")
-        self.assertEqual(args[1].name, "jobs")
+        self.assertEqual(args[1].name, "builds")
+
+
+class TestOrchestratorArgsFilter(TestCase):
+    """Testing sort_and_filter_args method of the Orchestrator class."""
+
+    def setUp(self):
+        self.orchestrator = Orchestrator()
+
+        self.valid_single_jenkins_env_config_data = {
+            'environments': {
+                'env1': {
+                    'system1': {
+                        'system_type': 'jenkins',
+                        'sources': {}}}}}
+
+        self.valid_single_zuul_env_config_data = {
+            'environments': {
+                'env1': {
+                    'system1': {
+                        'system_type': 'zuul',
+                        'sources': {}}}}}
+
+        self.valid_multiple_envs_config_data = {
+            'environments': {
+                'env3': {
+                    'system3': {
+                        'system_type': 'jenkins',
+                        'sources': {}},
+                    'system4': {
+                        'system_type': 'zuul',
+                        'sources': {}}
+                }}}
+
+    def prepare_tests(self, config_data):
+        """Make some preparations to run tests in this class, this can't be
+        a setUp method because it requires data that will change from test to
+        test."""
+        self.orchestrator.config = AppConfig(data=config_data)
+        self.orchestrator.create_ci_environments()
+        for env in self.orchestrator.environments:
+            self.orchestrator.extend_parser(attributes=env.API)
+
+    def test_sort_and_filter_args_jobs_system(self):
+        """Test that the sort_and_filter_args filters multiple arguments with
+        the same func attribute."""
+        self.prepare_tests(self.valid_single_jenkins_env_config_data)
+        self.orchestrator.parser.parse(["--jobs", "--builds",
+                                        "--build-status"])
+        args = self.orchestrator.sort_and_filter_args()
+        self.assertEqual(1, len(args))
+        self.assertEqual("get_builds", args[0].func)
+        self.assertEqual("get_jobs", args[0].parent_func)
+
+    def test_sort_and_filter_args_jobs_system_jobs(self):
+        """Test that the sort_and_filter_args returns the only argument with a
+        func attribute."""
+        self.prepare_tests(self.valid_single_jenkins_env_config_data)
+        self.orchestrator.parser.parse(["--jobs"])
+        args = self.orchestrator.sort_and_filter_args()
+        self.assertEqual(1, len(args))
+        self.assertEqual("get_jobs", args[0].func)
+        self.assertIsNone(args[0].parent_func)
+
+    def test_sort_and_filter_args_jobs_system_tests(self):
+        """Test that the sort_and_filter_args filters multiple arguments with
+        the same func attribute."""
+        self.prepare_tests(self.valid_single_jenkins_env_config_data)
+        self.orchestrator.parser.parse(["--jobs", "--builds", "--build-status",
+                                        "--tests", "--test-result"])
+        args = self.orchestrator.sort_and_filter_args()
+        self.assertEqual(1, len(args))
+        self.assertEqual("get_tests", args[0].func)
+        self.assertEqual("get_builds", args[0].parent_func)
+
+    def test_sort_and_filter_args_zuul_system(self):
+        """Test that the sort_and_filter_args filters multiple arguments with
+        the same func attribute."""
+        self.prepare_tests(self.valid_single_zuul_env_config_data)
+        self.orchestrator.parser.parse(["--jobs", "--builds",
+                                        "--build-status"])
+        args = self.orchestrator.sort_and_filter_args()
+        self.assertEqual(1, len(args))
+        self.assertEqual("get_builds", args[0].func)
+        self.assertEqual("get_jobs", args[0].parent_func)
+
+    def test_sort_and_filter_args_zuul_system_tests(self):
+        """Test that the sort_and_filter_args filters multiple arguments with
+        the same func attribute."""
+        self.prepare_tests(self.valid_single_zuul_env_config_data)
+        self.orchestrator.parser.parse(["--jobs", "--builds", "--build-status",
+                                        "--tests", "--test-result"])
+        args = self.orchestrator.sort_and_filter_args()
+        self.assertEqual(1, len(args))
+        self.assertEqual("get_tests", args[0].func)
+        self.assertEqual("get_builds", args[0].parent_func)
+
+    def test_sort_and_filter_args_zuul_system_multiple_paths(self):
+        """Test that the sort_and_filter_args filters handles correctly
+        argument that connect through multiple paths."""
+        self.prepare_tests(self.valid_single_zuul_env_config_data)
+        self.orchestrator.parser.parse(["--jobs", "--tenants", "--pipelines"])
+        args = self.orchestrator.sort_and_filter_args()
+        self.assertEqual(1, len(args))
+        self.assertEqual("get_jobs", args[0].func)
+
+
+class TestOrchestratorArgsFilterOpenstackPlugin(TestOrchestratorArgsFilter,
+                                                OpenstackPluginWithJobSystem):
+    """Testing sort_and_filter_args method of the Orchestrator class with the
+    openstack plugin."""
+
+    def test_sort_and_filter_args_jobs_system_deployment_builds(self):
+        """Test that the sort_and_filter_args filters multiple arguments with
+        the same func attribute."""
+        self.prepare_tests(self.valid_single_jenkins_env_config_data)
+        self.orchestrator.parser.parse(["--ip-version", "--packages",
+                                        "--build-status"])
+        args = self.orchestrator.sort_and_filter_args()
+        self.assertEqual(2, len(args))
+        self.assertEqual("get_deployment", args[0].func)
+        self.assertEqual("get_jobs", args[0].parent_func)
+        self.assertEqual("get_builds", args[1].func)
+        self.assertEqual("get_jobs", args[1].parent_func)
+
+    def test_sort_and_filter_args_jobs_system_deployment_tests(self):
+        """Test that the sort_and_filter_args filters multiple arguments with
+        the same func attribute."""
+        self.prepare_tests(self.valid_single_jenkins_env_config_data)
+        self.orchestrator.parser.parse(["--ip-version", "--packages",
+                                        "--build-status", "--tests"])
+        args = self.orchestrator.sort_and_filter_args()
+        self.assertEqual(2, len(args))
+        self.assertEqual("get_deployment", args[0].func)
+        self.assertEqual("get_jobs", args[0].parent_func)
+        self.assertEqual("get_tests", args[1].func)
+        self.assertEqual("get_builds", args[1].parent_func)


### PR DESCRIPTION
This PR contains a proposal for the problem discussed in the last cibyl sync.
The goal of this PR is to have a proof of concept to help in the
discussion of the best solution for the orchestrator refactor. If we were to
choose this solution and go forward, this PR could be split into several to
make a thorough review simpler.

As a reminder of the problem, the current way
the orchestrator chooses which queries to run against the sources is based on
the argument level. Those arguments at the deepest level will result in queries
to some source, and the results will be aggregated and added to the system.
However some queries like: cibyl --ip-version --tests would result in missing
queries, since for a JobsSystem the level of tests is greater than that of
ip-version, and therefore get_deployments would not be called at all. 

A possible solution, that is demonstrated here, is to not only rely on the
argument level, but have a full context of the possible sources' queries. That
way, the orchestrator can pick those queries that are on the deepest level of
each branch of the graph drawn by the relationships between the queries. For
example, the get_builds method of any source will have a dependency on
get_jobs, since to get Build information one needs to know to which Job it
belongs to. A similar relationship can be established between get_tests and
get_builds, get_jobs and get_tenants in a Zuul system, etc.

This solutions requires adding a parameter to the arguments *parent_func* that
creates the relationships mentioned above. When the parser is extended, the
arguments that have this new parameter are added to a graph (created using the
networkx library) adding the func and parent_func attributes as nodes in the
graph, and a directed edge (parent_func, func). In the `run_query` method of
the orchestrator, the arguments are filtered using this graph, to make the
necessary queries while avoiding redundant ones. The PR contains 4 commits:

- Add tests that show arguments levels problems
Add some integration tests that would fail in the main branch, highlighting the
issue with the current orchestrator implementation.

- Add parent_func to Jobs system arguments
- Add parent_func attribute to Zuul arguments

- Construct the queries graph and use it to select args
Add a new method to the orchestrator: `get_args_to_query` which takes the user
arguments and the graph constructed while extending the parser and returns only
those arguments that contain the queries to be made to the sources.
