### PR TITLE
Add type hints

### DIFF
--- a/cibyl/exceptions/cli.py
+++ b/cibyl/exceptions/cli.py
@@ -20,7 +20,7 @@ class AbortedByUserError(CibylException):
     """Represents an action that was interrupted by the user.
     """
 
-    def __init__(self, message='Operation aborted by user.'):
+    def __init__(self, message: str = 'Operation aborted by user.'):
         """Constructor.
         """
         super().__init__(message)
@@ -30,7 +30,7 @@ class InvalidArgument(CibylException):
     """Represents an argument with invalid format.
     """
 
-    def __init__(self, message='Invalid argument provided.'):
+    def __init__(self, message: str = 'Invalid argument provided.'):
         """Constructor.
         """
         super().__init__(message)
@@ -40,7 +40,7 @@ class MissingArgument(CibylException):
     """Represents a missing required argument
     """
 
-    def __init__(self, message='Missing required argument.'):
+    def __init__(self, message: str = 'Missing required argument.'):
         """Constructor.
         """
         super().__init__(message)

--- a/cibyl/exceptions/config.py
+++ b/cibyl/exceptions/config.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from typing import Iterable
+
 from cibyl.exceptions import CibylException
 from cibyl.utils.colors import Colors
 
@@ -24,7 +26,7 @@ for more information"
 class ConfigurationNotFound(CibylException):
     """Configuration file not found exception"""
 
-    def __init__(self, paths):
+    def __init__(self, paths: str):
         if paths:
             paths = f" at: '{paths}'"
         else:
@@ -38,7 +40,7 @@ class ConfigurationNotFound(CibylException):
 class EmptyConfiguration(CibylException):
     """Configuration file is empty exception."""
 
-    def __init__(self, file):
+    def __init__(self, file: str):
         self.message = f"""Configuration file {file} is empty.
 {CHECK_DOCS_MSG}"""
 
@@ -48,7 +50,7 @@ class EmptyConfiguration(CibylException):
 class InvalidSourceConfiguration(CibylException):
     """Invalid source configuration exception."""
 
-    def __init__(self, source_name, source_data):
+    def __init__(self, source_name: str, source_data: dict):
         self.message = f"""Invalid source configuration.
 
 {source_name}: {source_data}\n\n{CHECK_DOCS_MSG}"""
@@ -59,7 +61,7 @@ class InvalidSourceConfiguration(CibylException):
 class NonSupportedSourceKey(CibylException):
     """Configuration section key is not supported."""
 
-    def __init__(self, source_type, key):
+    def __init__(self, source_type: str, key: str):
         self.message = f"""The following key in "{source_type}" source type \
 is not supported: {key}\n\n{CHECK_DOCS_MSG}"""
 
@@ -69,7 +71,7 @@ is not supported: {key}\n\n{CHECK_DOCS_MSG}"""
 class NonSupportedSystemKey(CibylException):
     """Configuration section key is not supported."""
 
-    def __init__(self, system_type, key):
+    def __init__(self, system_type: str, key: str):
         self.message = f"""The following key in "{system_type}" system type \
 is not supported: {key}\n\n{CHECK_DOCS_MSG}"""
 
@@ -79,7 +81,7 @@ is not supported: {key}\n\n{CHECK_DOCS_MSG}"""
 class NonSupportedSourceType(CibylException):
     """Configuration source type is not supported."""
 
-    def __init__(self, source_type, source_types):
+    def __init__(self, source_type: str, source_types: Iterable):
         types = Colors.blue("\n  ".join([t.value for t in source_types]))
         self.message = f"""The source type "{source_type}" isn't supported.
 Use one of the following source types:\n  {types}"""
@@ -90,7 +92,7 @@ Use one of the following source types:\n  {types}"""
 class MissingSourceKey(CibylException):
     """Configuration section is incomplete and missing a key."""
 
-    def __init__(self, source_type, key):
+    def __init__(self, source_type: str, key: str):
         colored_key = Colors.blue(key)
         self.message = f"""The following key in "{source_type}" source type \
 is missing and required for the source to become operational: {colored_key}"""
@@ -101,7 +103,7 @@ is missing and required for the source to become operational: {colored_key}"""
 class MissingSystemKey(CibylException):
     """System configuration is incomplete and missing a key."""
 
-    def __init__(self, system_name, key):
+    def __init__(self, system_name: str, key: str):
         colored_key = Colors.blue(key)
         self.message = f"""The following key in "{system_name}" system \
 is missing and required for the system to become operational: {colored_key}"""
@@ -112,7 +114,7 @@ is missing and required for the system to become operational: {colored_key}"""
 class MissingSourceType(CibylException):
     """Configuration source type isn't specified."""
 
-    def __init__(self, source_name, source_types):
+    def __init__(self, source_name: str, source_types: Iterable):
         types = Colors.blue("\n  ".join([t.value for t in source_types]))
         self.message = f"""Missing 'driver: <TYPE>' for source {source_name}
 Use one of the following source types:\n  {types}"""
