### PR TITLE
Filter jobs without tests in Elasticsearh when needed

### DIFF
--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -24,6 +24,7 @@ from urllib.parse import urlparse
 import requests
 import urllib3
 
+from cibyl.cli.argument import Argument
 from cibyl.exceptions.jenkins import JenkinsError
 from cibyl.models.attribute import AttributeDictValue, AttributeListValue
 from cibyl.models.ci.base.build import Build
@@ -37,6 +38,7 @@ from cibyl.utils.filtering import (apply_filters,
                                    satisfy_case_insensitive_match,
                                    satisfy_exact_match, satisfy_range_match,
                                    satisfy_regex_match)
+from cibyl.utils.models import has_tests_job
 
 LOG = logging.getLogger(__name__)
 
@@ -112,7 +114,6 @@ def has_filter_builds(**kwargs):
 
 def has_filter_tests(**kwargs):
     """Check if the kwargs contain any argument with value to filter tests.
-
     :returns: Whether there is any tests-related argument that has a value to
     filter the found tests.
     :rtype: bool
@@ -158,8 +159,8 @@ def is_test(test):
     return bool(test['className'])
 
 
-def filter_tests(tests_found: List[Dict], **kwargs):
-    """Filter the tests obtainedfrom the Jenkins API according to
+def filter_tests(tests_found: List[Dict], **kwargs: Argument) -> List[Dict]:
+    """Filter the tests obtained from the Jenkins API according to
     user input."""
     checks_to_apply = [is_test]
 
@@ -182,19 +183,6 @@ def filter_tests(tests_found: List[Dict], **kwargs):
                                        field_to_check="duration"))
 
     return apply_filters(tests_found, *checks_to_apply)
-
-
-def has_tests_job(job: Job):
-    """Check if a job has any tests added.
-    :param job: Job to check
-    :type job: :class:`Job`
-    :returns: whether the job has any tests
-    :rtype: bool
-    """
-    for build in job.builds.values():
-        if build.tests.value:
-            return True
-    return False
 
 
 # pylint: disable=no-member

--- a/cibyl/utils/models.py
+++ b/cibyl/utils/models.py
@@ -1,0 +1,28 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+
+from cibyl.models.ci.base.job import Job
+
+
+def has_tests_job(job: Job) -> bool:
+    """Check if a job has any tests added.
+    :param job: Job to check
+    :returns: whether the job has any tests
+    """
+    for build in job.builds.values():
+        if build.tests.value:
+            return True
+    return False

--- a/tests/cibyl/unit/sources/elasticsearch/test_api.py
+++ b/tests/cibyl/unit/sources/elasticsearch/test_api.py
@@ -348,6 +348,31 @@ class TestElasticSearch(TestCase):
             1
         )
 
+    @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
+    def test_get_tests_jobs_filtered_no_tests(self: object,
+                                              mock_query_hits: object) -> None:
+        """Tests internal logic :meth:`ElasticSearch.get_tests`
+            is correct and filters by test name supporting regex, if some jobs
+            turn out to have no tests as a result of the filtering, they should
+            not be returned.
+        """
+        mock_query_hits.return_value = self.tests_hits
+
+        builds_kwargs = MagicMock()
+        builds_value = PropertyMock(return_value=[])
+        type(builds_kwargs).value = builds_value
+
+        tests_kwargs = MagicMock()
+        tests_value = PropertyMock(return_value=["test3$"])
+        type(tests_kwargs).value = tests_value
+
+        tests = self.es_api.get_tests(
+            builds=builds_kwargs,
+            tests=tests_kwargs
+        )
+
+        self.assertEqual(len(tests), 0)
+
     @patch('cibyl.sources.elasticsearch.api.ElasticSearchClient')
     def test_setup(self, mock_client):
         """Test setup method of ElasticSearch"""

--- a/tests/cibyl/unit/utils/test_models.py
+++ b/tests/cibyl/unit/utils/test_models.py
@@ -1,0 +1,50 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.models.ci.base.build import Build
+from cibyl.models.ci.base.job import Job
+from cibyl.models.ci.base.test import Test
+from cibyl.utils.models import has_tests_job
+
+
+class TestHastTestJob(TestCase):
+    """Test has_tests_job function of utils.models module."""
+    def test_has_tests_job_with_tests(self):
+        """Checks that has_tests_job identifies that a job has tests.
+        """
+        test = Test(name="test")
+        build = Build(build_id="1")
+        build.add_test(test)
+        job = Job(name="test")
+        job.add_build(build)
+        self.assertTrue(has_tests_job(job))
+
+    def test_has_tests_job_with_build_no_tests(self):
+        """Checks that has_tests_job identifies that a job has builds but no
+        tests.
+        """
+        build = Build(build_id="1")
+        job = Job(name="test")
+        job.add_build(build)
+        self.assertFalse(has_tests_job(job))
+
+    def test_has_tests_job_with_no_build_no_tests(self):
+        """Checks that has_tests_job identifies that a job has no builds and no
+        tests.
+        """
+        job = Job(name="test")
+        self.assertFalse(has_tests_job(job))


### PR DESCRIPTION
When querying for tests in Elasticsearh source with some filtering
(--test-result, --test-duration for example), filter the jobs that have
no tests matching the criteria. If the user passes no filter, then all
jobs will be kept, even those without any tests.

Since the same functionality was recently added to the Jenkins source,
this change reuses the same solution by extracting some functions
to modules in the utils subpackage.
