### PR TITLE
Split openstack deployment properties into models

### DIFF
--- a/cibyl/plugins/openstack/ironic.py
+++ b/cibyl/plugins/openstack/ironic.py
@@ -1,0 +1,50 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from typing import Optional
+
+from cibyl.models.model import Model
+
+# pylint: disable=no-member
+
+
+class Ironic(Model):
+    """Ironic-related properties of an openstack deployment"""
+
+    API = {
+        'cleaning_network': {
+            'arguments': []
+        },
+        'ironic_inspector': {
+            'arguments': []
+        }
+    }
+
+    def __init__(self, ironic_inspector: Optional[str] = None,
+                 cleaning_network: Optional[str] = None):
+        super().__init__({'ironic_inspector': ironic_inspector,
+                          'cleaning_network': cleaning_network})
+
+    def merge(self, other: 'Ironic'):
+        """Merge the information of two deployment objects representing the
+        same deployment.
+
+        :param other: The Deployment object to merge
+        :type other: :class:`.Deployment`
+        """
+        if not self.ironic_inspector.value:
+            self.ironic_inspector.value = other.ironic_inspector.value
+        if not self.cleaning_network.value:
+            self.cleaning_network.value = other.cleaning_network.value

--- a/cibyl/plugins/openstack/network.py
+++ b/cibyl/plugins/openstack/network.py
@@ -1,0 +1,80 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from typing import Optional
+
+from cibyl.models.model import Model
+
+# pylint: disable=no-member
+
+
+class Network(Model):
+    """Network properties of an openstack deployment"""
+
+    API = {
+        'ip_version': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'ml2_driver': {
+            'attr_type': str,
+            'arguments': []
+        },
+        'dvr': {
+            'arguments': []
+        },
+        'tls_everywhere': {
+            'arguments': []
+        },
+        'security_group': {
+            'arguments': []
+        },
+        'network_backend': {
+            'attr_type': str,
+            'arguments': []
+        },
+    }
+
+    def __init__(self, ip_version: Optional[str] = None,
+                 network_backend: Optional[str] = None,
+                 dvr: Optional[str] = None,
+                 tls_everywhere: Optional[str] = None,
+                 ml2_driver: Optional[str] = None,
+                 security_group: Optional[str] = None):
+        super().__init__({
+                          'ip_version': ip_version,
+                          'network_backend': network_backend,
+                          'dvr': dvr, 'tls_everywhere': tls_everywhere,
+                          'ml2_driver': ml2_driver,
+                          'security_group': security_group})
+
+    def merge(self, other: 'Network') -> None:
+        """Merge the information of two deployment objects representing the
+        same deployment.
+
+        :param other: The Deployment object to merge
+        """
+        if not self.ip_version.value:
+            self.ip_version.value = other.ip_version.value
+        if not self.network_backend.value:
+            self.network_backend.value = other.network_backend.value
+        if not self.dvr.value:
+            self.dvr.value = other.dvr.value
+        if not self.tls_everywhere.value:
+            self.tls_everywhere.value = other.tls_everywhere.value
+        if not self.ml2_driver.value:
+            self.ml2_driver.value = other.ml2_driver.value
+        if not self.security_group.value:
+            self.security_group.value = other.security_group.value

--- a/cibyl/plugins/openstack/printers/colored.py
+++ b/cibyl/plugins/openstack/printers/colored.py
@@ -15,7 +15,10 @@
 """
 from cibyl.cli.query import QueryType
 from cibyl.outputs.cli.ci.system.common.stages import print_stage
+from cibyl.plugins.openstack.ironic import Ironic
+from cibyl.plugins.openstack.network import Network
 from cibyl.plugins.openstack.printers import OSPrinter
+from cibyl.plugins.openstack.storage import Storage
 from cibyl.utils.colors import DefaultPalette
 from cibyl.utils.strings import IndentedTextBuilder
 
@@ -47,104 +50,100 @@ class OSColoredPrinter(OSPrinter):
         """
         return self._palette
 
-    def _print_deployment_network_section(self, deployment, printer):
+    def _print_deployment_network_section(self, network: Network,
+                                          printer: IndentedTextBuilder):
         """Print the network related properties of the deployment.
-        :param deployment: Deployment model representing an Openstack
-        deployment
-        :type deployment: :class:`cibyl.plugins.openstack.deployment`
+        :param network: Network properties of an Openstack deployment
         :param printer: Printer that provides the output representation
-        :type printer: :class:`cibyl.utils.strings.IndentedTextBuilder`
         :returns: Whether the network section of the deployment is empty
         """
         is_empty_network = True
         printer.add(self.palette.blue("Network: "), 1)
-        ip_version = deployment.ip_version.value
+        ip_version = network.ip_version.value
         if ip_version and ip_version != "unknown":
             is_empty_network = False
             printer.add(self.palette.blue('IP version: '), 2)
-            printer[-1].append(deployment.ip_version)
+            printer[-1].append(network.ip_version)
 
-        if deployment.network_backend.value:
+        if network.network_backend.value:
             is_empty_network = False
             printer.add(self.palette.blue('Network backend: '), 2)
-            printer[-1].append(deployment.network_backend)
+            printer[-1].append(network.network_backend)
 
-        if deployment.ml2_driver.value:
-            if deployment.ml2_driver.value != "N/A" or self.verbosity > 0:
+        if network.ml2_driver.value:
+            if network.ml2_driver.value != "N/A" or self.verbosity > 0:
                 is_empty_network = False
                 printer.add(self.palette.blue('ML2 driver: '), 2)
-                printer[-1].append(deployment.ml2_driver)
+                printer[-1].append(network.ml2_driver)
 
-        if deployment.security_group.value:
-            if deployment.security_group.value != "N/A" or self.verbosity > 0:
+        if network.security_group.value:
+            if network.security_group.value != "N/A" or self.verbosity > 0:
                 is_empty_network = False
                 printer.add(self.palette.blue('Security group mechanism: '),
                             2)
