### PR TITLE
Integrating TripleO library in Cibyl

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/actions.py
+++ b/cibyl/plugins/openstack/sources/zuul/actions.py
@@ -125,8 +125,9 @@ class DeploymentGenerator:
         """Tools the factory will use to do its task.
         """
         outline_creator = OutlineCreator()
+        """Tests care of creating the TripleO outline for a Zuul job."""
         deployment_lookup = DeploymentLookUp()
-
+        """Gets additional information on the deployment from TripleO."""
         release_search = ReleaseSearch()
         """Takes care of finding the release of the deployment."""
 

--- a/cibyl/plugins/openstack/sources/zuul/deployments/__init__.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/cibyl/plugins/openstack/sources/zuul/deployments/outlines.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/outlines.py
@@ -1,0 +1,85 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from dataclasses import dataclass
+
+from cibyl.plugins.openstack.sources.zuul.tripleo import (
+    QuickStartFileCreator, QuickStartPathCreator)
+from cibyl.plugins.openstack.sources.zuul.variants import FeatureSetSearch
+from cibyl.sources.zuul.transactions import VariantResponse
+from tripleo.insights import DeploymentOutline
+
+
+class OutlineCreator:
+    """Factory for generation of :class:`DeploymentOutline`.
+    """
+
+    @dataclass
+    class Tools:
+        """Tools the factory will use to do its task.
+        """
+        quickstart_files = QuickStartFileCreator()
+        """Factory for creating the name of files at the QuickStart repo."""
+        quickstart_paths = QuickStartPathCreator()
+        """Factory for creating paths relative to the QuickStart repo root."""
+
+        featureset_search = FeatureSetSearch()
+        """Takes care of finding the featureset of the outline."""
+
+    def __init__(self, tools: Tools = Tools()):
+        """Constructor.
+
+        :param tools: The tools this will use.
+        """
+        self._tools = tools
+
+    @property
+    def tools(self) -> Tools:
+        """
+        :return: The tools this will use.
+        """
+        return self._tools
+
+    def new_outline_for(self, variant: VariantResponse) -> DeploymentOutline:
+        """Creates the outline of a deployment from the data found a job
+        variant.
+
+        :param variant: The variant to fetch data from.
+        :return: The outline to be passed to TripleO Insights for such variant.
+        """
+        result = DeploymentOutline()
+        result.featureset = self._get_featureset(variant, result.featureset)
+
+        return result
+
+    def _get_featureset(self, variant: VariantResponse, default: str) -> str:
+        def search_featureset():
+            search = self._tools.featureset_search.search(variant)
+
+            if not search:
+                return None
+
+            _, value = search
+
+            return value
+
+        featureset = search_featureset()
+
+        if not featureset:
+            return default
+
+        return self._tools.quickstart_paths.create_featureset_path(
+            self._tools.quickstart_files.create_featureset(featureset)
+        )

--- a/cibyl/plugins/openstack/sources/zuul/deployments/outlines.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/outlines.py
@@ -17,13 +17,66 @@ from dataclasses import dataclass
 
 from cibyl.plugins.openstack.sources.zuul.tripleo import (
     QuickStartFileCreator, QuickStartPathCreator)
-from cibyl.plugins.openstack.sources.zuul.variants import FeatureSetSearch
+from cibyl.plugins.openstack.sources.zuul.variants import (FeatureSetSearch,
+                                                           InfraTypeSearch)
 from cibyl.sources.zuul.transactions import VariantResponse
 from tripleo.insights import DeploymentOutline
 
 
