### PR TITLE
Add support for --test-setup in elasticsearch

### DIFF
--- a/cibyl/plugins/openstack/printers/colored.py
+++ b/cibyl/plugins/openstack/printers/colored.py
@@ -242,8 +242,8 @@ class OSColoredPrinter(OSPrinter):
         """
         printer = IndentedTextBuilder()
         printer.add(self.palette.blue('Testing information: '), 0)
-        printer.add(self.palette.blue('Test suites: '), 1)
         if test_collection.tests.value:
+            printer.add(self.palette.blue('Test suites: '), 1)
             for test in test_collection.tests.value:
                 printer.add(self.palette.blue('- '), 2)
                 printer[-1].append(test)


### PR DESCRIPTION
Support querying for the source of testing setup in the Elasticsearch
source. This change also introduces the test-setup and test suites to
the spec, to match what Jenkins does.

Can be used for example with `cibyl --test-setup rpm`. At the moment of
opening this PR, only about six jobs had this information in elasticsearch,
since the field was introduced recently.
