### PR TITLE
Add type hints and return types to methods in utils package

### DIFF
--- a/cibyl/config.py
+++ b/cibyl/config.py
@@ -39,7 +39,6 @@ def _ask_user_for_overwrite() -> bool:
             Blocking call, requires interaction.
 
     :return: True if the user answered yes, false if not.
-    :rtype: bool
     """
     return ask_yes_no_question('Overwrite file?')
 

--- a/cibyl/utils/colors.py
+++ b/cibyl/utils/colors.py
@@ -28,27 +28,27 @@ class Colors:
     UNDERLINE = '\033[4m'
 
     @staticmethod
-    def red(text):
+    def red(text: str):
         return f"{Colors.RED}{Colors.BOLD}{text}{Colors.CLOSE}"
 
     @staticmethod
-    def green(text):
+    def green(text: str):
         return f"{Colors.GREEN}{Colors.BOLD}{text}{Colors.CLOSE}"
 
     @staticmethod
-    def blue(text):
+    def blue(text: str):
         return f"{Colors.BLUE}{Colors.BOLD}{text}{Colors.CLOSE}"
 
     @staticmethod
-    def yellow(text):
+    def yellow(text: str):
         return f"{Colors.YELLOW}{text}{Colors.CLOSE}"
 
     @staticmethod
-    def bold(text):
+    def bold(text: str):
         return f"{Colors.BOLD}{text}{Colors.CLOSE}"
 
     @staticmethod
-    def underline(text):
+    def underline(text: str):
         return f"{Colors.UNDERLINE}{text}{Colors.CLOSE}"
 
 
@@ -121,22 +121,22 @@ class DefaultPalette(ColorPalette):
     """The default color scheme of the app.
     """
 
-    def red(self, text):
+    def red(self, text: str):
         return Colors.red(text)
 
-    def green(self, text):
+    def green(self, text: str):
         return Colors.green(text)
 
-    def blue(self, text):
+    def blue(self, text: str):
         return Colors.blue(text)
 
-    def yellow(self, text):
+    def yellow(self, text: str):
         return Colors.yellow(text)
 
-    def bold(self, text):
+    def bold(self, text: str):
         return Colors.bold(text)
 
-    def underline(self, text):
+    def underline(self, text: str):
         return Colors.underline(text)
 
 
@@ -145,20 +145,20 @@ class ClearText(ColorPalette):
     coloring wherever it is present.
     """
 
-    def red(self, text):
+    def red(self, text: str):
         return text
 
-    def green(self, text):
+    def green(self, text: str):
         return text
 
-    def blue(self, text):
+    def blue(self, text: str):
         return text
 
-    def yellow(self, text):
+    def yellow(self, text: str):
         return text
 
-    def bold(self, text):
+    def bold(self, text: str):
         return text
 
-    def underline(self, text):
+    def underline(self, text: str):
         return text

--- a/cibyl/utils/colors.py
+++ b/cibyl/utils/colors.py
@@ -28,27 +28,27 @@ class Colors:
     UNDERLINE = '\033[4m'
 
     @staticmethod
-    def red(text: str):
+    def red(text: str) -> str:
         return f"{Colors.RED}{Colors.BOLD}{text}{Colors.CLOSE}"
 
     @staticmethod
-    def green(text: str):
+    def green(text: str) -> str:
         return f"{Colors.GREEN}{Colors.BOLD}{text}{Colors.CLOSE}"
 
     @staticmethod
-    def blue(text: str):
+    def blue(text: str) -> str:
         return f"{Colors.BLUE}{Colors.BOLD}{text}{Colors.CLOSE}"
 
     @staticmethod
-    def yellow(text: str):
+    def yellow(text: str) -> str:
         return f"{Colors.YELLOW}{text}{Colors.CLOSE}"
 
     @staticmethod
-    def bold(text: str):
+    def bold(text: str) -> str:
         return f"{Colors.BOLD}{text}{Colors.CLOSE}"
 
     @staticmethod
-    def underline(text: str):
+    def underline(text: str) -> str:
         return f"{Colors.UNDERLINE}{text}{Colors.CLOSE}"
 
 
@@ -121,22 +121,22 @@ class DefaultPalette(ColorPalette):
     """The default color scheme of the app.
     """
 
-    def red(self, text: str):
+    def red(self, text: str) -> str:
         return Colors.red(text)
 
-    def green(self, text: str):
+    def green(self, text: str) -> str:
         return Colors.green(text)
 
-    def blue(self, text: str):
+    def blue(self, text: str) -> str:
         return Colors.blue(text)
 
-    def yellow(self, text: str):
+    def yellow(self, text: str) -> str:
         return Colors.yellow(text)
 
-    def bold(self, text: str):
+    def bold(self, text: str) -> str:
         return Colors.bold(text)
 
-    def underline(self, text: str):
+    def underline(self, text: str) -> str:
         return Colors.underline(text)
 
 