-                printer[-1].append(deployment.security_group)
+                printer[-1].append(network.security_group)
 
-        if deployment.dvr.value:
-            if deployment.dvr.value != "N/A" or self.verbosity > 0:
+        if network.dvr.value:
+            if network.dvr.value != "N/A" or self.verbosity > 0:
                 is_empty_network = False
                 printer.add(self.palette.blue('DVR: '), 2)
-                printer[-1].append(deployment.dvr)
+                printer[-1].append(network.dvr)
 
-        if deployment.tls_everywhere.value:
-            if deployment.tls_everywhere.value != "N/A" or self.verbosity > 0:
+        if network.tls_everywhere.value:
+            if network.tls_everywhere.value != "N/A" or self.verbosity > 0:
                 is_empty_network = False
                 printer.add(self.palette.blue('TLS everywhere: '), 2)
-                printer[-1].append(deployment.tls_everywhere)
+                printer[-1].append(network.tls_everywhere)
 
         if is_empty_network:
             printer.pop()
         return is_empty_network
 
-    def _print_deployment_storage_section(self, deployment, printer):
-        """Print the storage related properties of the deployment.
-        :param deployment: Deployment model representing an Openstack
-        deployment
-        :type deployment: :class:`cibyl.plugins.openstack.deployment`
+    def _print_deployment_storage_section(self, storage: Storage,
+                                          printer: IndentedTextBuilder
+                                          ) -> bool:
+        """Print the storage related properties of the storage.
+        :param storage: Storage properties of an Openstack deployment
         :param printer: Printer that provides the output representation
-        :type printer: :class:`cibyl.utils.strings.IndentedTextBuilder`
-        :returns: Whether the network section of the deployment is empty
+        :returns: Whether the network section of the storage is empty
         """
         is_empty_storage = True
         printer.add(self.palette.blue("Storage: "), 1)
 
-        if deployment.cinder_backend.value:
-            if deployment.cinder_backend.value != "N/A" or self.verbosity > 0:
+        if storage.cinder_backend.value:
+            if storage.cinder_backend.value != "N/A" or self.verbosity > 0:
                 is_empty_storage = False
                 printer.add(self.palette.blue('Cinder backend: '), 2)
-                printer[-1].append(deployment.cinder_backend)
+                printer[-1].append(storage.cinder_backend)
 
         if is_empty_storage:
             printer.pop()
         return is_empty_storage
 
-    def _print_deployment_ironic_section(self, deployment, printer):
+    def _print_deployment_ironic_section(self, ironic: Ironic,
+                                         printer: IndentedTextBuilder) -> bool:
         """Print the ironic related properties of the deployment.
-        :param deployment: Deployment model representing an Openstack
+        :param ironic: Ironic-related properties of an Openstack
         deployment
-        :type deployment: :class:`cibyl.plugins.openstack.deployment`
         :param printer: Printer that provides the output representation