-class OutlineCreator:
-    """Factory for generation of :class:`DeploymentOutline`.
+class OverridesCollector:
+    """Tools used to gather all the overrides the job defines over the
+    TripleO deployment.
+    """
+
+    @dataclass
+    class Tools:
+        """Tools the factory will use to do its task.
+        """
+        infra_type_search = InfraTypeSearch()
+        """Checks whether there is an override for 'infra_type'."""
+
+    def __init__(self, tools: Tools = Tools()):
+        """Constructor.
+
+        :param tools: The tools this will use.
+        """
+        self._tools = tools
+
+    @property
+    def tools(self) -> Tools:
+        """
+        :return: The tools this will use.
+        """
+        return self._tools
+
+    def collect_overrides_for(self, variant: VariantResponse) -> dict:
+        """Collects all the known overrides that a variant may apply on top
+        of the TripleO deployment.
+
+        :param variant: The variant to fetch data from.
+        :return: A dictionary that matches a deployment item to its
+            overridden value.
+        """
+        result = {}
+
+        self._handle_infra_type(variant, result)
+
+        return result
+
+    def _handle_infra_type(
+        self,
+        variant: VariantResponse,
+        overrides: dict,
+    ) -> None:
+        infra_type = self.tools.infra_type_search.search(variant)
+
+        if infra_type:
+            variable, value = infra_type
+            overrides[variable] = value
+
+
+class FeatureSetFetcher:
+    """Tool used to find any custom featureset a job may define.
     """
 
     @dataclass
@@ -34,9 +87,54 @@ class OutlineCreator:
         """Factory for creating the name of files at the QuickStart repo."""
         quickstart_paths = QuickStartPathCreator()
         """Factory for creating paths relative to the QuickStart repo root."""
-
         featureset_search = FeatureSetSearch()
         """Takes care of finding the featureset of the outline."""
+
+    def __init__(self, tools: Tools = Tools()):
+        """Constructor.
+
+        :param tools: The tools this will use.
+        """
+        self._tools = tools
+
+    @property
+    def tools(self) -> Tools:
+        """
+        :return: The tools this will use.
+        """
+        return self._tools
+
+    def fetch_featureset(self, variant: VariantResponse, default: str) -> str:
+        """Studies a variant in order to determine the featureset file on
+        TripleO QuickStart that its deployment uses.
+
+        :param variant: The variant to fetch data from.
+        :param default: Path to the default featureset file that will be
+            returned in case the variant has no custom one.
+        :return: Path to the featureset file of the variant.
+        """
+        featureset = self.tools.featureset_search.search(variant)
+
+        if not featureset:
+            return default
+
+        _, value = featureset
+
+        return self.tools.quickstart_paths.create_featureset_path(
+            self.tools.quickstart_files.create_featureset(value)
+        )
+
+
+class OutlineCreator:
+    """Factory for generation of :class:`DeploymentOutline`.
+    """
+
+    @dataclass
+    class Tools:
+        """Tools the factory will use to do its task.
+        """
+        featureset_fetcher = FeatureSetFetcher()
+        overrides_collector = OverridesCollector()
 
     def __init__(self, tools: Tools = Tools()):
         """Constructor.