@@ -145,20 +145,20 @@ class ClearText(ColorPalette):
     coloring wherever it is present.
     """
 
-    def red(self, text: str):
+    def red(self, text: str) -> str:
         return text
 
-    def green(self, text: str):
+    def green(self, text: str) -> str:
         return text
 
-    def blue(self, text: str):
+    def blue(self, text: str) -> str:
         return text
 
-    def yellow(self, text: str):
+    def yellow(self, text: str) -> str:
         return text
 
-    def bold(self, text: str):
+    def bold(self, text: str) -> str:
         return text
 
-    def underline(self, text: str):
+    def underline(self, text: str) -> str:
         return text

--- a/cibyl/utils/dicts.py
+++ b/cibyl/utils/dicts.py
@@ -20,14 +20,13 @@ from cibyl.models.attribute import AttributeDictValue
 LOG = logging.getLogger(__name__)
 
 
-def subset(dictionary, keys: list) -> dict:
+def subset(dictionary: dict, keys: list) -> dict:
     """Creates a new dictionary from items from another one. A new
     dictionary is formed by extracting the keys explicitly indicated. If one of
     the given keys is not present on the dictionary, it is ignored. The
     original dictionary is left untouched.
 
     :param dictionary: The dictionary to extract items from.
-    :type dictionary: dict
     :param keys: The keys to get from the dictionary.
     :return: The new dictionary.
     """

--- a/cibyl/utils/dicts.py
+++ b/cibyl/utils/dicts.py
@@ -20,7 +20,7 @@ from cibyl.models.attribute import AttributeDictValue
 LOG = logging.getLogger(__name__)
 
 
-def subset(dictionary, keys):
+def subset(dictionary, keys: list) -> dict:
     """Creates a new dictionary from items from another one. A new
     dictionary is formed by extracting the keys explicitly indicated. If one of
     the given keys is not present on the dictionary, it is ignored. The
@@ -29,9 +29,7 @@ def subset(dictionary, keys):
     :param dictionary: The dictionary to extract items from.
     :type dictionary: dict
     :param keys: The keys to get from the dictionary.
-    :type keys: list
     :return: The new dictionary.
-    :rtype: dict
     """
     result = {}
 
@@ -47,7 +45,7 @@ def subset(dictionary, keys):
     return result
 
 
-def nsubset(dictionary, keys):
+def nsubset(dictionary, keys: list) -> dict:
     """Creates a new dictionary from items from another one. The 'n' stands
     for 'negative', meaning that the keys form an excluded list. All keys
     from the other dictionary will be extracted except for the ones explicitly
@@ -56,9 +54,7 @@ def nsubset(dictionary, keys):
     :param dictionary: The dictionary to extract items from.
     :type dictionary: dict
     :param keys: The keys to not get from the dictionary.
-    :type keys: list
     :return: The new dictionary.
-    :rtype: dict
     """
     result = {}
 
@@ -92,19 +88,16 @@ def chunk_dictionary_into_lists(dictionary: dict, size: int = 300) -> list:
     return chunked_list
 
 
-def intersect_models(dict1, dict2):
+def intersect_models(dict1: dict, dict2: dict) -> dict:
     """Combine two dictionaries that are returned from a source method call to
     keep only those models that are present in both. It assumes that the models
     present in both dictionaries are identical and takes them for the first
     input dictionary.
 
     :param dict1: The first dictionary with models.
-    :type dict1: dict
     :param dict2: The second dictionary with models.
-    :type dict2: dict
     :return: A new dictionary that contains only the models present in both
     input dictionaries.
-    :rtype: dict
     """
     intersection = dict1.keys() & dict2.keys()
     models = {key: dict1[key] for key in intersection}

--- a/cibyl/utils/dicts.py
+++ b/cibyl/utils/dicts.py
@@ -44,14 +44,13 @@ def subset(dictionary: dict, keys: list) -> dict:
     return result
 
 
-def nsubset(dictionary, keys: list) -> dict:
+def nsubset(dictionary: dict, keys: list) -> dict:
     """Creates a new dictionary from items from another one. The 'n' stands
     for 'negative', meaning that the keys form an excluded list. All keys
     from the other dictionary will be extracted except for the ones explicitly
     indicated. The original dictionary is left untouched.
 
     :param dictionary: The dictionary to extract items from.
-    :type dictionary: dict
     :param keys: The keys to not get from the dictionary.
     :return: The new dictionary.
     """

--- a/cibyl/utils/files.py
+++ b/cibyl/utils/files.py
@@ -125,7 +125,9 @@ def is_file_available(filename: str) -> bool:
     return os.path.isfile(filename)
 
 
-def get_first_available_file(filenames: Iterable[bytes | str | PathLike],
+def get_first_available_file(filenames: Iterable[
+                                Union[bytes, str, PathLike]
+                             ],
                              file_check: Callable[[str], bool]
                              = is_file_available
                              ) -> Union[bytes, str, None]:

--- a/cibyl/utils/files.py
+++ b/cibyl/utils/files.py
@@ -68,7 +68,7 @@ class FileSearch:
         self._excluded.extend(excluded)
         return self
 
-    def get(self) -> list[str]:
+    def get(self) -> List[str]:
         """Performs the query and gets the paths to the files that were
         found by the search.
 