-        :type printer: :class:`cibyl.utils.strings.IndentedTextBuilder`
         :returns: Whether the network section of the deployment is empty
         """
         is_empty_ironic = True
         printer.add(self.palette.blue("Ironic: "), 1)
 
-        if deployment.ironic_inspector.value:
-            if deployment.ironic_inspector.value != "N/A" or \
+        if ironic.ironic_inspector.value:
+            if ironic.ironic_inspector.value != "N/A" or \
                self.verbosity > 0:
                 is_empty_ironic = False
                 printer.add(self.palette.blue('Ironic inspector: '), 2)
-                printer[-1].append(deployment.ironic_inspector)
+                printer[-1].append(ironic.ironic_inspector)
 
-        if deployment.cleaning_network.value:
-            if deployment.cleaning_network.value != "N/A" or \
+        if ironic.cleaning_network.value:
+            if ironic.cleaning_network.value != "N/A" or \
                self.verbosity > 0:
                 is_empty_ironic = False
                 printer.add(self.palette.blue('Cleaning network: '), 2)
-                printer[-1].append(deployment.cleaning_network)
+                printer[-1].append(ironic.cleaning_network)
 
         if is_empty_ironic:
             printer.pop()
@@ -171,12 +170,21 @@ class OSColoredPrinter(OSPrinter):
             printer.add(self.palette.blue('Topology: '), 1)
             printer[-1].append(deployment.topology)
 
-        is_empty_network = self._print_deployment_network_section(deployment,
-                                                                  printer)
-        is_empty_storage = self._print_deployment_storage_section(deployment,
-                                                                  printer)
-        is_empty_ironic = self._print_deployment_ironic_section(deployment,
-                                                                printer)
+        is_empty_network = True
+        if deployment.network.value:
+            network = deployment.network.value
+            is_empty_network = self._print_deployment_network_section(network,
+                                                                      printer)
+        is_empty_storage = True
+        if deployment.storage.value:
+            storage = deployment.storage.value
+            is_empty_storage = self._print_deployment_storage_section(storage,
+                                                                      printer)
+        is_empty_ironic = True
+        if deployment.ironic.value:
+            ironic = deployment.ironic.value
+            is_empty_ironic = self._print_deployment_ironic_section(ironic,
+                                                                    printer)
         if deployment.overcloud_templates.value:
             if deployment.overcloud_templates.value != "N/A" or \
                self.verbosity > 0:

--- a/cibyl/plugins/openstack/sources/elasticsearch.py
+++ b/cibyl/plugins/openstack/sources/elasticsearch.py
@@ -17,6 +17,9 @@
 from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.base.job import Job
 from cibyl.plugins.openstack.deployment import Deployment
+from cibyl.plugins.openstack.ironic import Ironic
+from cibyl.plugins.openstack.network import Network
+from cibyl.plugins.openstack.storage import Storage
 from cibyl.sources.plugins import SourceExtension
 from cibyl.sources.source import speed_index
 from cibyl.utils.dicts import chunk_dictionary_into_lists
@@ -237,17 +240,20 @@ class ElasticSearch(SourceExtension):
                 continue
 
             job_objects[job_name] = Job(name=job_name, url=job_url)
+            network = Network(ip_version=ip_version, dvr=dvr,
+                              network_backend=network_backend,
+                              tls_everywhere='')
+            storage = Storage(cinder_backend=cinder_backend)
+            ironic = Ironic()
             deployment = Deployment(
                 release=osp_release,
                 infra_type='',
                 nodes={},
                 services={},
-                ip_version=ip_version,
                 topology=topology,
-                network_backend=network_backend,
-                dvr=dvr,
-                cinder_backend=cinder_backend,
-                tls_everywhere=''
+                network=network,
+                storage=storage,
+                ironic=ironic
             )
 
             job_objects[job_name].add_deployment(deployment)

--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -27,9 +27,12 @@ from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.base.job import Job
 from cibyl.plugins.openstack.container import Container
 from cibyl.plugins.openstack.deployment import Deployment
+from cibyl.plugins.openstack.ironic import Ironic
+from cibyl.plugins.openstack.network import Network
 from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.package import Package
 from cibyl.plugins.openstack.service import Service
+from cibyl.plugins.openstack.storage import Storage
 from cibyl.plugins.openstack.test_collection import TestCollection
 from cibyl.plugins.openstack.utils import translate_topology_string
 from cibyl.sources.jenkins import LOG, detect_job_info_regex, filter_jobs
@@ -362,22 +365,26 @@ accurate results", len(jobs_found))
             security_group = job.get("security_group", "")
             overcloud_templates = job.get("overcloud_templates")
             test_collection = job.get("test_collection")
+            network = Network(ip_version=job.get("ip_version", ""),
+                              ml2_driver=job.get("ml2_driver", ""),
+                              network_backend=network_backend,
+                              dvr=job.get("dvr", ""),
+                              tls_everywhere=tls_everywhere,
+                              security_group=security_group)
+            storage = Storage(cinder_backend=cinder_backend)
+            ironic = Ironic(ironic_inspector=ironic_inspector,
+                            cleaning_network=cleaning_network)
+
             deployment = Deployment(job.get("release", ""),
                                     job.get("infra_type", ""),
                                     nodes=job.get("nodes", {}),
                                     services=job.get("services", {}),
-                                    ip_version=job.get("ip_version", ""),
-                                    ml2_driver=job.get("ml2_driver", ""),
                                     topology=topology,
-                                    network_backend=network_backend,
-                                    cinder_backend=cinder_backend,
-                                    dvr=job.get("dvr", ""),
-                                    ironic_inspector=ironic_inspector,
-                                    cleaning_network=cleaning_network,
+                                    network=network,
+                                    storage=storage,
+                                    ironic=ironic,
                                     test_collection=test_collection,
-                                    tls_everywhere=tls_everywhere,
                                     overcloud_templates=overcloud_templates,
-                                    security_group=security_group,
                                     stages=job.get("stages"))
             job_objects[name].add_deployment(deployment)
 

--- a/cibyl/plugins/openstack/storage.py
+++ b/cibyl/plugins/openstack/storage.py
@@ -1,0 +1,43 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from typing import Optional
+
+from cibyl.models.model import Model
+
+# pylint: disable=no-member
+
+
+class Storage(Model):
+    """Storage properties of an openstack deployment"""
+
+    API = {
+        'cinder_backend': {
+            'attr_type': str,
+            'arguments': []
+        }
+    }
+
+    def __init__(self, cinder_backend: Optional[str] = None):
+        super().__init__({'cinder_backend': cinder_backend})
+
+    def merge(self, other: 'Storage'):
+        """Merge the information of two deployment objects representing the
+        same deployment.
+
+        :param other: The Deployment object to merge
+        """
+        if not self.cinder_backend.value:
+            self.cinder_backend.value = other.cinder_backend.value

--- a/tests/cibyl/intr/test_orchestrator.py
+++ b/tests/cibyl/intr/test_orchestrator.py
@@ -26,6 +26,7 @@ from cibyl.models.attribute import AttributeDictValue
 from cibyl.models.ci.base.build import Build
 from cibyl.models.ci.base.job import Job
 from cibyl.plugins.openstack.deployment import Deployment
+from cibyl.plugins.openstack.network import Network
 from cibyl.plugins.openstack.sources.jenkins import Jenkins as OSPJenkins
 from cibyl.sources.jenkins import Jenkins
 
@@ -101,7 +102,8 @@ class TestOrchestrator(TestCase):
         source_instance_mock.return_value = Jenkins(url="url")
         builds = {"1": Build("1")}
         builds_out = {"job1": Job("job1", builds=builds), "job2": Job("job2")}
-        deployment = Deployment("N/A", "N/A", {}, {}, ip_version="4")
+        network = Network(ip_version="4")
+        deployment = Deployment("N/A", "N/A", {}, {}, network=network)
         deployment_out = {"job1": Job("job1", deployment=deployment),
                           "job3": Job("job3")}
         jenkins_builds.return_value = AttributeDictValue("jobs", attr_type=Job,
@@ -120,7 +122,7 @@ class TestOrchestrator(TestCase):
             config_file.write(b"          url: url\n")
             config_file.seek(0)
             sys.argv = ['', '-p', 'openstack', '--config', config_file.name,
-                        '--last-build', '--ip-version', '4', '-f', 'text']
+                        '--last-build', '--spec', '4', '-f', 'text']
 
             main()
 

--- a/tests/cibyl/unit/plugins/openstack/printers/test_raw.py
+++ b/tests/cibyl/unit/plugins/openstack/printers/test_raw.py
@@ -18,10 +18,13 @@ from unittest import TestCase
 from cibyl.models.ci.base.stage import Stage
 from cibyl.plugins.openstack import Deployment
 from cibyl.plugins.openstack.container import Container
+from cibyl.plugins.openstack.ironic import Ironic
+from cibyl.plugins.openstack.network import Network
 from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.package import Package
 from cibyl.plugins.openstack.printers.raw import OSRawPrinter
 from cibyl.plugins.openstack.service import Service
+from cibyl.plugins.openstack.storage import Storage
 from cibyl.plugins.openstack.test_collection import TestCollection
 
 
@@ -48,20 +51,21 @@ class TestOSRawPrinter(TestCase):
         cleaning_net = "False"
         security_group = "N/A"
         test_collection = TestCollection(set(["test1", "test2"]), setup="rpm")
+        network_obj = Network(ip_version=ip_version, network_backend=network,
+                              dvr=dvr, tls_everywhere=tls_everywhere,
+                              ml2_driver=ml2_driver,
+                              security_group=security_group)
+        storage_obj = Storage(cinder_backend=storage)
+        ironic_obj = Ironic(ironic_inspector=ironic,
+                            cleaning_network=cleaning_net)
 
         deployment = Deployment(release, infra,
                                 nodes, services,
-                                ip_version=ip_version,
+                                network=network_obj,
                                 topology=topology,
-                                network_backend=network,
-                                cinder_backend=storage,
-                                dvr=dvr,
-                                tls_everywhere=tls_everywhere,
+                                storage=storage_obj,
                                 overcloud_templates=templates,
-                                ml2_driver=ml2_driver,
-                                ironic_inspector=ironic,
-                                cleaning_network=cleaning_net,
-                                security_group=security_group,
+                                ironic=ironic_obj,
                                 test_collection=test_collection)
 
         printer = OSRawPrinter(verbosity=1)
@@ -164,20 +168,21 @@ class TestOSRawPrinter(TestCase):
         cleaning_net = "N/A"
         security_group = "N/A"
         test_collection = "N/A"
+        network_obj = Network(ip_version=ip_version, network_backend=network,
+                              dvr=dvr, tls_everywhere=tls_everywhere,
+                              ml2_driver=ml2_driver,
+                              security_group=security_group)
+        storage_obj = Storage(cinder_backend=storage)
+        ironic_obj = Ironic(ironic_inspector=ironic,
+                            cleaning_network=cleaning_net)
 
         deployment = Deployment(release, infra,
                                 nodes, {},
-                                ip_version=ip_version,
                                 topology=topology,
-                                network_backend=network,
-                                cinder_backend=storage,
-                                dvr=dvr,
-                                tls_everywhere=tls_everywhere,
+                                network=network_obj,
                                 overcloud_templates=templates,
-                                ml2_driver=ml2_driver,
-                                ironic_inspector=ironic,
-                                cleaning_network=cleaning_net,
-                                security_group=security_group,
+                                storage=storage_obj,
+                                ironic=ironic_obj,
                                 test_collection=test_collection)
 
         printer = OSRawPrinter(verbosity=0)

--- a/tests/cibyl/unit/plugins/openstack/sources/test_jenkins.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/test_jenkins.py
@@ -170,7 +170,8 @@ class TestJenkinsSourceOpenstackPlugin(OpenstackPluginWithJobSystem):
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
+            network = deployment.network.value
+            self.assertEqual(network.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
             self.assertEqual(len(deployment.nodes.value), 0)
 
@@ -209,11 +210,12 @@ class TestJenkinsSourceOpenstackPlugin(OpenstackPluginWithJobSystem):
                                                    releases, topologies):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(network.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
 
     def test_get_deployment_artifacts_fallback(self):
@@ -250,11 +252,12 @@ class TestJenkinsSourceOpenstackPlugin(OpenstackPluginWithJobSystem):
                                                    releases, topologies):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(network.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
 
     def test_get_deployment_artifacts_fallback_no_logs_link(self):
@@ -292,11 +295,12 @@ class TestJenkinsSourceOpenstackPlugin(OpenstackPluginWithJobSystem):
                                                    releases, topologies):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(network.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
 
     def test_get_deployment_artifacts(self):
@@ -373,16 +377,18 @@ tripleo_ironic_conductor.service loaded    active     running
                                                    releases, topologies):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
+            storage = deployment.storage.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(network.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
-            self.assertEqual(deployment.cinder_backend.value, "ceph")
-            self.assertEqual(deployment.network_backend.value, "geneve")
-            self.assertEqual(deployment.dvr.value, "False")
-            self.assertEqual(deployment.tls_everywhere.value, "False")
+            self.assertEqual(storage.cinder_backend.value, "ceph")
+            self.assertEqual(network.network_backend.value, "geneve")
+            self.assertEqual(network.dvr.value, "False")
+            self.assertEqual(network.tls_everywhere.value, "False")
             self.assertEqual(deployment.infra_type.value, "ovb")
             for component in topology.split(","):
                 role, amount = component.split(":")
@@ -430,16 +436,18 @@ tripleo_ironic_conductor.service loaded    active     running
         for job_name, ip, release in zip(job_names, ip_versions, releases):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
+            storage = deployment.storage.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(network.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, "")
-            self.assertEqual(deployment.cinder_backend.value, "")
-            self.assertEqual(deployment.network_backend.value, "")
-            self.assertEqual(deployment.dvr.value, "")
-            self.assertEqual(deployment.tls_everywhere.value, "")
+            self.assertEqual(storage.cinder_backend.value, "")
+            self.assertEqual(network.network_backend.value, "")
+            self.assertEqual(network.dvr.value, "")
+            self.assertEqual(network.tls_everywhere.value, "")
             self.assertEqual(deployment.infra_type.value, "")
             self.assertEqual(deployment.nodes.value, {})
             self.assertEqual(deployment.services.value, {})
@@ -476,11 +484,12 @@ tripleo_ironic_conductor.service loaded    active     running
                                                    releases, topologies):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(network.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
 
     def test_get_deployment_filter_ipv(self):
@@ -503,11 +512,12 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = 'test_17.3_ipv4_job'
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "")
-        self.assertEqual(deployment.ip_version.value, "4")
+        self.assertEqual(network.ip_version.value, "4")
         self.assertEqual(deployment.topology.value, "")
 
     def test_get_deployment_job_names_nodes(self):
@@ -536,11 +546,12 @@ tripleo_ironic_conductor.service loaded    active     running
         for job_name, node_list in zip(job_names, nodes):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, "")
-            self.assertEqual(deployment.ip_version.value, "")
+            self.assertEqual(network.ip_version.value, "")
             self.assertEqual(deployment.topology.value, "")
             self.assertEqual(len(deployment.nodes.value), len(node_list))
             for node_name, node_expected in zip(deployment.nodes, node_list):
@@ -569,11 +580,12 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = 'test_17.3_ipv4_job_2comp_1cont'
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "")
-        self.assertEqual(deployment.ip_version.value, "")
+        self.assertEqual(network.ip_version.value, "")
         self.assertEqual(deployment.topology.value, topology_value)
 
     def test_get_deployment_filter_release(self):
@@ -596,11 +608,12 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = 'test_17.3_ipv4_job_2comp_1cont'
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "17.3")
-        self.assertEqual(deployment.ip_version.value, "")
+        self.assertEqual(network.ip_version.value, "")
         self.assertEqual(deployment.topology.value, "")
 
     def test_get_deployment_filter_topology_ip_version(self):
@@ -643,13 +656,14 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = 'test_17.3_ipv4_job_2comp_1cont_geneve'
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "")
-        self.assertEqual(deployment.ip_version.value, "")
+        self.assertEqual(network.ip_version.value, "")
         self.assertEqual(deployment.topology.value, "")
-        self.assertEqual(deployment.network_backend.value, "geneve")
+        self.assertEqual(network.network_backend.value, "geneve")
 
     def test_get_deployment_filter_cinder_backend(self):
         """Test that get_deployment filters by storage backend."""
@@ -672,14 +686,16 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = 'test_17.3_ipv4_job_2comp_1cont_geneve_swift'
         job = jobs[job_name]
         deployment = job.deployment.value
+        storage = deployment.storage.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "")
-        self.assertEqual(deployment.ip_version.value, "")
+        self.assertEqual(network.ip_version.value, "")
         self.assertEqual(deployment.topology.value, "")
-        self.assertEqual(deployment.cinder_backend.value, "swift")
-        self.assertEqual(deployment.network_backend.value, "")
+        self.assertEqual(storage.cinder_backend.value, "swift")
+        self.assertEqual(network.network_backend.value, "")
 
     def test_get_deployment_filter_controller(self):
         """Test that get_deployment filters by controller."""
@@ -700,11 +716,12 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = 'test_17.3_ipv4_job_2comp_1cont'
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "")
-        self.assertEqual(deployment.ip_version.value, "")
+        self.assertEqual(network.ip_version.value, "")
         self.assertEqual(deployment.topology.value, "")
 
     def test_get_deployment_filter_computes(self):
@@ -726,11 +743,12 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = 'test_17.3_ipv4_job_2comp_1cont'
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "")
-        self.assertEqual(deployment.ip_version.value, "")
+        self.assertEqual(network.ip_version.value, "")
         self.assertEqual(deployment.topology.value, "")
 
     def test_get_deployment_filter_infra_type(self):
@@ -753,11 +771,12 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = 'test_17.3_ipv4_job_2comp_1cont_ovb'
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "")
-        self.assertEqual(deployment.ip_version.value, "")
+        self.assertEqual(network.ip_version.value, "")
         self.assertEqual(deployment.topology.value, "")
         self.assertEqual(deployment.infra_type.value, "ovb")
 
@@ -782,13 +801,14 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = 'test_17.3_ipv4_job_2comp_1cont_no_dvr'
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "")
-        self.assertEqual(deployment.ip_version.value, "")
+        self.assertEqual(network.ip_version.value, "")
         self.assertEqual(deployment.topology.value, "")
-        self.assertEqual(deployment.dvr.value, "False")
+        self.assertEqual(network.dvr.value, "False")
 
     def test_get_deployment_artifacts_ironic_inspector(self):
         """ Test that get_deployment filters by ironic_inspector."""
@@ -829,13 +849,15 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = "test_17.3_ipv4_job"
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
+        ironic = deployment.ironic.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, release)
-        self.assertEqual(deployment.ip_version.value, ip_version)
+        self.assertEqual(network.ip_version.value, ip_version)
         self.assertEqual(deployment.topology.value, topology)
-        self.assertEqual(deployment.ironic_inspector.value, "True")
+        self.assertEqual(ironic.ironic_inspector.value, "True")
 
     def test_get_deployment_artifacts_dvr(self):
         """ Test that get_deployment reads properly the information obtained
