### PR TITLE
Small tweaks to TripleO library and deployments.

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -124,8 +124,11 @@ class Deployment(Model):
             }
     }
 
-    def __init__(self, release: str, infra_type: str,
-                 nodes: Dict[str, Node], services: Dict[str, Service],
+    def __init__(self,
+                 release: Optional[str] = None,
+                 infra_type: Optional[str] = None,
+                 nodes: Optional[Dict[str, Node]] = None,
+                 services: Optional[Dict[str, Service]] = None,
                  topology: Optional[str] = None,
                  network: Optional[Network] = None,
                  storage: Optional[Storage] = None,

--- a/cibyl/plugins/openstack/sources/zuul/actions.py
+++ b/cibyl/plugins/openstack/sources/zuul/actions.py
@@ -157,17 +157,15 @@ class DeploymentGenerator:
         :param variant: The variant to fetch data from.
         :return: The deployment.
         """
-        deployment = self.tools.deployment_lookup.run(
+        summary = self.tools.deployment_lookup.run(
             self.tools.outline_creator.new_outline_for(variant)
         )
 
         return Deployment(
             release=self._get_release(variant, **kwargs),
-            infra_type=deployment.infra_type,
-            nodes={},
-            services={},
+            infra_type=summary.infra_type,
             network=Network(
-                ip_version=deployment.ip_version
+                ip_version=summary.ip_version
             )
         )
 

--- a/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
@@ -102,7 +102,7 @@ class DeploymentFiltering:
 
         :param deployment: The deployment to check.
         :type deployment: :class:`Deployment`
-        :return: Whether it passes the filters in this instance or not.
+        :return: Whether it passes all filters in this instance or not.
         :rtype: bool
         """
         for check in self.filters:

--- a/tripleo/insights/deployment.py
+++ b/tripleo/insights/deployment.py
@@ -143,7 +143,7 @@ class FeatureSetInterpreter(FileInterpreter):
     def is_ipv6(self) -> bool:
         """
         :return: True if the deployment works under IPv6, False if it does
-            under IPv4.
+            under IPv4. If the field is not present, then IPv4 is assumed.
         """
         key = self.KEYS.ipv6
 

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from typing import Optional
+
 from dataclasses import dataclass, field
 
 from tripleo.insights.defaults import (DEFAULT_ENVIRONMENT_FILE,
@@ -56,8 +58,11 @@ class DeploymentOutline:
 class DeploymentSummary:
     """Defines the deployment that TripleO will perform based on the
     outline provided as input.
+
+    Every field left as 'None' indicates that no information related to it
+    could be found. Interpret it as missing content.
     """
-    ip_version: str = 'N/A'
+    ip_version: Optional[str] = None
     """Name of the IP protocol used on the deployment."""
-    infra_type: str = 'N/A'
+    infra_type: Optional[str] = None
     """Infrastructure type of the cloud."""

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -13,9 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from typing import Optional
-
 from dataclasses import dataclass, field
+from typing import Optional
 
 from tripleo.insights.defaults import (DEFAULT_ENVIRONMENT_FILE,
                                        DEFAULT_FEATURESET_FILE,

--- a/tripleo/insights/lookup.py
+++ b/tripleo/insights/lookup.py
@@ -92,10 +92,6 @@ class DeploymentLookUp:
 
             result.infra_type = environment.get_intra_type()
 
-            # Handle missing fields
-            if not result.infra_type:
-                result.infra_type = 'N/A'
-
         def handle_featureset():
             featureset = FeatureSetInterpreter(
                 self.downloader.download_as_yaml(

--- a/tripleo/insights/lookup.py
+++ b/tripleo/insights/lookup.py
@@ -101,7 +101,7 @@ class DeploymentLookUp:
                 overrides=outline.overrides
             )
 
-            result.ip_version = 'IPv6' if featureset.is_ipv6() else 'IPv4'
+            result.ip_version = '6' if featureset.is_ipv6() else '4'
 
         result = DeploymentSummary()
 


### PR DESCRIPTION
On this PR:
- Have the IP version follow the same naming as in the Jenkins deployment.
- Let all fields on the deployment summary be None in case no data was found on them.
- Add some more documentation to 'is_ipv6'.
- Adding a default value for all fields of Deployment, making creating one less cumbersome.
- Cleaning up the deployment generator class.