### PR TITLE
Support --test-setup argument in Jenkins

### DIFF
--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -140,7 +140,7 @@ Arguments Matrix
      - |:x:|
    * - --test-setup
      - | Source of test setup (rpm, git)
-     - |:black_square_button:|
+     - |:ballot_box_with_check:|
      - |:black_square_button:|
      - |:black_square_button:|
      - |:black_square_button:|


### PR DESCRIPTION
Support querying for the source of testing setup in the Jenkins source.
This argument will only be used when a few jobs are passed, since it
requires requesting artifacts and we want to avoid overloading the
Jenkins instance.
