### PR TITLE
Returning topology as part of the deployment summary.

### DIFF
--- a/tests/tripleo/unit/insights/test_deployment.py
+++ b/tests/tripleo/unit/insights/test_deployment.py
@@ -20,6 +20,7 @@ from tripleo.insights.deployment import (EnvironmentInterpreter,
                                          FeatureSetInterpreter,
                                          NodesInterpreter)
 from tripleo.insights.exceptions import IllegibleData
+from tripleo.insights.io import Topology
 
 
 class TestEnvironmentInterpreter(TestCase):
@@ -266,24 +267,6 @@ class TestFeatureSetInterpreter(TestCase):
         self.assertEqual(False, featureset.is_ipv6())
 
 
-class TestTopology(TestCase):
-    """Tests for :class:`NodesInterpreter`.
-    """
-
-    def test_default_to_str(self):
-        """Checks default textual representation of the class.
-        """
-        topology = NodesInterpreter.Topology()
-        topology.compute = 1
-        topology.ctrl = 3
-        topology.ceph = 2
-
-        self.assertEqual(
-            'compute:1,controller:3,ceph:2',
-            str(topology)
-        )
-
-
 class TestNodesInterpreter(TestCase):
     """Tests for :class:`NodesInterpreter`.
     """
@@ -377,8 +360,8 @@ class TestNodesInterpreter(TestCase):
         result = nodes.get_topology()
 
         self.assertEqual(
-            'compute:3,controller:1,ceph:0',
-            str(result)
+            Topology(3, 1, 0),
+            result
         )
 
     def test_overrides_get_topology(self):
@@ -418,6 +401,6 @@ class TestNodesInterpreter(TestCase):
         result = nodes.get_topology()
 
         self.assertEqual(
-            'compute:3,controller:1,ceph:0',
-            str(result)
+            Topology(3, 1, 0),
+            result
         )

--- a/tests/tripleo/unit/insights/test_deployment.py
+++ b/tests/tripleo/unit/insights/test_deployment.py
@@ -17,7 +17,8 @@ from unittest import TestCase
 from unittest.mock import Mock, call
 
 from tripleo.insights.deployment import (EnvironmentInterpreter,
-                                         FeatureSetInterpreter)
+                                         FeatureSetInterpreter,
+                                         NodesInterpreter)
 from tripleo.insights.exceptions import IllegibleData
 
 
@@ -263,3 +264,160 @@ class TestFeatureSetInterpreter(TestCase):
         )
 
         self.assertEqual(False, featureset.is_ipv6())
+
+
+class TestTopology(TestCase):
+    """Tests for :class:`NodesInterpreter`.
+    """
+
+    def test_default_to_str(self):
+        """Checks default textual representation of the class.
+        """
+        topology = NodesInterpreter.Topology()
+        topology.compute = 1
+        topology.ctrl = 3
+        topology.ceph = 2
+
+        self.assertEqual(
+            'compute:1,controller:3,ceph:2',
+            str(topology)
+        )
+
+
+class TestNodesInterpreter(TestCase):
+    """Tests for :class:`NodesInterpreter`.
+    """
+
+    def test_checks_data_validity(self):
+        """Verifies that the class checks that the data follows the schema.
+        """
+        data = {}
+        overrides = {}
+
+        schema = Mock()
+
+        validator = Mock()
+        validator.is_valid = Mock()
+        validator.is_valid.return_value = True
+
+        factory = Mock()
+        factory.from_file = Mock()
+        factory.from_file.return_value = validator
+
+        NodesInterpreter(
+            data,
+            schema=schema,
+            overrides=overrides,
+            validator_factory=factory
+        )
+
+        factory.from_file.assert_called_once_with(schema)
+
+        validator.is_valid.assert_has_calls(
+            [
+                call(data),
+                call(overrides)
+            ]
+        )
+
+    def test_error_if_invalid_data(self):
+        """Checks that an error is thrown if the data is not valid.
+        """
+        data = {}
+
+        schema = Mock()
+
+        validator = Mock()
+        validator.is_valid = Mock()
+        validator.is_valid.return_value = False
+
+        factory = Mock()
+        factory.from_file = Mock()
+        factory.from_file.return_value = validator
+
+        with self.assertRaises(IllegibleData):
+            NodesInterpreter(
+                data,
+                schema=schema,
+                validator_factory=factory
+            )
+
+    def test_get_topology(self):
+        """Checks that the topology map is built from the data on the file.
+        """
+        keys = NodesInterpreter.KEYS
+
+        data = {
+            keys.topology: {
+                'Controller': {
+                    'scale': 1
+                },
+                'Compute': {
+                    'scale': 3
+                }
+            }
+        }
+
+        schema = Mock()
+
+        validator = Mock()
+        validator.is_valid = Mock()
+        validator.is_valid.return_value = True
+
+        factory = Mock()
+        factory.from_file = Mock()
+        factory.from_file.return_value = validator
+
+        nodes = NodesInterpreter(
+            data,
+            schema=schema,
+            validator_factory=factory
+        )
+
+        result = nodes.get_topology()
+
+        self.assertEqual(
+            'compute:3,controller:1,ceph:0',
+            str(result)
+        )
+
+    def test_overrides_get_topology(self):
+        """Checks that the topology map can be overridden.
+        """
+        keys = NodesInterpreter.KEYS
+
+        data = {}
+        overrides = {
+            keys.topology: {
+                'Controller': {
+                    'scale': 1
+                },
+                'Compute': {
+                    'scale': 3
+                }
+            }
+        }
+
+        schema = Mock()
+
+        validator = Mock()
+        validator.is_valid = Mock()
+        validator.is_valid.return_value = True
+
+        factory = Mock()
+        factory.from_file = Mock()
+        factory.from_file.return_value = validator
+
+        nodes = NodesInterpreter(
+            data,
+            schema=schema,
+            overrides=overrides,
+            validator_factory=factory
+        )
+
+        result = nodes.get_topology()
+
+        self.assertEqual(
+            'compute:3,controller:1,ceph:0',
+            str(result)
+        )

