### PR TITLE
Add --test-setup argument to openstack plugin

### DIFF
--- a/cibyl/cli/argument.py
+++ b/cibyl/cli/argument.py
@@ -14,7 +14,7 @@
 #    under the License.
 """
 import argparse
-from typing import List, Type, Union
+from typing import Iterable, List, Optional, Type, Union
 
 from cibyl.cli.ranged_argument import (EXPRESSION_PATTERN, RANGE_OPERATORS,
                                        VALID_OPS, Range)
@@ -29,7 +29,7 @@ class Argument():
                  description: str, nargs: Union[str, int] = 1,
                  func: str = None, populated: bool = False, level: int = 0,
                  ranged: bool = False, value: List[str] = None,
-                 default: object = None):
+                 default: object = None, choices: Optional[Iterable] = None):
         self.name = name
 
         self.arg_type = arg_type
@@ -44,6 +44,7 @@ class Argument():
         else:
             self.value = value
         self.default = default
+        self.choices = choices
 
     def parse_ranges(self, expressions: List[str]) -> List[Range]:
         parsed_expressions = []

--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -154,6 +154,6 @@ class Parser:
                     ranged=arg.ranged,
                     populated=arg.populated,
                     default=arg.default,
-                    level=level)
+                    level=level, choices=arg.choices)
         except argparse.ArgumentError:
             pass

--- a/cibyl/plugins/openstack/__init__.py
+++ b/cibyl/plugins/openstack/__init__.py
@@ -25,7 +25,8 @@ PLUGIN_ARGUMENTS = ('release', 'spec', 'infra_type', 'nodes', 'controllers',
                     'computes', 'node_name', 'role', 'containers',
                     'container_image', 'packages', 'services', 'ip_version',
                     'topology', 'dvr', 'ml2_driver', 'tls_everywhere',
-                    'ironic_inspector', 'network_backend', 'cinder_backend')
+                    'ironic_inspector', 'network_backend', 'cinder_backend',
+                    'test_setup')
 
 
 def add_deployment(self, deployment: Deployment) -> None:

--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -111,7 +111,10 @@ class Deployment(Model):
         },
         'test_collection': {
             'attr_type': TestCollection,
-            'arguments': []
+            'arguments': [Argument(name="--test-setup", arg_type=str,
+                                   func='get_deployment', nargs=1,
+                                   choices=('rpm', 'git'),
+                                   description="Source for the test setup")]
         },
         'network_backend': {
             'attr_type': str,

--- a/cibyl/plugins/openstack/test_collection.py
+++ b/cibyl/plugins/openstack/test_collection.py
@@ -35,7 +35,8 @@ class TestCollection(Model):
         }
     }
 
-    def __init__(self, tests: Optional[Set[str]] = None, setup: str = None):
+    def __init__(self, tests: Optional[Set[str]] = None,
+                 setup: Optional[str] = None):
         if tests is None:
             tests = set()
         super().__init__({'tests': tests, 'setup': setup})

--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -138,3 +138,10 @@ Arguments Matrix
      - |:black_square_button:|
      - |:x:|
      - |:x:|
+   * - --test-setup
+     - | Source of test setup (rpm, git)
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|

--- a/tests/cibyl/unit/test_orchestrator.py
+++ b/tests/cibyl/unit/test_orchestrator.py
@@ -312,8 +312,18 @@ class TestArgumentsFilteringOpenstack(OpenstackPluginWithJobSystem,
         """Test that sort_and_filter_args handles properly the case with many
         arguments that should query get_deployment with different levels."""
         self.orchestrator.parser.parse(["--jobs", "--ip-version",
-                                        "--packages", '--release'])
+                                        "--packages", "--release"])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(len(args), 2)
         self.assertEqual(args[0].name, "packages")
         self.assertEqual(args[1].name, "jobs")
+
+
+class TestArgumentsParsingOpenstack(OpenstackPluginWithJobSystem,
+                                    TestOrchestratorArgumentsFiltering):
+    """Test argument parsing behavior for some openstack arguments"""
+    def test_test_setup_choices(self):
+        """Test that an exception is raised when calling --test-setup with
+        a non-existing option."""
+        with self.assertRaises(SystemExit):
+            self.orchestrator.parser.parse(["--test-setup", "non-existing"])


### PR DESCRIPTION
This change adds the --test-setup argument to the openstack plugin and
adds it to the list of openstack argument to properly detect the query
type. The argument still needs to be supported by the sources.
