### PR TITLE
Rename --env-name argument to --envs in validator

### DIFF
--- a/cibyl/cli/validator.py
+++ b/cibyl/cli/validator.py
@@ -62,7 +62,7 @@ class Validator:
         :param env: Model to validate
         :returns: Whether the environment is consistent with user input
         """
-        user_env = self.ci_args.get("env_name")
+        user_env = self.ci_args.get("envs")
         if user_env:
             return env.name.value in user_env.value
         return True

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -14,7 +14,7 @@ Jobs
 
 Running ``cibyl --jobs`` will retrieve information on all the jobs for each environment specified in your configuration.
 
-In order to retrieve jobs for a specific environment, use the ``--env-name Environment`` argument.
+In order to retrieve jobs for a specific environment, use the ``--envs Environment`` argument.
 If the environment includes multiple systems, you can also choose a specific system with the ``--systems System`` argument.
 
 Python

--- a/tests/cibyl/unit/cli/test_validator.py
+++ b/tests/cibyl/unit/cli/test_validator.py
@@ -96,8 +96,8 @@ class TestValidator(TestCase):
         """Testing Validator validate_environment method."""
         self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
-        self.ci_args["env_name"] = Mock()
-        self.ci_args["env_name"].value = ["env"]
+        self.ci_args["envs"] = Mock()
+        self.ci_args["envs"].value = ["env"]
         validator = Validator(self.ci_args)
         original_envs = self.orchestrator.environments
 
@@ -114,8 +114,8 @@ class TestValidator(TestCase):
         """Testing Validator validate_environment method."""
         self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
-        self.ci_args["env_name"] = Mock()
-        self.ci_args["env_name"].value = ["env"]
+        self.ci_args["envs"] = Mock()
+        self.ci_args["envs"].value = ["env"]
         self.ci_args["systems"] = Mock()
         self.ci_args["systems"].value = ["system3"]
 
@@ -133,8 +133,8 @@ class TestValidator(TestCase):
         """Testing Validator validate_environment method."""
         self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
-        self.ci_args["env_name"] = Mock()
-        self.ci_args["env_name"].value = ["env"]
+        self.ci_args["envs"] = Mock()
+        self.ci_args["envs"].value = ["env"]
         self.ci_args["system_type"] = Mock()
         self.ci_args["system_type"].value = ["jenkins"]
 
@@ -152,8 +152,8 @@ class TestValidator(TestCase):
         """Testing Validator validate_environment method."""
         self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
-        self.ci_args["env_name"] = Mock()
-        self.ci_args["env_name"].value = ["env"]
+        self.ci_args["envs"] = Mock()
+        self.ci_args["envs"].value = ["env"]
         self.ci_args["system_type"] = Mock()
         self.ci_args["system_type"].value = ["unk"]
 
@@ -220,8 +220,8 @@ class TestValidator(TestCase):
         """Test Validator validate_environments with no sources."""
         self.orchestrator.config = AppConfig(data=self.config)
         self.orchestrator.create_ci_environments()
-        self.ci_args["env_name"] = Mock()
-        self.ci_args["env_name"].value = ["env"]
+        self.ci_args["envs"] = Mock()
+        self.ci_args["envs"].value = ["env"]
         self.ci_args["sources"] = Mock()
         self.ci_args["sources"].value = ["zuul"]
 


### PR DESCRIPTION
After renaming the --env-name argument to --envs, this change was not
reflected in the validator or its tests, so the argument was not being
applied.