--- a/tripleo/_data/schemas/nodes.json
+++ b/tripleo/_data/schemas/nodes.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "topology_map": {
+      "type": "object",
+      "properties": {
+        "Controller": {
+          "type": "object",
+          "required": [
+            "scale"
+          ],
+          "properties": {
+            "scale": {
+              "type": "integer"
+            }
+          }
+        },
+        "Compute": {
+          "type": "object",
+          "required": [
+            "scale"
+          ],
+          "properties": {
+            "scale": {
+              "type": "integer"
+            }
+          }
+        },
+        "CephStorage": {
+          "type": "object",
+          "required": [
+            "scale"
+          ],
+          "properties": {
+            "scale": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tripleo/insights/deployment.py
+++ b/tripleo/insights/deployment.py
@@ -14,9 +14,8 @@
 #    under the License.
 """
 from abc import ABC
-from string import Template
-
 from dataclasses import dataclass
+from string import Template
 from typing import Dict, Optional
 
 from tripleo.insights.exceptions import IllegibleData

--- a/tripleo/insights/deployment.py
+++ b/tripleo/insights/deployment.py
@@ -158,17 +158,31 @@ class FeatureSetInterpreter(FileInterpreter):
 
 
 class NodesInterpreter(FileInterpreter):
+    """Takes care of making sense out of the contents of a nodes file.
+    """
+
     @dataclass
     class Keys:
+        """Defines the fields of interest contained by a nodes file.
+        """
+        # Root level
         topology: str = 'topology_map'
+        """Field that defines the deployment's topology."""
 
+        # 'topology_map' level
         ctrl = 'Controller'
+        """Contains data on controller nodes."""
         compute = 'Compute'
+        """Contains data on compute nodes."""
         ceph = 'CephStorage'
+        """Contains data on ceph nodes."""
 
+        # 'node' level
         scale = 'scale'
+        """Number of nodes of a certain type."""
 
     KEYS = Keys()
+    """Knowledge that this has about the nodes file's contents."""
 
     def __init__(
         self,
@@ -180,6 +194,9 @@ class NodesInterpreter(FileInterpreter):
         super().__init__(data, schema, overrides, validator_factory)
 
     def get_topology(self) -> Optional[Topology]:
+        """
+        :return: Information on the topology described by the file.
+        """
         key = self.KEYS.topology
 
         for provider in (self.overrides, self.data):
@@ -189,6 +206,10 @@ class NodesInterpreter(FileInterpreter):
         return None
 
     def _new_topology_from(self, topology_map: dict) -> Topology:
+        """
+        :param topology_map: Take a look at the 'topology_map' level on the
+            'Keys' dictionary for the set of keys expected on this dictionary.
+        """
         result = Topology()
 
         keys = self.KEYS

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from typing import Optional
+
 from dataclasses import dataclass, field
 
 from tripleo.insights.defaults import (DEFAULT_ENVIRONMENT_FILE,
@@ -73,3 +75,5 @@ class DeploymentSummary:
     """Name of the IP protocol used on the deployment."""
     infra_type: str = 'N/A'
     """Infrastructure type of the cloud."""
+    topology: Optional[Topology] = None
+    """Nodes on the deployment."""

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -53,6 +53,13 @@ class DeploymentOutline:
 
 
 @dataclass
+class Topology:
+    compute: int = 0
+    ctrl: int = 0
+    ceph: int = 0
+
+
+@dataclass
 class DeploymentSummary:
     """Defines the deployment that TripleO will perform based on the
     outline provided as input.

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -54,9 +54,14 @@ class DeploymentOutline:
 
 @dataclass
 class Topology:
+    """Description of the deployment's topology.
+    """
     compute: int = 0
+    """Number of compute nodes."""
     ctrl: int = 0
+    """Number of controller nodes."""
     ceph: int = 0
+    """Number of ceph nodes."""
 
 
 @dataclass

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -13,9 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from typing import Optional
-
 from dataclasses import dataclass, field
+from typing import Optional
 
 from tripleo.insights.defaults import (DEFAULT_ENVIRONMENT_FILE,
                                        DEFAULT_FEATURESET_FILE,

--- a/tripleo/insights/lookup.py
+++ b/tripleo/insights/lookup.py
@@ -16,7 +16,8 @@
 import logging
 
 from tripleo.insights.deployment import (EnvironmentInterpreter,
-                                         FeatureSetInterpreter)
+                                         FeatureSetInterpreter,
+                                         NodesInterpreter)
 from tripleo.insights.git import GitDownload
 from tripleo.insights.io import DeploymentOutline, DeploymentSummary
 from tripleo.insights.validation import OutlineValidator
@@ -107,9 +108,21 @@ class DeploymentLookUp:
 
             result.ip_version = 'IPv6' if featureset.is_ipv6() else 'IPv4'
 
+        def handle_nodes():
+            nodes = NodesInterpreter(
+                self.downloader.download_as_yaml(
+                    repo=outline.quickstart,
+                    file=outline.nodes
+                ),
+                overrides=outline.overrides
+            )
+
+            result.topology = nodes.get_topology()
+
         result = DeploymentSummary()
 
         handle_environment()
         handle_featureset()
+        handle_nodes()
 
         return result


### PR DESCRIPTION
Now that I have the interpreter, I can add the topology as part of the deployment's summary.