@@ -123,7 +125,7 @@ Use one of the following source types:\n  {types}"""
 class MissingSystemType(CibylException):
     """Configuration system type isn't specified."""
 
-    def __init__(self, system_name, system_types):
+    def __init__(self, system_name: str, system_types: Iterable):
         types = Colors.blue("\n  ".join([t for t in system_types]))
         self.message = f"""Missing 'system_type: <TYPE>' for system {system_name}
 Use one of the following system types:\n  {types}"""
@@ -134,7 +136,7 @@ Use one of the following system types:\n  {types}"""
 class MissingSystemSources(CibylException):
     """Configuration system sources aren't specified."""
 
-    def __init__(self, system_name):
+    def __init__(self, system_name: str):
         self.message = f"""Missing sources for system \
 '{system_name}'
 
@@ -163,7 +165,7 @@ Configure environments with the "environments" mapping:
 class MissingSystems(CibylException):
     """An environment in the configuration doesn't include any systems."""
 
-    def __init__(self, env_name):
+    def __init__(self, env_name: str):
         self.message = f"""No systems defined in the configuration file \
 for the environment '{env_name}'
 

--- a/cibyl/exceptions/features.py
+++ b/cibyl/exceptions/features.py
@@ -20,7 +20,7 @@ class MissingFeature(CibylException):
     """Represents an error loading a feature.
     """
 
-    def __init__(self, message='Feature not found.'):
+    def __init__(self, message: str = 'Feature not found.'):
         """Constructor.
         """
         super().__init__(message)

--- a/cibyl/exceptions/model.py
+++ b/cibyl/exceptions/model.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from typing import List
+
 from cibyl.exceptions import CibylException
 from cibyl.exceptions.config import CHECK_DOCS_MSG
 from cibyl.utils.colors import Colors
@@ -21,7 +23,7 @@ from cibyl.utils.colors import Colors
 class NonSupportedModelType(CibylException):
     """Exception for trying to populate non-supported model"""
 
-    def __init__(self, model_type):
+    def __init__(self, model_type: object):
         self.model_type = model_type
         self.message = f"""Not supported type for model: {self.model_type}.
 Unable to populate system with pulled data"""
@@ -31,7 +33,7 @@ Unable to populate system with pulled data"""
 class NoValidSystem(CibylException):
     """Exception for a case when no valid system is found."""
 
-    def __init__(self, valid_systems=None):
+    def __init__(self, valid_systems: List[str] = None):
         self.message = """No valid system(s) defined."""
         if valid_systems:
             self.message += "\nPlease use one of the following available"
@@ -46,7 +48,7 @@ class NoValidSystem(CibylException):
 class InvalidEnvironment(CibylException):
     """Exception for a case when no valid environment is found."""
 
-    def __init__(self, environment, valid_environments=None):
+    def __init__(self, environment: str, valid_environments: List[str] = None):
         self.message = f"No such environment: {environment}"
         if valid_environments:
             self.message += "\nPlease use one of the following available"
@@ -63,7 +65,7 @@ class InvalidEnvironment(CibylException):
 class InvalidSystem(CibylException):
     """Exception for a case when non existing system is passed by the user."""
 
-    def __init__(self, system, valid_systems=None):
+    def __init__(self, system: str, valid_systems: List[str] = None):
         self.message = f"No such system: {system}"
         if valid_systems:
             self.message += "\nAvailable systems:\n"
@@ -78,7 +80,7 @@ class InvalidSystem(CibylException):
 class NoEnabledSystem(CibylException):
     """Exception for a case when no enabled system is found."""
 
-    def __init__(self, message=None):
+    def __init__(self, message: str = None):
         """Constructor."""
         if not message:
             message = "No enabled system was found. Please ensure at least one"

--- a/cibyl/exceptions/plugin.py
+++ b/cibyl/exceptions/plugin.py
@@ -19,7 +19,7 @@ from cibyl.exceptions import CibylException
 class MissingPlugin(CibylException):
     """Missing plugin exception"""
 
-    def __init__(self, plugin_name):
+    def __init__(self, plugin_name: str):
         self.plugin_name = plugin_name
         self.message = f"""Unable to locate the plugin {plugin_name}.
 Make sure the plugin is defined in cibyl.plugins directory

--- a/cibyl/exceptions/source.py
+++ b/cibyl/exceptions/source.py
@@ -22,7 +22,7 @@ class NoSupportedSourcesFound(CibylException):
        implementing the function of the argument the user is interested in
     """
 
-    def __init__(self, system, function):
+    def __init__(self, system: str, function: str):
         self.message = f"""Couldn't find any enabled source for the system
 {system} that implements the function {function}.""".replace("\n", " ")
         super().__init__(self.message)
@@ -31,7 +31,7 @@ class NoSupportedSourcesFound(CibylException):
 class NoValidSources(CibylException):
     """Exception for a case when no valid source is found."""
 
