### PR TITLE
Returning 'infra_type' as part of the deployment

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/actions.py
+++ b/cibyl/plugins/openstack/sources/zuul/actions.py
@@ -131,13 +131,17 @@ class DeploymentGenerator:
         release_search = ReleaseSearch()
         """Takes care of finding the release of the deployment."""
 
-    def __init__(self, tools=Tools()):
+    def __init__(self, tools: Tools = Tools()):
         """Constructor.
 
         :param tools: The tools this will use.
         :type tools: :class:`DeploymentGenerator.Tools`
         """
         self._tools = tools
+
+    @property
+    def tools(self):
+        return self._tools
 
     def generate_deployment_for(self, variant, **kwargs):
         """Creates a new deployment based on the data from a job's variant.
@@ -147,13 +151,13 @@ class DeploymentGenerator:
         :return: The deployment.
         :rtype: :class:`Deployment`
         """
-        deployment = self._tools.deployment_lookup.run(
-            self._tools.outline_creator.new_outline_for(variant)
+        deployment = self.tools.deployment_lookup.run(
+            self.tools.outline_creator.new_outline_for(variant)
         )
 
         return Deployment(
             release=self._get_release(variant, **kwargs),
-            infra_type='',
+            infra_type=deployment.infra_type,
             nodes={},
             services={},
             network=Network(
@@ -162,7 +166,7 @@ class DeploymentGenerator:
         )
 
     def _get_release(self, variant, **kwargs) -> str:
-        release_search = self._tools.release_search
+        release_search = self.tools.release_search
 
         if any(term in kwargs for term in ('spec', 'release')):
             release = release_search.search(variant)

--- a/cibyl/plugins/openstack/sources/zuul/actions.py
+++ b/cibyl/plugins/openstack/sources/zuul/actions.py
@@ -140,7 +140,10 @@ class DeploymentGenerator:
         self._tools = tools
 
     @property
-    def tools(self):
+    def tools(self) -> Tools:
+        """
+        :return: The tools this will use.
+        """
         return self._tools
 
     def generate_deployment_for(self, variant, **kwargs):

--- a/cibyl/plugins/openstack/sources/zuul/actions.py
+++ b/cibyl/plugins/openstack/sources/zuul/actions.py
@@ -16,7 +16,7 @@
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable
+from typing import Any, Callable
 
 from cibyl.plugins.openstack import Deployment
 from cibyl.plugins.openstack.network import Network
@@ -25,6 +25,7 @@ from cibyl.plugins.openstack.sources.zuul.deployments.outlines import \
 from cibyl.plugins.openstack.sources.zuul.variants import ReleaseSearch
 from cibyl.sources.zuul.output import QueryOutputBuilder
 from cibyl.sources.zuul.queries.jobs import perform_jobs_query
+from cibyl.sources.zuul.transactions import VariantResponse
 from cibyl.utils.filtering import matches_regex
 from tripleo.insights import DeploymentLookUp
 
@@ -135,7 +136,6 @@ class DeploymentGenerator:
         """Constructor.
 
         :param tools: The tools this will use.
-        :type tools: :class:`DeploymentGenerator.Tools`
         """
         self._tools = tools
 
@@ -146,13 +146,15 @@ class DeploymentGenerator:
         """
         return self._tools
 
-    def generate_deployment_for(self, variant, **kwargs):
+    def generate_deployment_for(
+        self,
+        variant: VariantResponse,
+        **kwargs: Any
+    ) -> Deployment:
         """Creates a new deployment based on the data from a job's variant.
 
         :param variant: The variant to fetch data from.
-        :type variant: :class:`cibyl.sources.zuul.transactions.VariantResponse`
         :return: The deployment.
-        :rtype: :class:`Deployment`
         """
         deployment = self.tools.deployment_lookup.run(
             self.tools.outline_creator.new_outline_for(variant)
@@ -168,7 +170,7 @@ class DeploymentGenerator:
             )
         )
 
-    def _get_release(self, variant, **kwargs) -> str:
+    def _get_release(self, variant: VariantResponse, **kwargs: Any) -> str:
         release_search = self.tools.release_search
 
         if any(term in kwargs for term in ('spec', 'release')):

--- a/cibyl/plugins/openstack/sources/zuul/variants.py
+++ b/cibyl/plugins/openstack/sources/zuul/variants.py
@@ -131,3 +131,21 @@ class FeatureSetOverridesSearch(VariableSearch):
         LOG.debug("Searching for overrides on variant: '%s'.", variant.name)
 
         return super().search(variant)
+
+
+class InfraTypeSearch(VariableSearch):
+    """Utility designed to make finding the infra type for a job
+    easier.
+    """
+    DEFAULT_SEARCH_TERMS = ('environment_type',)
+
+    def __init__(self, search_terms: Iterable[str] = DEFAULT_SEARCH_TERMS):
+        """Constructor. See parent for more information.
+        """
+        super().__init__(search_terms)
+
+    @overrides
+    def search(self, variant: VariantResponse) -> Optional[Tuple[str, str]]:
+        LOG.debug("Searching for infra_type on variant: '%s'.", variant.name)
+
+        return super().search(variant)

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
@@ -35,7 +35,7 @@ class TestOutlineCreator(TestCase):
         search.search = Mock()
         search.search.return_value = ('var', None)
 
-        tools = OutlineCreator.Tools()
+        tools = Mock()
         tools.featureset_search = search
 
         creator = OutlineCreator(tools)
@@ -66,7 +66,7 @@ class TestOutlineCreator(TestCase):
         search.search = Mock()
         search.search.return_value = ('var', fs)
 
-        tools = OutlineCreator.Tools()
+        tools = Mock()
         tools.quickstart_files = files
         tools.quickstart_paths = paths
         tools.featureset_search = search

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
@@ -16,8 +16,8 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from cibyl.plugins.openstack.sources.zuul.deployments.outlines import \
-    OutlineCreator, FeatureSetFetcher, OverridesCollector
+from cibyl.plugins.openstack.sources.zuul.deployments.outlines import (
+    FeatureSetFetcher, OutlineCreator, OverridesCollector)
 from tripleo.insights.defaults import DEFAULT_FEATURESET_FILE
 
 
@@ -90,7 +90,7 @@ class TestFeatureSetFetcher(TestCase):
 
         search = Mock()
         search.search = Mock()
-        search.search.return_value = ('var', None)
+        search.search.return_value = None
 
         tools = Mock()
         tools.featureset_search = search

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
@@ -17,8 +17,63 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from cibyl.plugins.openstack.sources.zuul.deployments.outlines import \
-    OutlineCreator, FeatureSetFetcher
+    OutlineCreator, FeatureSetFetcher, OverridesCollector
 from tripleo.insights.defaults import DEFAULT_FEATURESET_FILE
+
+
+class TestOverridesCollector(TestCase):
+    """Tests for :class:`OverridesCollector`.
+    """
+
+    def test_no_infra_type(self):
+        """Tests that the result is not modified if there is not
+        'infra_type' override.
+        """
+        overrides = {}
+
+        variant = Mock()
+
+        search = Mock()
+        search.search = Mock()
+        search.search.return_value = None
+
+        tools = Mock()
+        tools.infra_type_search = search
+
+        collector = OverridesCollector(tools)
+
+        result = collector.collect_overrides_for(variant)
+
+        self.assertEqual(overrides, result)
+
+        search.search.assert_called_once_with(variant)
+
+    def test_infra_type(self):
+        """Checks that an override for 'infra_type' is found.
+        """
+        infra_type_var = 'infra_type'
+        infra_type_val = 'ovb'
+
+        overrides = {
+            infra_type_var: infra_type_val
+        }
+
+        variant = Mock()
+
+        search = Mock()
+        search.search = Mock()
+        search.search.return_value = (infra_type_var, infra_type_val)
+
+        tools = Mock()
+        tools.infra_type_search = search
+
+        collector = OverridesCollector(tools)
+
+        result = collector.collect_overrides_for(variant)
+
+        self.assertEqual(overrides, result)
+
+        search.search.assert_called_once_with(variant)
 
 
 class TestFeatureSetFetcher(TestCase):

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
@@ -17,18 +17,20 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from cibyl.plugins.openstack.sources.zuul.deployments.outlines import \
-    OutlineCreator
+    OutlineCreator, FeatureSetFetcher
 from tripleo.insights.defaults import DEFAULT_FEATURESET_FILE
 
 
-class TestOutlineCreator(TestCase):
-    """Tests for :class:`OutlineCreator`.
+class TestFeatureSetFetcher(TestCase):
+    """Tests for :class:`FeatureSetFetcher`.
     """
 
-    def test_outline_no_path_for_featureset(self):
-        """Checks that the default featureset is used if the variant has no
+    def test_no_custom_featureset(self):
+        """Checks that the default value is returned if the variant has no
         custom featureset.
         """
+        default = 'path'
+
         variant = Mock()
 
         search = Mock()
@@ -38,14 +40,14 @@ class TestOutlineCreator(TestCase):
         tools = Mock()
         tools.featureset_search = search
 
-        creator = OutlineCreator(tools)
+        fetcher = FeatureSetFetcher(tools)
 
-        result = creator.new_outline_for(variant)
+        result = fetcher.fetch_featureset(variant, default)
 
-        self.assertEqual(DEFAULT_FEATURESET_FILE, result.featureset)
+        self.assertEqual(default, result)
 
-    def test_outline_has_path_for_featureset(self):
-        """Checks that the factory generates the featureset path from the
+    def test_custom_featureset(self):
+        """Checks that this generates the featureset path from the
         variant's variables.
         """
         fs = '001'
@@ -71,12 +73,68 @@ class TestOutlineCreator(TestCase):
         tools.quickstart_paths = paths
         tools.featureset_search = search
 
-        creator = OutlineCreator(tools)
+        fetcher = FeatureSetFetcher(tools)
 
-        result = creator.new_outline_for(variant)
+        result = fetcher.fetch_featureset(variant, 'unused')
 
-        self.assertEqual(path, result.featureset)
+        self.assertEqual(path, result)
 
         search.search.assert_called_once_with(variant)
         files.create_featureset.assert_called_once_with(fs)
         paths.create_featureset_path.assert_called_once_with(file)
+
+
+class TestOutlineCreator(TestCase):
+    """Tests for :class:`OutlineCreator`.
+    """
+
+    def test_fetches_featureset(self):
+        """Checks that this will read the featureset from the variant. Also
+        checks the default value it will use if there is no custom
+        featureset on the variant.
+        """
+        featureset = 'some_value'
+
+        variant = Mock()
+
+        fetcher = Mock()
+        fetcher.fetch_featureset = Mock()
+        fetcher.fetch_featureset.return_value = featureset
+
+        tools = Mock()
+        tools.featureset_fetcher = fetcher
+
+        creator = OutlineCreator(tools)
+
+        result = creator.new_outline_for(variant)
+
+        self.assertEqual(featureset, result.featureset)
+
+        fetcher.fetch_featureset.assert_called_once_with(
+            variant,
+            DEFAULT_FEATURESET_FILE
+        )
+
+    def test_fetches_overrides(self):
+        """Checks that this will read all possible overrides from the variant.
+        """
+        overrides = {
+            'var1': 'val1'
+        }
+
+        variant = Mock()
+
+        collector = Mock()
+        collector.collect_overrides_for = Mock()
+        collector.collect_overrides_for.return_value = overrides
+
+        tools = Mock()
+        tools.overrides_collector = collector
+
+        creator = OutlineCreator(tools)
+
+        result = creator.new_outline_for(variant)
+
+        self.assertEqual(overrides, result.overrides)
+
+        collector.collect_overrides_for.assert_called_once_with(variant)

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -41,6 +41,15 @@ class DeploymentOutline:
     """Path to release file relative to the repository's root."""
 
     overrides: dict = field(default_factory=lambda: {})
+    """Defines the collection of deployment items that will override those 
+    coming from the deployment's files. The dictionary is meant to have the 
+    format: YAML item -> New value. On any case, the items on the dictionary 
+    must follow the same item naming and value types as the original file.
+    
+    This can be used as a way of altering the deployment without the need of
+    modifying the files. For example, this dictionary: {'overcloud_ipv6' : 
+    True } will force the featureset to use IPv6.
+    """
 
 
 @dataclass

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -41,13 +41,13 @@ class DeploymentOutline:
     """Path to release file relative to the repository's root."""
 
     overrides: dict = field(default_factory=lambda: {})
-    """Defines the collection of deployment items that will override those 
-    coming from the deployment's files. The dictionary is meant to have the 
-    format: YAML item -> New value. On any case, the items on the dictionary 
+    """Defines the collection of deployment items that will override those
+    coming from the deployment's files. The dictionary is meant to have the
+    format: YAML item -> New value. On any case, the items on the dictionary
     must follow the same item naming and value types as the original file.
-    
+
     This can be used as a way of altering the deployment without the need of
-    modifying the files. For example, this dictionary: {'overcloud_ipv6' : 
+    modifying the files. For example, this dictionary: {'overcloud_ipv6' :
     True } will force the featureset to use IPv6.
     """
 


### PR DESCRIPTION
On this PR:
- Using type hinting for DeploymenGenerator.
- Separating OutlineCreator into two different tools: FeatureSetFetcher and OverridesCollector. This will make testing easier.
- Added a tool to look for the variable that defines 'infra_type'.
- Introduced that variable as an override at OverridesCollector.
- Returning 'infra_type' as part of the deployment.