### PR TITLE
Fix a bug where all available APIs where used to download a file from a Git repo

### DIFF
--- a/tripleo/insights/git.py
+++ b/tripleo/insights/git.py
@@ -211,20 +211,26 @@ class GitDownloaderFetcher:
 
 
 class GitDownload:
+    """Takes care of joining all the tools in this module together and
+    allow to safely download files from a Git repository.
+    """
+
     def __init__(
         self,
         downloader_fetcher: GitDownloaderFetcher = GitDownloaderFetcher()
     ):
         """Constructor.
 
-        :param downloader_fetcher: Tool used to get APIs to interact with Git.
+        :param downloader_fetcher: Tool that provides the APIs that this
+            will use to interact with Git.
         """
         self._download_fetcher = downloader_fetcher
 
     @property
     def download_fetcher(self) -> GitDownloaderFetcher:
         """
-        :return: Tool used to get APIs to interact with Git.
+        :return: Tool that provides the APIs that this
+            will use to interact with Git.
         """
         return self._download_fetcher
 
@@ -234,6 +240,18 @@ class GitDownload:
         file: str,
         yaml_parser: YAMLParser = StandardYAMLParser()
     ) -> YAML:
+        """Downloads a YAML file from a Git repository and parses it into
+        a Python object.
+
+        :param repo: The Git repository.
+        :param file: Relative path to the repo's root to the file to download.
+        :param yaml_parser: Tool used to parse the YAML file.
+        :return: The file as a Python object.
+        :raises DownloadError:
+            If no API is available to download the file.
+            If all APIs failed to download the file.
+            If the file is not in YAML format.
+        """
         try:
             for api in self._get_apis_for(repo):
                 LOG.info(

--- a/tripleo/utils/yaml.py
+++ b/tripleo/utils/yaml.py
@@ -23,23 +23,30 @@ from tripleo.utils.types import YAML
 
 
 class YAMLError(Exception):
-    """
+    """Describes any errors that happened while parsing a stream in YAML
+    format.
     """
 
 
 class YAMLParser(ABC):
+    """Base class for all tools that transform some stream in YAML format
+    into a Python object.
+    """
+
     @abstractmethod
     def as_yaml(self, string: str) -> YAML:
         """
-
-        :param string:
-        :return:
-        :raises YAMLError:
+        :param string: Text in YAML format.
+        :return: The corresponding Python object.
+        :raises YAMLError: If the text is not in YAML format.
         """
         raise NotImplementedError
 
 
 class StandardYAMLParser(YAMLParser):
+    """Implementation of a YAML parser that uses Python's standard library.
+    """
+
     @overrides
     def as_yaml(self, string: str) -> YAML:
         try:

--- a/tripleo/utils/yaml.py
+++ b/tripleo/utils/yaml.py
@@ -1,0 +1,49 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from abc import ABC, abstractmethod
+
+import yaml
+from overrides import overrides
+from yaml import YAMLError as StandardYAMLError
+
+from tripleo.utils.types import YAML
+
+
+class YAMLError(Exception):
+    """
+    """
+
+
+class YAMLParser(ABC):
+    @abstractmethod
+    def as_yaml(self, string: str) -> YAML:
+        """
+
+        :param string:
+        :return:
+        :raises YAMLError:
+        """
+        raise NotImplementedError
+
+
+class StandardYAMLParser(YAMLParser):
+    @overrides
+    def as_yaml(self, string: str) -> YAML:
+        try:
+            return yaml.safe_load(string)
+        except StandardYAMLError as ex:
+            msg = f"Failed to parse text: '{string}'."
+            raise YAMLError(msg) from ex


### PR DESCRIPTION
There are multiple APIs available to download a file from a Git repository. At this point I have one through the GitHub API and another that uses Git's CLI. This PR fixes a bug that downloaded the same file through all available APIs, which is completely unnecessary as the first one to work will get you the file.

On this PR:
- Added GitDownload, which takes care of handling any errors coming out of the "download" operation.
- Simplifying DeploymentLookup by making it use GitDownload, leveraging that task.
- Added YAMLParser to have a better control on how that action is performed.