@@ -887,13 +909,14 @@ tripleo_ironic_conductor.service loaded    active     running
                                                         dvr_status):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(network.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
-            self.assertEqual(deployment.dvr.value, dvr)
+            self.assertEqual(network.dvr.value, dvr)
 
     def test_get_deployment_filter_ml2_driver(self):
         """ Test that get_deployment filters properly according to the value of
@@ -947,14 +970,15 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = "test_17.3_ipv4_job"
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, releases[0])
-        self.assertEqual(deployment.ip_version.value, ip_versions[0])
+        self.assertEqual(network.ip_version.value, ip_versions[0])
         self.assertEqual(deployment.topology.value, topologies[0])
-        self.assertEqual(deployment.dvr.value, dvr_status[0])
-        self.assertEqual(deployment.ml2_driver.value, "ovs")
+        self.assertEqual(network.dvr.value, dvr_status[0])
+        self.assertEqual(network.ml2_driver.value, "ovs")
 
     def test_get_deployment_filter_overcloud_templates(self):
         """ Test that get_deployment filters properly according to the value of
@@ -1012,14 +1036,15 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = "test_17.3_ipv4_job"
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, releases[0])
-        self.assertEqual(deployment.ip_version.value, ip_versions[0])
+        self.assertEqual(network.ip_version.value, ip_versions[0])
         self.assertEqual(deployment.topology.value, topologies[0])