@@ -61,25 +159,12 @@ class OutlineCreator:
         """
         result = DeploymentOutline()
         result.featureset = self._get_featureset(variant, result.featureset)
+        result.overrides = self._get_overrides(variant)
 
         return result
 
     def _get_featureset(self, variant: VariantResponse, default: str) -> str:
-        def search_featureset():
-            search = self._tools.featureset_search.search(variant)
+        return self.tools.featureset_fetcher.fetch_featureset(variant, default)
 
-            if not search:
-                return None
-
-            _, value = search
-
-            return value
-
-        featureset = search_featureset()
-
-        if not featureset:
-            return default
-
-        return self._tools.quickstart_paths.create_featureset_path(
-            self._tools.quickstart_files.create_featureset(featureset)
-        )
+    def _get_overrides(self, variant: VariantResponse) -> dict:
+        return self.tools.overrides_collector.collect_overrides_for(variant)

--- a/cibyl/plugins/openstack/sources/zuul/variants.py
+++ b/cibyl/plugins/openstack/sources/zuul/variants.py
@@ -131,3 +131,21 @@ class FeatureSetOverridesSearch(VariableSearch):
         LOG.debug("Searching for overrides on variant: '%s'.", variant.name)
 
         return super().search(variant)
+
+
+class InfraTypeSearch(VariableSearch):
+    """Utility designed to make finding the infra type for a job
+    easier.
+    """
+    DEFAULT_SEARCH_TERMS = ('environment_type',)
+
+    def __init__(self, search_terms: Iterable[str] = DEFAULT_SEARCH_TERMS):
+        """Constructor. See parent for more information.
+        """
+        super().__init__(search_terms)
+
+    @overrides
+    def search(self, variant: VariantResponse) -> Optional[Tuple[str, str]]:
+        LOG.debug("Searching for infra_type on variant: '%s'.", variant.name)
+
+        return super().search(variant)

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/__init__.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
@@ -1,0 +1,82 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.plugins.openstack.sources.zuul.deployments.outlines import \
+    OutlineCreator
+from tripleo.insights.defaults import DEFAULT_FEATURESET_FILE
+
+
+class TestOutlineCreator(TestCase):
+    """Tests for :class:`OutlineCreator`.
+    """
+
+    def test_outline_no_path_for_featureset(self):
+        """Checks that the default featureset is used if the variant has no
+        custom featureset.
+        """
+        variant = Mock()
+
+        search = Mock()
+        search.search = Mock()
+        search.search.return_value = ('var', None)
+
+        tools = OutlineCreator.Tools()
+        tools.featureset_search = search
+
+        creator = OutlineCreator(tools)
+
+        result = creator.new_outline_for(variant)
+
+        self.assertEqual(DEFAULT_FEATURESET_FILE, result.featureset)
+
+    def test_outline_has_path_for_featureset(self):
+        """Checks that the factory generates the featureset path from the
+        variant's variables.
+        """
+        fs = '001'
+        file = 'some_file.yml'
+        path = 'path/to/some_file.yml'
+
+        variant = Mock()
+
+        files = Mock()
+        files.create_featureset = Mock()
+        files.create_featureset.return_value = file
+
+        paths = Mock()
+        paths.create_featureset_path = Mock()
+        paths.create_featureset_path.return_value = path
+
+        search = Mock()
+        search.search = Mock()
+        search.search.return_value = ('var', fs)
+
+        tools = OutlineCreator.Tools()
+        tools.quickstart_files = files
+        tools.quickstart_paths = paths
+        tools.featureset_search = search
+
+        creator = OutlineCreator(tools)
+
+        result = creator.new_outline_for(variant)
+
+        self.assertEqual(path, result.featureset)
+
+        search.search.assert_called_once_with(variant)
+        files.create_featureset.assert_called_once_with(fs)
+        paths.create_featureset_path.assert_called_once_with(file)

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
@@ -16,36 +16,93 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from cibyl.plugins.openstack.sources.zuul.deployments.outlines import \
-    OutlineCreator
+from cibyl.plugins.openstack.sources.zuul.deployments.outlines import (
+    FeatureSetFetcher, OutlineCreator, OverridesCollector)
 from tripleo.insights.defaults import DEFAULT_FEATURESET_FILE
 
 
-class TestOutlineCreator(TestCase):
-    """Tests for :class:`OutlineCreator`.
+class TestOverridesCollector(TestCase):
+    """Tests for :class:`OverridesCollector`.
     """
 
-    def test_outline_no_path_for_featureset(self):
-        """Checks that the default featureset is used if the variant has no
-        custom featureset.
+    def test_no_infra_type(self):
+        """Tests that the result is not modified if there is not
+        'infra_type' override.
         """
+        overrides = {}
+
         variant = Mock()
 
         search = Mock()
         search.search = Mock()
-        search.search.return_value = ('var', None)
+        search.search.return_value = None
 
-        tools = OutlineCreator.Tools()
+        tools = Mock()
+        tools.infra_type_search = search
+
+        collector = OverridesCollector(tools)
+
+        result = collector.collect_overrides_for(variant)
+
+        self.assertEqual(overrides, result)
+
+        search.search.assert_called_once_with(variant)
+
+    def test_infra_type(self):
+        """Checks that an override for 'infra_type' is found.
+        """
+        infra_type_var = 'infra_type'
+        infra_type_val = 'ovb'
+
+        overrides = {
+            infra_type_var: infra_type_val
+        }
+
+        variant = Mock()
+
+        search = Mock()
+        search.search = Mock()
+        search.search.return_value = (infra_type_var, infra_type_val)
+
+        tools = Mock()
+        tools.infra_type_search = search
+
+        collector = OverridesCollector(tools)
+
+        result = collector.collect_overrides_for(variant)
+
+        self.assertEqual(overrides, result)
+
+        search.search.assert_called_once_with(variant)
+
+
+class TestFeatureSetFetcher(TestCase):
+    """Tests for :class:`FeatureSetFetcher`.
+    """
+
+    def test_no_custom_featureset(self):
+        """Checks that the default value is returned if the variant has no
+        custom featureset.
+        """
+        default = 'path'
+
+        variant = Mock()
+
+        search = Mock()
+        search.search = Mock()
+        search.search.return_value = None
+
+        tools = Mock()
         tools.featureset_search = search
 
-        creator = OutlineCreator(tools)
+        fetcher = FeatureSetFetcher(tools)
 
-        result = creator.new_outline_for(variant)
+        result = fetcher.fetch_featureset(variant, default)
 
-        self.assertEqual(DEFAULT_FEATURESET_FILE, result.featureset)
+        self.assertEqual(default, result)
 
-    def test_outline_has_path_for_featureset(self):
-        """Checks that the factory generates the featureset path from the
+    def test_custom_featureset(self):
+        """Checks that this generates the featureset path from the
         variant's variables.
         """
         fs = '001'
