### PR TITLE
Print a message when a build has no tests

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -35,7 +35,9 @@ class QueryType(IntEnum):
     """Retrieve data concerning jobs and above."""
     BUILDS = 6
     """Retrieve data concerning builds and above."""
-    FEATURES_JOBS = 7
+    TESTS = 7
+    """Retrieve data concerning tests and above."""
+    FEATURES_JOBS = 8
     """Retrieve data using features and jobs."""
 
 
@@ -77,6 +79,10 @@ class QuerySelector:
         build_args = subset(kwargs, ["builds", "last_build", "build_status"])
         if build_args:
             result = QueryType.BUILDS
+
+        test_args = subset(kwargs, ["tests", "test_result", "test_duration"])
+        if test_args:
+            result = QueryType.TESTS
 
         if 'features' in kwargs:
             if job_args:

--- a/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
@@ -107,9 +107,13 @@ class ColoredJobsSystemPrinter(ColoredBaseSystemPrinter):
             if build.duration.value:
                 printer.add(get_duration_section(self.palette, build), 1)
 
-        if build.tests.value:
-            for test in build.tests.values():
-                printer.add(self.print_test(test), 1)
+        if self.query >= QueryType.TESTS:
+            if build.tests.value:
+                for test in build.tests.values():
+                    printer.add(self.print_test(test), 1)
+            else:
+                msg = 'No tests in query.'
+                printer.add(self.palette.red(msg), 1)
 
         if build.stages.value:
             printer.add(self.palette.blue('Stages: '), 1)

--- a/tests/cibyl/unit/cli/test_query.py
+++ b/tests/cibyl/unit/cli/test_query.py
@@ -98,6 +98,33 @@ class TestGetQueryType(TestCase):
 
         self.assertEqual(QueryType.BUILDS, get_query_type(**args))
 
+    def test_get_tests(self):
+        """Checks that "Tests" is returned for "--tests".
+        """
+        args = {
+            'tests': None
+        }
+
+        self.assertEqual(QueryType.TESTS, get_query_type(**args))
+
+    def test_get_test_duration(self):
+        """Checks that "Tests" is returned for "--test-duration".
+        """
+        args = {
+            'test_duration': None
+        }
+
+        self.assertEqual(QueryType.TESTS, get_query_type(**args))
+
+    def test_get_test_result(self):
+        """Checks that "Tests" is returned for "--test-result".
+        """
+        args = {
+            'test_result': None
+        }
+
+        self.assertEqual(QueryType.TESTS, get_query_type(**args))
+
     def test_get_variants(self):
         """Checks that "Jobs" is returned for "--variants"."""
         args = {
@@ -132,6 +159,16 @@ class TestGetQueryType(TestCase):
         }
 
         self.assertEqual(QueryType.FEATURES_JOBS, get_query_type(**args))
+
+    def test_get_tests_builds(self):
+        """Checks that "Tests" is returned for "--tests" and "--last-build".
+        """
+        args = {
+            'tests': None,
+            'last_build': None
+        }
+
+        self.assertEqual(QueryType.TESTS, get_query_type(**args))
 
 
 class TestGetQueryTypeOpenstackPlugin(OpenstackPluginWithJobSystem):


### PR DESCRIPTION
If a call to get_tests returns a job that had no tests, print a message
indicating so to the user. Adding this message required adding the TESTS
QueryType.