-        self.assertEqual(deployment.dvr.value, dvr_status[0])
-        self.assertEqual(deployment.ml2_driver.value, "ovs")
+        self.assertEqual(network.dvr.value, dvr_status[0])
+        self.assertEqual(network.ml2_driver.value, "ovs")
         self.assertEqual(deployment.overcloud_templates.value, set(["a"]))
 
     def test_get_deployment_filter_tls(self):
@@ -1043,13 +1068,14 @@ tripleo_ironic_conductor.service loaded    active     running
         job_name = 'test_17.3_ipv4_job_2comp_1cont_tls'
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "")
-        self.assertEqual(deployment.ip_version.value, "")
+        self.assertEqual(network.ip_version.value, "")
         self.assertEqual(deployment.topology.value, "")
-        self.assertEqual(deployment.tls_everywhere.value, "True")
+        self.assertEqual(network.tls_everywhere.value, "True")
 
     def test_get_deployment_artifacts_tls(self):
         """ Test that get_deployment reads properly the information obtained
@@ -1102,13 +1128,14 @@ tripleo_ironic_conductor.service loaded    active     running
                                                         tls_status):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(network.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
-            self.assertEqual(deployment.tls_everywhere.value, tls)
+            self.assertEqual(network.tls_everywhere.value, tls)
 
     def test_get_deployment_artifacts_missing_topology(self):
         """ Test that get_deployment reads properly the information obtained