@@ -66,17 +123,73 @@ class TestOutlineCreator(TestCase):
         search.search = Mock()
         search.search.return_value = ('var', fs)
 
-        tools = OutlineCreator.Tools()
+        tools = Mock()
         tools.quickstart_files = files
         tools.quickstart_paths = paths
         tools.featureset_search = search
+
+        fetcher = FeatureSetFetcher(tools)
+
+        result = fetcher.fetch_featureset(variant, 'unused')
+
+        self.assertEqual(path, result)
+
+        search.search.assert_called_once_with(variant)
+        files.create_featureset.assert_called_once_with(fs)
+        paths.create_featureset_path.assert_called_once_with(file)
+
+
+class TestOutlineCreator(TestCase):
+    """Tests for :class:`OutlineCreator`.
+    """
+
+    def test_fetches_featureset(self):
+        """Checks that this will read the featureset from the variant. Also
+        checks the default value it will use if there is no custom
+        featureset on the variant.
+        """
+        featureset = 'some_value'
+
+        variant = Mock()
+
+        fetcher = Mock()
+        fetcher.fetch_featureset = Mock()
+        fetcher.fetch_featureset.return_value = featureset
+
+        tools = Mock()
+        tools.featureset_fetcher = fetcher
 
         creator = OutlineCreator(tools)
 
         result = creator.new_outline_for(variant)
 
-        self.assertEqual(path, result.featureset)
+        self.assertEqual(featureset, result.featureset)
 
-        search.search.assert_called_once_with(variant)
-        files.create_featureset.assert_called_once_with(fs)
-        paths.create_featureset_path.assert_called_once_with(file)
+        fetcher.fetch_featureset.assert_called_once_with(
+            variant,
+            DEFAULT_FEATURESET_FILE
+        )
+
+    def test_fetches_overrides(self):
+        """Checks that this will read all possible overrides from the variant.
+        """
+        overrides = {
+            'var1': 'val1'
+        }
+
+        variant = Mock()
+
+        collector = Mock()
+        collector.collect_overrides_for = Mock()
+        collector.collect_overrides_for.return_value = overrides
+
+        tools = Mock()
+        tools.overrides_collector = collector
+
+        creator = OutlineCreator(tools)
+
+        result = creator.new_outline_for(variant)
+
+        self.assertEqual(overrides, result.overrides)
+
+        collector.collect_overrides_for.assert_called_once_with(variant)

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/test_actions.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/test_actions.py
@@ -37,7 +37,7 @@ class TestDeploymentGenerator(TestCase):
 
         variant = Mock()
 
-        tools = DeploymentGenerator.Tools()
+        tools = Mock()
         tools.release_search = release_search
 
         generator = DeploymentGenerator(tools)
@@ -64,7 +64,7 @@ class TestDeploymentGenerator(TestCase):
 
         variant = Mock()
 
-        tools = DeploymentGenerator.Tools()
+        tools = Mock()
         tools.release_search = release_search
 
         generator = DeploymentGenerator(tools)
@@ -91,7 +91,7 @@ class TestDeploymentGenerator(TestCase):
 
         variant = Mock()
 
-        tools = DeploymentGenerator.Tools()
+        tools = Mock()
         tools.release_search = release_search
 
         generator = DeploymentGenerator(tools)

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -41,6 +41,15 @@ class DeploymentOutline:
     """Path to release file relative to the repository's root."""
 
     overrides: dict = field(default_factory=lambda: {})
+    """Defines the collection of deployment items that will override those
+    coming from the deployment's files. The dictionary is meant to have the
+    format: YAML item -> New value. On any case, the items on the dictionary
+    must follow the same item naming and value types as the original file.
+
+    This can be used as a way of altering the deployment without the need of
+    modifying the files. For example, this dictionary: {'overcloud_ipv6' :
+    True } will force the featureset to use IPv6.
+    """
 
 
 @dataclass


### PR DESCRIPTION
On this PR:
- Added a tool that takes care of generating the TripleO outline for a Zuul job variant.
- Using the TripleO library to get information on the deployment to be done by a Zuul job.
- Output the deployment's IP version.