--- a/cibyl/utils/files.py
+++ b/cibyl/utils/files.py
@@ -17,7 +17,7 @@ import logging
 import os
 from os import PathLike
 from pathlib import Path
-from typing import List, Union
+from typing import Callable, Iterable, List, Union
 
 LOG = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ class FileSearch:
         self._excluded.extend(excluded)
         return self
 
-    def get(self):
+    def get(self) -> list[str]:
         """Performs the query and gets the paths to the files that were
         found by the search.
 
@@ -125,8 +125,9 @@ def is_file_available(filename: str) -> bool:
     return os.path.isfile(filename)
 
 
-def get_first_available_file(filenames: list,
-                             file_check: bool = is_file_available
+def get_first_available_file(filenames: Iterable[bytes | str | PathLike],
+                             file_check: Callable[[str], bool]
+                             = is_file_available
                              ) -> Union[bytes, str, None]:
     """Searches for the first file out of the provided paths that exists
     on the host's drive.

--- a/cibyl/utils/files.py
+++ b/cibyl/utils/files.py
@@ -17,6 +17,7 @@ import logging
 import os
 from os import PathLike
 from pathlib import Path
+from typing import List, Union
 
 LOG = logging.getLogger(__name__)
 
@@ -25,41 +26,37 @@ class FileSearch:
     """Allows for complex search queries targeting files on the filesystem.
     """
 
-    def __init__(self, directory):
+    def __init__(self, directory: str):
         """Constructor.
 
         :param directory: Path to directory to look for files in.
-        :type directory: str
         """
         self._directory = directory
         self._recursive = False
         self._extensions = []
         self._excluded = []
 
-    def with_recursion(self):
+    def with_recursion(self) -> 'FileSearch':
         """Extends the search to the folders inside the directory and beyond.
 
         :return: The instance.
-        :rtype: :class:`FileSearch`
         """
         self._recursive = True
         return self
 
-    def with_extension(self, extension):
+    def with_extension(self, extension: str) -> 'FileSearch':
         """Limits the search to files of a certain extensions. If this is
         called more than once, then the filters are joined together following
         and 'OR' approach.
 
         :param extension: The extension to filter by. Must be passed
             dot-prefixed, like: '.py'.
-        :type extension: str
         :return: The instance.
-        :rtype: :class:`FileSearch`
         """
         self._extensions.append(extension)
         return self
 
-    def with_excluded(self, excluded):
+    def with_excluded(self, excluded: list) -> 'FileSearch':
         """Limits the search to files that are not in the excluded list. If this
         is called more than once, then the filters are joined together
         following an 'OR' approach.
@@ -67,7 +64,6 @@ class FileSearch:
         :param excluded: The file names to filter by.
         :type excluded: list
         :return: The instance.
-        :rtype: :class:`FileSearch`
         """
         self._excluded.extend(excluded)
         return self
@@ -77,10 +73,9 @@ class FileSearch:
         found by the search.
 
         :return: Paths to the files.
-        :rtype: list[str]
         """
 
-        def list_directory():
+        def list_directory() -> List[str]:
             return [
                 f'{self._directory}/{entry}'
                 for entry in os.listdir(self._directory)
@@ -104,15 +99,13 @@ class FileSearch:
 
         return result
 
-    def _copy_for(self, directory):
+    def _copy_for(self, directory: str) -> 'FileSearch':
         """Makes a copy of this search intended for another directory. The
         resulting search will follow the same filters as this one, making
         the resulting files follow the same rules.
 
         :param directory: The directory to search this time around.
-        :type directory: str
         :return: The search's instance.
-        :rtype: :class:`FileSearch`
         """
         other = FileSearch(directory)
 
@@ -123,27 +116,25 @@ class FileSearch:
         return other
 
 
-def is_file_available(filename):
+def is_file_available(filename: str) -> bool:
     """Checks if a file is present on the filesystem.
 
     :param filename: A path pointing to the file to be checked.
-    :type filename: str
     :return: Whether the file is there or not.
-    :rtype: bool
     """
     return os.path.isfile(filename)
 
 
-def get_first_available_file(filenames, file_check=is_file_available):
+def get_first_available_file(filenames: list,
+                             file_check: bool = is_file_available
+                             ) -> Union[bytes, str, None]:
     """Searches for the first file out of the provided paths that exists
     on the host's drive.
 
     :param filenames: A list of paths pointing to different files.
-    :type filenames: :class:`typing.Iterable[bytes | str | PathLike]`
     :param file_check: A function that determines if a file is present.
     :return: A string containing the path to the found file. 'None' if no
         file is available
-    :rtype: bytes or str or None
     """
     for filename in filenames:
         # Resolve path into a string
@@ -160,26 +151,22 @@ def get_first_available_file(filenames, file_check=is_file_available):
     return None
 
 
-def get_file_name_from_path(path):
+def get_file_name_from_path(path: str) -> str:
     """Get the file name from a path. Strip all leading path
     information as well as the extension.
     :param path: Path of the file
-    :type path: str
     :returns: The name of the file that path points to, without extension