-    def __init__(self, system="", sources=""):
+    def __init__(self, system: str = "", sources: str = ""):
         if sources:
             sources = Colors.blue('\n  '.join(sources))
             sources = f"\nAvailable sources:\n  {sources}"
@@ -57,7 +57,7 @@ class SourceException(CibylException):
 class MissingArgument(SourceException):
     """Represents a missing required argument inside a source method call."""
 
-    def __init__(self, message='Missing required argument.'):
+    def __init__(self, message: str = 'Missing required argument.'):
         """Constructor.
         """
         super().__init__(message)
@@ -67,7 +67,7 @@ class InvalidArgument(SourceException):
     """Represents an invalid combination of arguments inside a source
     method call."""
 
-    def __init__(self, message='Invalid argument passed.'):
+    def __init__(self, message: str = 'Invalid argument passed.'):
         """Constructor.
         """
         super().__init__(message)

--- a/cibyl/exceptions/zuul.py
+++ b/cibyl/exceptions/zuul.py
@@ -21,6 +21,6 @@ class RateLimitException(SourceException):
     Exception for rate limit exceeded.
     """
 
-    def __init__(self, system, function):
+    def __init__(self, system: str, function: str):
         self.message = """Rate limit exceeded. Please use tokens."""
         super().__init__(self.message)

--- a/cibyl/features/__init__.py
+++ b/cibyl/features/__init__.py
@@ -19,10 +19,12 @@ import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from inspect import isclass
+from typing import Type, Union
 
 from cibyl.exceptions.cli import InvalidArgument
 from cibyl.exceptions.features import MissingFeature
 from cibyl.exceptions.source import NoSupportedSourcesFound, SourceException
+from cibyl.models.ci.base.system import System
 from cibyl.sources.source import (get_source_instance_from_method,
                                   select_source_method,
                                   source_information_from_method)
@@ -35,15 +37,13 @@ LOG = logging.getLogger(__name__)
 MODULE_PATTERN = re.compile(r"([a-zA-Z][a-zA-Z_]*)\.py")
 
 
-def is_feature_class(symbol):
+def is_feature_class(symbol: object) -> bool:
     """Check whether the symbols imported from a module correspond to
     classes defining a feature. We assume that the symbol in question
     defines a feature if it inherits from the FeatureDefinition class.
 
     :param symbol: An imported symbol to check
-    :type symbol: object
     :returns: Whether the symbol defines a feature
-    :rtype: bool
     """
     return isclass(symbol) and issubclass(symbol, FeatureDefinition) and \
         symbol is not FeatureDefinition
@@ -57,12 +57,12 @@ features_by_category = defaultdict(list)
 all_features = {}
 
 
-def add_feature_location(location: str):
+def add_feature_location(location: str) -> None:
     """Add an additional location where to find features."""
     features_locations.append(location)
 
 
-def load_features(feature_paths: list = None):
+def load_features(feature_paths: list = None) -> None:
     global features_locations
     if feature_paths:
         features_locations = feature_paths
@@ -88,7 +88,7 @@ def load_features(feature_paths: list = None):
                 features_by_category[module_name].append(feature.name)
 
 
-def get_string_all_features():
+def get_string_all_features() -> str:
     """Get a string representation listing all available features to use in
     an exception message."""
     msg = ""
@@ -103,11 +103,10 @@ def get_string_all_features():
     return msg
 
 
-def get_feature(name_feature):
+def get_feature(name_feature: str) -> Type:
     """Get the function associated with the given feature name
 
-    :param feature_name: Name of the feature
-    :type feature_name: str
+    :param name_feature: Name of the feature
 
     :returns: class that implements the given feature
     :rtype: class
@@ -158,7 +157,7 @@ class FeatureTemplate(ABC):
         the feature."""
         pass
 
-    def query(self, system, **kwargs):
+    def query(self, system: System, **kwargs) -> Union[dict, None]:
         """Execute the sources query that would provide the information that
         defines the feature."""
         debug = kwargs.get("debug", False)

--- a/cibyl/publisher.py
+++ b/cibyl/publisher.py
@@ -17,6 +17,7 @@ import logging
 
 from cibyl.cli.output import OutputStyle
 from cibyl.cli.query import QueryType
+from cibyl.models.ci.base.environment import Environment
 from cibyl.outputs.cli.ci.env.factory import CIPrinterFactory
 
 LOG = logging.getLogger(__name__)
@@ -29,11 +30,11 @@ class Publisher:
     """
 
     def publish(self,
-                environment,
-                target="terminal",
-                style=OutputStyle.TEXT,
-                query=QueryType.NONE,
-                verbosity=0):
+                environment: Environment,
+                target: str = "terminal",
+                style: OutputStyle = OutputStyle.TEXT,
+                query: QueryType = QueryType.NONE,
+                verbosity: int = 0) -> None:
         """Publishes the data of the given environments to the
         chosen destination.
         """


### PR DESCRIPTION
Add type hints to functions according to PEP-484 [1] in:
-  features subpackage,
-  exceptions subpackage and
-  publisher.py.

This patch also removes now redundant type hints from
docstrings in the modified files.