@@ -1159,13 +1186,14 @@ tripleo_ironic_conductor.service loaded    active     running
                                                         tls_status):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
+            self.assertEqual(network.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
-            self.assertEqual(deployment.tls_everywhere.value, tls)
+            self.assertEqual(network.tls_everywhere.value, tls)
 
     def test_get_packages_node(self):
         """ Test that get_packages_node reads properly the information obtained
@@ -1340,17 +1368,19 @@ tripleo_ironic_conductor.service loaded    active     running
                                                    releases, topologies):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
+            storage = deployment.storage.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
-            self.assertEqual(deployment.topology.value, topology)
-            self.assertEqual(deployment.cinder_backend.value, "ceph")
-            self.assertEqual(deployment.network_backend.value, "geneve")
-            self.assertEqual(deployment.dvr.value, "False")
-            self.assertEqual(deployment.tls_everywhere.value, "False")
             self.assertEqual(deployment.infra_type.value, "ovb")
+            self.assertEqual(deployment.topology.value, topology)
+            self.assertEqual(storage.cinder_backend.value, "ceph")
+            self.assertEqual(network.ip_version.value, ip)
+            self.assertEqual(network.network_backend.value, "geneve")
+            self.assertEqual(network.dvr.value, "False")
+            self.assertEqual(network.tls_everywhere.value, "False")
             for component in topology.split(","):
                 role, amount = component.split(":")
                 for i in range(int(amount)):
@@ -1453,21 +1483,24 @@ tripleo_ironic_conductor.service loaded    active     running
         self.assertEqual(len(jobs), 1)
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
+        storage = deployment.storage.value
+        ironic = deployment.ironic.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, release)
-        self.assertEqual(deployment.ip_version.value, ip)
+        self.assertEqual(network.ip_version.value, ip)
         self.assertEqual(deployment.topology.value, topology)
-        self.assertEqual(deployment.cinder_backend.value, "ceph")
-        self.assertEqual(deployment.network_backend.value, "geneve")
-        self.assertEqual(deployment.dvr.value, "False")
-        self.assertEqual(deployment.tls_everywhere.value, "False")
         self.assertEqual(deployment.infra_type.value, "ovb")
-        self.assertEqual(deployment.ml2_driver.value, "ovs")
-        self.assertEqual(deployment.ironic_inspector.value, "False")
-        self.assertEqual(deployment.cleaning_network.value, "True")
-        self.assertEqual(deployment.security_group.value, "openvswitch")
+        self.assertEqual(storage.cinder_backend.value, "ceph")
+        self.assertEqual(network.network_backend.value, "geneve")
+        self.assertEqual(network.dvr.value, "False")
+        self.assertEqual(network.tls_everywhere.value, "False")
+        self.assertEqual(network.ml2_driver.value, "ovs")
+        self.assertEqual(network.security_group.value, "openvswitch")
+        self.assertEqual(ironic.ironic_inspector.value, "False")
+        self.assertEqual(ironic.cleaning_network.value, "True")
         self.assertEqual(deployment.overcloud_templates.value,
                          set(["a", "b"]))
         services = deployment.services
@@ -1518,21 +1551,24 @@ tripleo_ironic_conductor.service loaded    active     running
         self.assertEqual(len(jobs), 1)
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
+        storage = deployment.storage.value
+        ironic = deployment.ironic.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, release)
-        self.assertEqual(deployment.ip_version.value, ip_version)
+        self.assertEqual(network.ip_version.value, ip_version)
         self.assertEqual(deployment.topology.value, topology)
-        self.assertEqual(deployment.cinder_backend.value, "ceph")
-        self.assertEqual(deployment.network_backend.value, "geneve")
-        self.assertEqual(deployment.dvr.value, "False")
-        self.assertEqual(deployment.tls_everywhere.value, "False")
+        self.assertEqual(storage.cinder_backend.value, "ceph")
+        self.assertEqual(network.network_backend.value, "geneve")
+        self.assertEqual(network.dvr.value, "False")
+        self.assertEqual(network.tls_everywhere.value, "False")
         self.assertEqual(deployment.infra_type.value, "ovb")
-        self.assertEqual(deployment.ml2_driver.value, "ovs")
-        self.assertEqual(deployment.ironic_inspector.value, "False")
-        self.assertEqual(deployment.cleaning_network.value, "True")
-        self.assertEqual(deployment.security_group.value, "openvswitch")
+        self.assertEqual(network.ml2_driver.value, "ovs")
+        self.assertEqual(ironic.ironic_inspector.value, "False")
+        self.assertEqual(ironic.cleaning_network.value, "True")
+        self.assertEqual(network.security_group.value, "openvswitch")
         self.assertEqual(deployment.overcloud_templates.value,
                          set(["a", "b"]))
         services = deployment.services
@@ -1562,11 +1598,12 @@ tripleo_ironic_conductor.service loaded    active     running
         self.assertEqual(len(jobs), 1)
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "")
-        self.assertEqual(deployment.ip_version.value, ip_version)
+        self.assertEqual(network.ip_version.value, ip_version)
         self.assertEqual(deployment.topology.value, "")
         self.jenkins.send_request.assert_called_once()
 
@@ -1600,19 +1637,21 @@ tripleo_ironic_conductor.service loaded    active     running
         self.assertEqual(len(jobs), 1)
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
+        storage = deployment.storage.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, release)
-        self.assertEqual(deployment.ip_version.value, ip)
+        self.assertEqual(network.ip_version.value, ip)
         self.assertEqual(deployment.topology.value, topology)
-        self.assertEqual(deployment.cinder_backend.value, "ceph")
-        self.assertEqual(deployment.network_backend.value, "geneve")
-        self.assertEqual(deployment.dvr.value, "False")
-        self.assertEqual(deployment.ml2_driver.value, "ovn")
-        self.assertEqual(deployment.tls_everywhere.value, "False")
+        self.assertEqual(storage.cinder_backend.value, "ceph")
+        self.assertEqual(network.network_backend.value, "geneve")
+        self.assertEqual(network.dvr.value, "False")
+        self.assertEqual(network.ml2_driver.value, "ovn")
+        self.assertEqual(network.tls_everywhere.value, "False")
         self.assertEqual(deployment.infra_type.value, "ovb")
-        self.assertEqual(deployment.security_group.value, "native ovn")
+        self.assertEqual(network.security_group.value, "native ovn")
         services = deployment.services
         self.assertEqual(len(services), 0)
         test_collection = deployment.test_collection.value
@@ -1650,21 +1689,24 @@ tripleo_ironic_conductor.service loaded    active     running
         missing_info = "N/A"
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
+        ironic = deployment.ironic.value
+        storage = deployment.storage.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "17.3")
-        self.assertEqual(deployment.ip_version.value, "4")
+        self.assertEqual(network.ip_version.value, "4")
         self.assertEqual(deployment.topology.value, topologies[0])
-        self.assertEqual(deployment.cinder_backend.value, missing_info)
-        self.assertEqual(deployment.network_backend.value, missing_info)
-        self.assertEqual(deployment.dvr.value, missing_info)
-        self.assertEqual(deployment.ml2_driver.value, "ovn")
-        self.assertEqual(deployment.tls_everywhere.value, missing_info)
+        self.assertEqual(storage.cinder_backend.value, missing_info)
+        self.assertEqual(network.network_backend.value, missing_info)
+        self.assertEqual(network.dvr.value, missing_info)
+        self.assertEqual(network.ml2_driver.value, "ovn")
+        self.assertEqual(network.tls_everywhere.value, missing_info)
         self.assertEqual(deployment.infra_type.value, missing_info)
-        self.assertEqual(deployment.security_group.value, "native ovn")
-        self.assertEqual(deployment.cleaning_network.value, missing_info)
-        self.assertEqual(deployment.ironic_inspector.value, missing_info)
+        self.assertEqual(network.security_group.value, "native ovn")
+        self.assertEqual(ironic.cleaning_network.value, missing_info)
+        self.assertEqual(ironic.ironic_inspector.value, missing_info)
 
     def test_get_deployment_spec_no_overcloud_info_ovs_default(self):
         """ Test get_deployment call with --spec and missing overcloud info.
@@ -1694,19 +1736,21 @@ tripleo_ironic_conductor.service loaded    active     running
         missing_info = "N/A"
         job = jobs[job_name]
         deployment = job.deployment.value
+        network = deployment.network.value
+        storage = deployment.storage.value
         self.assertEqual(job.name.value, job_name)
         self.assertEqual(job.url.value, "url")
         self.assertEqual(len(job.builds.value), 0)
         self.assertEqual(deployment.release.value, "14.3")
-        self.assertEqual(deployment.ip_version.value, "4")
+        self.assertEqual(network.ip_version.value, "4")
         self.assertEqual(deployment.topology.value, topologies[0])
-        self.assertEqual(deployment.cinder_backend.value, missing_info)
-        self.assertEqual(deployment.network_backend.value, missing_info)
-        self.assertEqual(deployment.dvr.value, missing_info)
-        self.assertEqual(deployment.ml2_driver.value, "ovs")
-        self.assertEqual(deployment.tls_everywhere.value, missing_info)
+        self.assertEqual(storage.cinder_backend.value, missing_info)
+        self.assertEqual(network.network_backend.value, missing_info)
+        self.assertEqual(network.dvr.value, missing_info)
+        self.assertEqual(network.ml2_driver.value, "ovs")
+        self.assertEqual(network.tls_everywhere.value, missing_info)
         self.assertEqual(deployment.infra_type.value, missing_info)
-        self.assertEqual(deployment.security_group.value, "iptables hybrid")
+        self.assertEqual(network.security_group.value, "iptables hybrid")
 
     def test_get_deployment_filter_containers(self):
         """ Test get_deployment call with --containers."""
@@ -1761,16 +1805,18 @@ tripleo_ironic_conductor.service loaded    active     running
                                                    releases, topologies):
             job = jobs[job_name]
             deployment = job.deployment.value