-    :rtype: str
     """
     path = path.replace("\\", os.sep)
     _, file_name = os.path.split(path)
     return os.path.splitext(file_name)[0]
 
 
-def get_file_extension(path):
+def get_file_extension(path: str) -> str:
     """Gets the dot-prefixed extension from the path to a file.
 
     :param path: Path to the file to get the extension from.
-    :type path: str
     :return: The file's extension.
-    :rtype: str
 
     Examples
     --------

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -15,7 +15,7 @@
 """
 import re
 import sre_constants
-from typing import Dict, Iterable, List, Pattern
+from typing import Dict, Iterable, List, Optional, Pattern
 
 from cibyl.cli.argument import Argument
 from cibyl.cli.ranged_argument import RANGE_OPERATORS
@@ -48,7 +48,6 @@ def satisfy_regex_match(model: Dict[str, str], pattern: Pattern,
     :param model: model information obtained from jenkins
     :param pattern: regex patter that the model name should match
     :param field_to_check: model field to perform the check
-    :param field_to_check: str
     :returns: Whether the model satisfies user input
     """
     return re.search(pattern, model[field_to_check]) is not None
@@ -63,7 +62,6 @@ def satisfy_exact_match(model: Dict[str, str], user_input: Argument,
     :param model: model information obtained from jenkins
     :param user_input: input argument specified by the user
     :param field_to_check: Job field to perform the check
-    :param field_to_check: str
     :returns: Whether the model satisfies user input
     """
     return model[field_to_check] in user_input.value
@@ -71,7 +69,7 @@ def satisfy_exact_match(model: Dict[str, str], user_input: Argument,
 
 def satisfy_case_insensitive_match(model: Dict[str, str], user_input: Argument,
                                    field_to_check: str,
-                                   default_user_value: List[str] = None
+                                   default_user_value: Optional[List[str]] = None
                                    ) -> bool:
     """Check whether model should be included according to the user input. The
     model should be added if the information provided field_to_check
@@ -83,7 +81,6 @@ def satisfy_case_insensitive_match(model: Dict[str, str], user_input: Argument,
     :param field_to_check: Job field to perform the check
     :param default_user_value: Default value to use if the user input contains
     no value
-    :type default_user_value: list
     :returns: Whether the model satisfies user input
     """
     if model[field_to_check] is None:
@@ -105,7 +102,6 @@ def satisfy_range_match(model: Dict[str, str], user_input: Argument,
     :param model: model information obtained from jenkins
     :param user_input: input argument specified by the user
     :param field_to_check: Job field to perform the check
-    :param field_to_check: str
     :returns: Whether the model satisfies user input
     """
     model_value = float(model[field_to_check])

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -15,7 +15,7 @@
 """
 import re
 import sre_constants
-from typing import Dict, Iterable, List, Optional, Pattern
+from typing import Callable, Dict, Iterable, List, Optional, Pattern
 
 from cibyl.cli.argument import Argument
 from cibyl.cli.ranged_argument import RANGE_OPERATORS
@@ -146,7 +146,7 @@ def matches_regex(pattern: str, string: str) -> bool:
         return False  # Do not crash against invalid patterns
 
 
-def apply_filters(iterable: Iterable, *filters: list) -> list:
+def apply_filters(iterable: Iterable, *filters: Callable) -> Iterable:
     """Applies a set of filters to a collection.
 
     :param iterable: The collection to filter.

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -69,7 +69,8 @@ def satisfy_exact_match(model: Dict[str, str], user_input: Argument,
 
 def satisfy_case_insensitive_match(model: Dict[str, str], user_input: Argument,
                                    field_to_check: str,
-                                   default_user_value: Optional[List[str]] = None
+                                   default_user_value: Optional[List[str]]
+                                   = None
                                    ) -> bool:
     """Check whether model should be included according to the user input. The
     model should be added if the information provided field_to_check

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -15,7 +15,7 @@
 """
 import re
 import sre_constants
-from typing import Dict, List, Pattern
+from typing import Dict, Iterable, List, Pattern
 
 from cibyl.cli.argument import Argument
 from cibyl.cli.ranged_argument import RANGE_OPERATORS
@@ -39,61 +39,52 @@ SERVICES_PATTERN = re.compile(services_pattern_str)
 
 
 def satisfy_regex_match(model: Dict[str, str], pattern: Pattern,
-                        field_to_check: str):
+                        field_to_check: str) -> bool:
     """Check whether model (job or build) should be included according to
     the user input.
     The model should be added if the information provided field_to_check
     (the model name or url for example) is matches the regex pattern.
 
     :param model: model information obtained from jenkins
-    :type model: str
     :param pattern: regex patter that the model name should match
-    :type pattern: :class:`re.Pattern`
     :param field_to_check: model field to perform the check
     :param field_to_check: str
     :returns: Whether the model satisfies user input
-    :rtype: bool
     """
     return re.search(pattern, model[field_to_check]) is not None
 
 
 def satisfy_exact_match(model: Dict[str, str], user_input: Argument,
-                        field_to_check: str):
+                        field_to_check: str) -> bool:
     """Check whether model should be included according to the user input. The
     model should be added if the information provided field_to_check
     (the model name or url for example) is present in the user_input values.
 
     :param model: model information obtained from jenkins
-    :type model: str
     :param user_input: input argument specified by the user
-    :type model_urls: :class:`.Argument`
     :param field_to_check: Job field to perform the check
     :param field_to_check: str
     :returns: Whether the model satisfies user input
-    :rtype: bool
     """
     return model[field_to_check] in user_input.value
 
 
 def satisfy_case_insensitive_match(model: Dict[str, str], user_input: Argument,
                                    field_to_check: str,
-                                   default_user_value: List[str] = None):
+                                   default_user_value: List[str] = None
+                                   ) -> bool:
     """Check whether model should be included according to the user input. The
     model should be added if the information provided field_to_check
     (the model name or url for example) is an exact case-insensitive match to
     the information in the user_input values.
 
     :param model: model information obtained from jenkins
-    :type model: str
     :param user_input: input argument specified by the user
-    :type model_urls: :class:`.Argument`
     :param field_to_check: Job field to perform the check
-    :type field_to_check: str
     :param default_user_value: Default value to use if the user input contains
     no value
     :type default_user_value: list
     :returns: Whether the model satisfies user input
-    :rtype: bool
     """
     if model[field_to_check] is None:
         return False
