### PR TITLE
Filter jobs without builds in Elasticsearch when needed

### DIFF
--- a/cibyl/sources/elasticsearch/api.py
+++ b/cibyl/sources/elasticsearch/api.py
@@ -35,7 +35,7 @@ from cibyl.sources.source import speed_index
 from cibyl.utils.dicts import chunk_dictionary_into_lists
 from cibyl.utils.filtering import (apply_filters, matches_regex,
                                    satisfy_exact_match, satisfy_regex_match)
-from cibyl.utils.models import has_tests_job
+from cibyl.utils.models import has_builds_job, has_tests_job
 
 LOG = logging.getLogger(__name__)
 
@@ -175,13 +175,12 @@ class ElasticSearch(ServerSource):
             ) from exception
 
     @speed_index({'base': 2})
-    def get_builds(self, **kwargs: Argument):
+    def get_builds(self, **kwargs: Argument) -> AttributeDictValue:
         """
             Get builds from elasticsearch server.
 
             :returns: container of jobs with build information from
             elasticsearch server
-            :rtype: :class:`AttributeDictValue`
         """
         jobs_found = self.get_jobs(**kwargs)
 
@@ -225,15 +224,21 @@ class ElasticSearch(ServerSource):
 
             query_body['query']['bool']['should'].clear()
 
+        # keep track if there is any flag that would
+        # cause builds to be filtered, to remove later jobs that are empty due
+        # to this filtering
+        filtering_builds = False
         build_statuses = []
         if 'build_status' in kwargs:
             build_statuses = [status.upper()
                               for status in
                               kwargs.get('build_status').value]
+            filtering_builds |= bool(build_statuses)
 
         build_id_argument = None
         if 'builds' in kwargs:
             build_id_argument = kwargs.get('builds').value
+            filtering_builds |= bool(build_id_argument)
 
         for build in builds:
             build_result = None
@@ -256,18 +261,27 @@ class ElasticSearch(ServerSource):
                                            build_result,
                                            build['_source']['time_duration']))
 
+        final_jobs = jobs_found.value
+        if filtering_builds:
+            # if there was some argument that leads to filtering out tests,
+            # make sure that the output jobs have at least one test
+            final_jobs = {job_name: job for job_name, job in
+                          jobs_found.items() if has_builds_job(job)}
+        jobs_found = AttributeDictValue("jobs", attr_type=Job,
+                                        value=final_jobs)
+
         if 'last_build' in kwargs:
             return self.get_last_build(jobs_found)
 
         return jobs_found
 
-    def get_last_build(self, builds_jobs: AttributeDictValue):
+    def get_last_build(self,
+                       builds_jobs: AttributeDictValue) -> AttributeDictValue:
         """
             Get last build from builds. It's determined
             by the build_id
 
             :returns: container of jobs with last build information
-            :rtype: :class:`AttributeDictValue`
         """
         job_object = {}
         for job_name, build_info in builds_jobs.items():
@@ -288,13 +302,12 @@ class ElasticSearch(ServerSource):
         return AttributeDictValue("jobs", attr_type=Job, value=job_object)
 
     @speed_index({'base': 3})
-    def get_tests(self, **kwargs: Argument):
+    def get_tests(self, **kwargs: Argument) -> AttributeDictValue:
         """
             Get tests for a elasticsearch job.
 
             :returns: container of jobs with the last completed build
             (if any) and the tests
-            :rtype: :class:`AttributeDictValue`
         """
         self.check_builds_for_test(**kwargs)
 
@@ -327,6 +340,9 @@ class ElasticSearch(ServerSource):
             "sort": [{"timestamp.keyword": {"order": "desc"}}]
         }
 
+        # keep track if there is any flag that would
+        # cause tests to be filtered, to remove later jobs that are empty due
+        # to this filtering
         tests_filtering = False
         tests_pattern = None
         if 'tests' in kwargs and kwargs['tests'].value:
@@ -335,15 +351,15 @@ class ElasticSearch(ServerSource):
 
         test_result_argument = []
         if 'test_result' in kwargs:
-            tests_filtering = True
             test_result_argument = [status.upper()
                                     for status in
                                     kwargs.get('test_result').value]
+            tests_filtering |= bool(test_result_argument)
 
         test_duration_arguments = []
         if 'test_duration' in kwargs:
-            tests_filtering = True
             test_duration_arguments = kwargs.get('test_duration').value
+            tests_filtering |= bool(test_duration_arguments)
 
         hits = []
         for job in job_builds_found:

--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -38,7 +38,7 @@ from cibyl.utils.filtering import (apply_filters,
                                    satisfy_case_insensitive_match,
                                    satisfy_exact_match, satisfy_range_match,
                                    satisfy_regex_match)
-from cibyl.utils.models import has_tests_job
+from cibyl.utils.models import has_builds_job, has_tests_job
 
 LOG = logging.getLogger(__name__)
 
@@ -370,7 +370,7 @@ try reducing verbosity for quicker query")
                                          stages=build_stages)
                     job.add_build(build_object)
 
-            has_builds = bool(job.builds.value)
+            has_builds = has_builds_job(job)
             if (filtering_builds and has_builds) or not filtering_builds:
                 jobs_with_builds[job_name] = job
 

--- a/cibyl/utils/models.py
+++ b/cibyl/utils/models.py
@@ -26,3 +26,11 @@ def has_tests_job(job: Job) -> bool:
         if build.tests.value:
             return True
     return False
+
+
+def has_builds_job(job: Job) -> bool:
+    """Check if a job has any builds added.
+    :param job: Job to check
+    :returns: whether the job has any builds
+    """
+    return bool(job.builds.value)


### PR DESCRIPTION
When querying for builds in Elasticsearch source with some filtering
(--builds, --build-status for example), filter the jobs that have
no builds matching the criteria. If the user passes no filter, then all
jobs will be kept, even those without any builds.