+            network = deployment.network.value
+            storage = deployment.storage.value
             self.assertEqual(job.name.value, job_name)
             self.assertEqual(job.url.value, "url")
             self.assertEqual(len(job.builds.value), 0)
             self.assertEqual(deployment.release.value, release)
-            self.assertEqual(deployment.ip_version.value, ip)
             self.assertEqual(deployment.topology.value, topology)
-            self.assertEqual(deployment.cinder_backend.value, "ceph")
-            self.assertEqual(deployment.network_backend.value, "geneve")
-            self.assertEqual(deployment.dvr.value, "False")
-            self.assertEqual(deployment.tls_everywhere.value, "False")
+            self.assertEqual(network.ip_version.value, ip)
+            self.assertEqual(storage.cinder_backend.value, "ceph")
+            self.assertEqual(network.network_backend.value, "geneve")
+            self.assertEqual(network.dvr.value, "False")
+            self.assertEqual(network.tls_everywhere.value, "False")
             self.assertEqual(deployment.infra_type.value, "ovb")
             for component in topology.split(","):
                 role, amount = component.split(":")

--- a/tests/cibyl/unit/plugins/openstack/test_ironic.py
+++ b/tests/cibyl/unit/plugins/openstack/test_ironic.py
@@ -1,0 +1,38 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.plugins.openstack.ironic import Ironic
+
+
+class TestOpenstackIronic(TestCase):
+    """Test openstack ironic model."""
+    def setUp(self):
+        self.ironic_inspector = "true"
+        self.cleaning_network = "true"
+        self.second_ironic = Ironic(ironic_inspector=self.ironic_inspector,
+                                    cleaning_network=self.cleaning_network)
+        self.ironic = Ironic()
+
+    def test_merge_method(self):
+        """Test merge method of Ironic class."""
+        self.assertIsNone(self.ironic.ironic_inspector.value)
+        self.ironic.merge(self.second_ironic)
+
+        self.assertEqual(self.ironic_inspector,
+                         self.ironic.ironic_inspector.value)
+        self.assertEqual(self.cleaning_network,
+                         self.ironic.cleaning_network.value)