@@ -105,20 +96,17 @@ def satisfy_case_insensitive_match(model: Dict[str, str], user_input: Argument,
 
 
 def satisfy_range_match(model: Dict[str, str], user_input: Argument,
-                        field_to_check: str):
+                        field_to_check: str) -> bool:
     """Check whether model should be included according to the user input. The
     model should be added if the information provided in field_to_check
     (the model name or url for example) is consistent with the range defined
     in the user_input values.
 
     :param model: model information obtained from jenkins
-    :type model: str
     :param user_input: input argument specified by the user
-    :type model_urls: :class:`.Argument`
     :param field_to_check: Job field to perform the check
     :param field_to_check: str
     :returns: Whether the model satisfies user input
-    :rtype: bool
     """
     model_value = float(model[field_to_check])
     results = [RANGE_OPERATORS[operator](float(model_value), float(user_value))
@@ -127,21 +115,18 @@ def satisfy_range_match(model: Dict[str, str], user_input: Argument,
 
 
 def filter_topology(model: Dict[str, str], operator: str, value: str,
-                    component: str):
+                    component: str) -> bool:
     """Check whether model should be included according to the user input. The
     model should be added if the its topology is consistent with the components
     requested by the user (number of controller or compute nodes).
 
     :param model: model information obtained from jenkins
-    :type model: str
     :param operator: operator to filter the topology with
-    :type operator: str
     :param value: Value to use in the comparison
     :param value: str
     :param component: Component of the topology to filter
     :param component: str
     :returns: Whether the model satisfies user input
-    :rtype: bool
     """
     topology = model["topology"]
     for part in topology.split(","):
@@ -151,15 +136,12 @@ def filter_topology(model: Dict[str, str], operator: str, value: str,
     return False
 
 
-def matches_regex(pattern, string):
+def matches_regex(pattern: str, string: str) -> bool:
     """Checks if a certain text is matched by a regex pattern.
 
     :param pattern: The pattern to test.
-    :type pattern: str
     :param string: The text to test the pattern against.
-    :type string: str
     :return: True if the string matched the pattern, false if not.
-    :rtype: bool
     """
     try:
         return bool(re.search(pattern, string))
@@ -167,13 +149,12 @@ def matches_regex(pattern, string):
         return False  # Do not crash against invalid patterns
 
 
-def apply_filters(iterable, *filters):
+def apply_filters(iterable: Iterable, *filters: list) -> list:
     """Applies a set of filters to a collection.
 
     :param iterable: The collection to filter.
     :param filters: List of filters to apply.
     :return: The collection post-filtering.
-    :rtype: list
     """
     result = list(iterable)
 

--- a/cibyl/utils/filtering.py
+++ b/cibyl/utils/filtering.py
@@ -120,9 +120,7 @@ def filter_topology(model: Dict[str, str], operator: str, value: str,
     :param model: model information obtained from jenkins
     :param operator: operator to filter the topology with
     :param value: Value to use in the comparison
-    :param value: str
     :param component: Component of the topology to filter
-    :param component: str
     :returns: Whether the model satisfies user input
     """
     topology = model["topology"]

--- a/cibyl/utils/json.py
+++ b/cibyl/utils/json.py
@@ -25,11 +25,10 @@ class JSONValidatorFactory(ABC):
     """
 
     @abstractmethod
-    def from_file(self, file):
+    def from_file(self, file: str):
         """Builds a new validator by reading the schema from a file.
 
         :param file: Path to the file to read.
-        :type file: str
         :return: New validator instance.
         :rtype: :class:`jsonschema.IValidator`
         :raise IOError: If the file could not be opened or read.
@@ -45,7 +44,7 @@ class Draft7ValidatorFactory(JSONValidatorFactory):
     """
 
     @overrides
-    def from_file(self, file):
+    def from_file(self, file: str) -> Draft7Validator:
         with open(file, 'r') as buffer:
             schema = json.loads(buffer.read())
 

--- a/cibyl/utils/logger.py
+++ b/cibyl/utils/logger.py
@@ -31,7 +31,7 @@ TERMINAL_LOGGER_FORMATTER = colorlog.ColoredFormatter(
                                     CRITICAL='bold_red,bg_white',))
 
 
-def configure_terminal_logging(level: int):
+def configure_terminal_logging(level: int) -> None:
     """Configure logger to print to terminal.
 
     :param level: Logging level, default DEBUG
@@ -43,7 +43,7 @@ def configure_terminal_logging(level: int):
     logger.addHandler(stream_handler)
 
 
-def configure_file_logging(log_file: str, level: int):
+def configure_file_logging(log_file: str, level: int) -> None:
     """Configure logger to print to file.
 
     :param log_file: Path to log file
@@ -56,7 +56,10 @@ def configure_file_logging(log_file: str, level: int):
     logger.addHandler(file_handler)
 
 
-def configure_logging(log_mode: str, log_file: str, level: int = logging.INFO):
+def configure_logging(
+        log_mode: str,
+        log_file: str,
+        level: int = logging.INFO) -> None:
     """Configure logging format and level.
 
     :param log_mode: Where to send the logs, file, terminal or both

--- a/cibyl/utils/logger.py
+++ b/cibyl/utils/logger.py
@@ -31,11 +31,10 @@ TERMINAL_LOGGER_FORMATTER = colorlog.ColoredFormatter(
                                     CRITICAL='bold_red,bg_white',))
 
 
-def configure_terminal_logging(level):
+def configure_terminal_logging(level: int):
     """Configure logger to print to terminal.
 
     :param level: Logging level, default DEBUG
-    :type level: int
     """
     logger = logging.getLogger('cibyl')
     stream_handler = logging.StreamHandler(sys.stderr)
@@ -44,13 +43,11 @@ def configure_terminal_logging(level):
     logger.addHandler(stream_handler)
 
 
-def configure_file_logging(log_file, level):
+def configure_file_logging(log_file: str, level: int):
     """Configure logger to print to file.
 
     :param log_file: Path to log file
-    :param log_file: str
     :param level: Logging level, default DEBUG
-    :type level: int
     """
     logger = logging.getLogger('cibyl')
     file_handler = logging.FileHandler(log_file, mode="w")
@@ -59,15 +56,13 @@ def configure_file_logging(log_file, level):
     logger.addHandler(file_handler)
 
 
-def configure_logging(log_mode, log_file, level=logging.INFO):
+def configure_logging(log_mode: str, log_file: str, level: int = logging.INFO):
     """Configure logging format and level.
 
     :param log_mode: Where to send the logs, file, terminal or both
-    :type log_mode: str
     :param log_file: Path to log file
     :param log_file: str
     :param level: Logging level, default DEBUG
-    :type level: int
     """
     # configure a top-level cibyl logger instead of the root logger,
     # to suppress logging coming from other libraries

--- a/cibyl/utils/net.py
+++ b/cibyl/utils/net.py
@@ -15,6 +15,7 @@
 """
 import logging
 import os
+from typing import Optional
 
 import requests
 
@@ -26,7 +27,7 @@ class DownloadError(Exception):
     """
 
 
-def download_file(url: str, dest: str):
+def download_file(url: str, dest: str) -> None:
     """Downloads a file from a remote host into the local filesystem.
 
     Supported protocols are:
@@ -69,7 +70,7 @@ def download_file(url: str, dest: str):
                 file.write(chunk)
 
 
-def download_into_memory(url: str, session: requests.Session = None) -> str:
+def download_into_memory(url: str, session: Optional[requests.Session] = None) -> str:
     """Downloads the contents of a URL into memory, leaving the filesystem
     untouched.
 

--- a/cibyl/utils/net.py
+++ b/cibyl/utils/net.py
@@ -70,7 +70,9 @@ def download_file(url: str, dest: str) -> None:
                 file.write(chunk)
 
 
-def download_into_memory(url: str, session: Optional[requests.Session] = None) -> str:
+def download_into_memory(url: str,
+                         session: Optional[requests.Session] = None
+                         ) -> str:
     """Downloads the contents of a URL into memory, leaving the filesystem
     untouched.
 

--- a/cibyl/utils/net.py
+++ b/cibyl/utils/net.py
@@ -26,7 +26,7 @@ class DownloadError(Exception):
     """
 
 
-def download_file(url, dest):
+def download_file(url: str, dest: str):
     """Downloads a file from a remote host into the local filesystem.
 
     Supported protocols are:
@@ -69,7 +69,7 @@ def download_file(url, dest):
                 file.write(chunk)
 
 
-def download_into_memory(url, session=None):
+def download_into_memory(url: str, session: requests.Session = None) -> str:
     """Downloads the contents of a URL into memory, leaving the filesystem
     untouched.
 
@@ -81,12 +81,9 @@ def download_into_memory(url, session=None):
         >>> download_into_memory('http://localhost/file.txt')
 
     :param url: URL to download.
-    :type url: str
     :param session: Session used to perform request. This function will not
         close the session, that task is up to the caller.
-    :type session: :class:`requests.Session` or None
     :return: Contents of the page.
-    :rtype: str
     :raise DownloadError: If the download failed.
     """
     LOG.info("Downloading file from: '%s'", url)

--- a/cibyl/utils/reflection.py
+++ b/cibyl/utils/reflection.py
@@ -15,17 +15,17 @@
 """
 import importlib.util
 import inspect
+from types import ModuleType
+from typing import Callable, List
 
 from cibyl.utils.files import get_file_name_from_path
 
 
-def load_module(path):
+def load_module(path: str) -> ModuleType:
     """Loads a Python module given its location.
 
     :param path: Absolute path to the module to be loaded.
-    :type path: str
     :return: The loaded module.
-    :rtype: :class:`ModuleType`
     """
     spec = importlib.util.spec_from_file_location(
         get_file_name_from_path(path), path
@@ -38,19 +38,18 @@ def load_module(path):
     return module
 
 
-def get_classes_in(__module, predicate=None, return_name=False):
+def get_classes_in(
+        __module: ModuleType,
+        predicate: Callable = None,
+        return_name: bool = False) -> List[type]:
     """Gets all class symbols stored within a Python module.
 
     :param __module: The module to get the classes from.
-    :type __module: :class:`types.ModuleType`
     :param predicate: A callable to pass to inspect.getmembers to filter the
     symbols found
-    :type predicate: callable
     :param return_name: Whether to return the name of the classes found, as
     inpect.getmembers does
-    :type return_name: bool
     :return: List of all classes stored in the module.
-    :rtype: list[type]
     """
     if predicate is None:
         predicate = inspect.isclass

--- a/cibyl/utils/reflection.py
+++ b/cibyl/utils/reflection.py
@@ -16,7 +16,7 @@
 import importlib.util
 import inspect
 from types import ModuleType
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 from cibyl.utils.files import get_file_name_from_path
 
@@ -40,7 +40,7 @@ def load_module(path: str) -> ModuleType:
 
 def get_classes_in(
         __module: ModuleType,
-        predicate: Callable = None,
+        predicate: Optional[Callable] = None,
         return_name: bool = False) -> List[type]:
     """Gets all class symbols stored within a Python module.
 

--- a/cibyl/utils/sorting.py
+++ b/cibyl/utils/sorting.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 from abc import ABC, abstractmethod
+from typing import Any, Iterable
 
 from overrides import overrides
 
@@ -25,16 +26,13 @@ class Comparator(ABC):
     """
 
     @abstractmethod
-    def compare(self, left, right):
+    def compare(self, left: Any, right: Any) -> int:
         """Compares the two arguments for order.
 
         :param left: First object to be compared.
-        :type left: Any
         :param right: Second object to be compared.
-        :type right: Any
         :return: A negative integer, zero or a positive integer as the left
             argument is less than, equal to or greater than the right one.
-        :rtype: int
         """
         raise NotImplementedError
 
@@ -45,7 +43,7 @@ class NativeComparator(Comparator):
     '__eq__' and '__lt__' methods."""
 
     @overrides
-    def compare(self, left, right):
+    def compare(self, left: Any, right: Any) -> int:
         if left == right:
             return 0
 
@@ -58,24 +56,21 @@ class SortingAlgorithm(ABC):
     These rules are defines by the comparator in use.
     """
 
-    def __init__(self, comparator=NativeComparator()):
+    def __init__(self, comparator: Comparator = NativeComparator()):
         """Constructor.
 
         :param comparator: Comparison function this uses to determine order.
-        :type comparator: :class:`Comparator`
         """
         self._comparator = comparator
 
     @abstractmethod
-    def sort(self, iterable):
+    def sort(self, iterable: Iterable) -> list:
         """Sorts the given collection in ascending order. The original
         collection remains untouched, instead, a sorted copy of it is returned.
 
         :param iterable: The collection to be sorted.
-        :type iterable: :class:`typing.Iterable`
         :return: The same collection, sorted following this algorithm's
             comparator.
-        :rtype: list
         """
         raise NotImplementedError
 
@@ -86,8 +81,8 @@ class BubbleSortAlgorithm(SortingAlgorithm):
     """
 
     @overrides
-    def sort(self, iterable):
-        def compare(lft, rght):
+    def sort(self, iterable: Iterable) -> list:
+        def compare(lft: Any, rght: Any):
             return self._comparator.compare(lft, rght)
 
         result = list(iterable)  # Do not affect the original list
@@ -104,21 +99,20 @@ class BubbleSortAlgorithm(SortingAlgorithm):
         return result
 
 
-def sort(iterable, algorithm=BubbleSortAlgorithm()):
+def sort(iterable: Iterable,
+         algorithm: SortingAlgorithm = BubbleSortAlgorithm()) -> list:
     """Shortcut for sorting the elements of a collection.
 
     :param iterable: The collection to sort.
-    :type iterable: :class:`typing.Iterable`
     :param algorithm: The algorithm that will be used to sort the collection.
         Contains the comparator used to determine order.
-    :type algorithm: :class:`SortingAlgorithm`
     :return: A copy of the input collection, sorted by the algorithm.
-    :rtype: list
     """
     return algorithm.sort(iterable)
 
 
-def nsort(iterable, algorithm=BubbleSortAlgorithm()):
+def nsort(iterable: Iterable,
+          algorithm: SortingAlgorithm = BubbleSortAlgorithm()) -> list:
     """Same as :func:`sort`, but this one reverses the collection before
     returning it. Use this function to get sorting in descending order.
     """

--- a/cibyl/utils/sorting.py
+++ b/cibyl/utils/sorting.py
@@ -82,7 +82,7 @@ class BubbleSortAlgorithm(SortingAlgorithm):
 
     @overrides
     def sort(self, iterable: Iterable) -> list:
-        def compare(lft: Any, rght: Any):
+        def compare(lft, rght):
             return self._comparator.compare(lft, rght)
 
         result = list(iterable)  # Do not affect the original list

--- a/cibyl/utils/status_bar.py
+++ b/cibyl/utils/status_bar.py
@@ -43,7 +43,7 @@ class StatusBar(threading.Thread):
         self.status_text = status_text
         self.update_frequency = update_frequency
 
-    def run(self):
+    def run(self) -> None:
         """Prints the animation to stdout"""
         characters = ['.   ', ' .  ', '  . ', '   .']
         for character in itertools.cycle(characters):

--- a/cibyl/utils/strings.py
+++ b/cibyl/utils/strings.py
@@ -55,7 +55,7 @@ class IndentedTextBuilder:
             """
             return self._level
 
-        def append(self, text: str):
+        def append(self, text: str) -> None:
             """Adds additional text at the end of this line.
 
             :param text: The text to add.
@@ -100,7 +100,6 @@ class IndentedTextBuilder:
         """Generates the text stored in the builder.
 
         :return: The generated piece of text.
-        :rtype: str
         """
         result = ''
 

--- a/cibyl/utils/strings.py
+++ b/cibyl/utils/strings.py
@@ -27,13 +27,11 @@ class IndentedTextBuilder:
         """A line of text.
         """
 
-        def __init__(self, text, level):
+        def __init__(self, text: str, level: int):
             """Constructor.
 
             :param text: The text on this line.
-            :type text: str
             :param level: The indentation level of this line.
-            :type level: int
             """
             self._text = text
             self._level = level
@@ -57,18 +55,17 @@ class IndentedTextBuilder:
             """
             return self._level
 
-        def append(self, text):
+        def append(self, text: str):
             """Adds additional text at the end of this line.
 
             :param text: The text to add.
             """
             self._text += str(text)
 
-    def __init__(self, spaces_per_tab=2):
+    def __init__(self, spaces_per_tab: int = 2):
         """Constructor.
 
         :param spaces_per_tab: Amount of spaces per indentation level.
-        :type spaces_per_tab: int
         """
         self._lines = []
         self._spaces_per_tab = spaces_per_tab
@@ -83,27 +80,23 @@ class IndentedTextBuilder:
         return self._lines.pop(index)
 
     @property
-    def spaces_per_tab(self):
+    def spaces_per_tab(self) -> int:
         """
         :return: Amount of spaces per indentation level.
-        :rtype: int
         """
         return self._spaces_per_tab
 
-    def add(self, text, level):
+    def add(self, text: str, level: int) -> 'IndentedTextBuilder':
         """Adds an additional line of text.
 
         :param text: The text to add.
-        :type text: str
         :param level: The indentation level.
-        :type level: int
         :return: The builder instance.
-        :rtype: :class:`IndentedTextBuilder`
         """
         self._lines.append(self.Line(text, level))
         return self
 
-    def build(self):
+    def build(self) -> str:
         """Generates the text stored in the builder.
 
         :return: The generated piece of text.

--- a/cibyl/utils/time.py
+++ b/cibyl/utils/time.py
@@ -15,12 +15,10 @@
 """
 
 
-def as_minutes(ms):
+def as_minutes(ms: int) -> int:
     """Converts ms to mins.
 
     :param ms: The ms to converts.
-    :type ms: int
     :return: The time in minutes.
-    :rtype: int
     """
     return ms / 60000

--- a/cibyl/utils/yaml.py
+++ b/cibyl/utils/yaml.py
@@ -22,13 +22,11 @@ class YAMLError(Exception):
     """
 
 
-def parse(file):
+def parse(file: str) -> dict:
     """Reads a YAML file.
 
     :param file: Path to the YAML file to be read.
-    :type file: str
     :return: The contents of the YAML file.
-    :rtype: dict
     :raises YAMLError: If the file failed to be loaded.
     """
     try:


### PR DESCRIPTION
- Add type hints for utils subpackage
- Remove type hints in docstring

Note: It seems that we aren't able to specify the return type for a self class if Python version <= 3.11 (from typing import Self - https://peps.python.org/pep-0673/). I've seen the way to specify the same class is in a string way. If the self class is e.g. Production then the type should be 'Production'.