--- a/tests/cibyl/unit/plugins/openstack/test_network.py
+++ b/tests/cibyl/unit/plugins/openstack/test_network.py
@@ -1,0 +1,50 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.plugins.openstack.network import Network
+
+
+class TestOpenstackNetwork(TestCase):
+    """Test openstack deployment model."""
+    def setUp(self):
+        self.ip_version = "4"
+        self.network_backend = "vxlan"
+        self.dvr = "true"
+        self.tls_everywhere = "false"
+        self.ml2_driver = "ovn"
+        self.security_group = "native ovn"
+        self.second_network = Network(ip_version=self.ip_version,
+                                      network_backend=self.network_backend,
+                                      dvr=self.dvr, ml2_driver=self.ml2_driver,
+                                      tls_everywhere=self.tls_everywhere,
+                                      security_group=self.security_group)
+        self.network = Network()
+
+    def test_merge_method(self):
+        """Test merge method of Network class."""
+        self.assertIsNone(self.network.ip_version.value)
+        self.network.merge(self.second_network)
+
+        self.assertEqual(self.ip_version, self.network.ip_version.value)
+        self.assertEqual(self.network_backend,
+                         self.network.network_backend.value)
+        self.assertEqual(self.dvr, self.network.dvr.value)
+        self.assertEqual(self.tls_everywhere,
+                         self.network.tls_everywhere.value)
+        self.assertEqual(self.ml2_driver, self.network.ml2_driver.value)
+        self.assertEqual(self.security_group,
+                         self.network.security_group.value)

--- a/tests/cibyl/unit/plugins/openstack/test_storage.py
+++ b/tests/cibyl/unit/plugins/openstack/test_storage.py
@@ -1,0 +1,34 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from cibyl.plugins.openstack.storage import Storage
+
+
+class TestOpenstackStorage(TestCase):
+    """Test openstack storage model."""
+    def setUp(self):
+        self.cinder_backend = "swift"
+        self.second_storage = Storage(cinder_backend=self.cinder_backend)
+        self.storage = Storage()
+
+    def test_merge_method(self):
+        """Test merge method of Storage class."""
+        self.assertIsNone(self.storage.cinder_backend.value)
+        self.storage.merge(self.second_storage)
+
+        self.assertEqual(self.cinder_backend,
+                         self.storage.cinder_backend.value)

--- a/tests/cibyl/unit/sources/elasticsearch/test_api.py
+++ b/tests/cibyl/unit/sources/elasticsearch/test_api.py
@@ -547,7 +547,8 @@ class TestElasticSearchOpenstackPlugin(OpenstackPluginWithJobSystem):
         jobs = self.es_api.get_deployment(jobs=jobs_argument,
                                           ip_version=ip_address_kwargs)
         deployment = jobs['test'].deployment.value
-        self.assertEqual(deployment.ip_version.value, '4')
+        network = deployment.network.value
+        self.assertEqual(network.ip_version.value, '4')
         self.assertEqual(deployment.topology.value, '')
 
     def test_spec_deployment(self: object):
@@ -580,5 +581,6 @@ class TestElasticSearchOpenstackPlugin(OpenstackPluginWithJobSystem):
                                             ip_version=ip_address_kwargs)
 
         deployment = builds['test'].deployment.value
-        self.assertEqual(deployment.ip_version.value, '4')
+        network = deployment.network.value
+        self.assertEqual(network.ip_version.value, '4')
         self.assertEqual(deployment.topology.value, '')


### PR DESCRIPTION
Create a model for Network, Storage and Ironic properties, to reduce the
amount of attributes found in the Deployment model. This change
introduces the new models, refactors the Deployment model to adapt for
them and fixes the sources to use the resulting Deployment model.

Sorry for the big PR, but if I tried to split it in several, I would get broken
CI.
