### PR TITLE
Distribute some deployment arguments to other models

### DIFF
--- a/cibyl/plugins/openstack/__init__.py
+++ b/cibyl/plugins/openstack/__init__.py
@@ -59,13 +59,10 @@ class Plugin:
         def get_deployment_api():
             return {
                 'attr_type': Deployment,
-                'arguments': [
-                    Argument(
-                        name="--deployment",
-                        arg_type=str,
-                        nargs="*",
-                        description="Openstack deployment")
-                ]
+                'arguments': [Argument(name='--spec', arg_type=str,
+                              func='get_deployment', nargs='*',
+                              description="Print complete openstack"
+                              " deployment")]
             }
 
         def extend_job_model():

--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -38,10 +38,7 @@ class Deployment(Model):
             'arguments': [Argument(name='--release', arg_type=str,
                                    func='get_deployment', nargs='*',
                                    description="Deployment release version"),
-                          Argument(name='--spec', arg_type=str,
-                                   func='get_deployment', nargs='*',
-                                   description="Print complete openstack"
-                                   " deployment")]
+                          ]
         },
         'infra_type': {
             'attr_type': str,
@@ -82,18 +79,7 @@ class Deployment(Model):
         },
         'network': {
             'attr_type': Network,
-            'arguments': [Argument(name='--ip-version', arg_type=str,
-                                   func='get_deployment', nargs='*',
-                                   description="Ip version used in the "
-                                               "deployment"),
-                          Argument(name='--ml2-driver', arg_type=str,
-                                   func='get_deployment', nargs='*',
-                                   description="ML2 driver used in the "
-                                               "deployment"),
-                          Argument(name='--network-backend', arg_type=str,
-                                   func='get_deployment', nargs='*',
-                                   description="Network backend used in the "
-                                               "deployment")]
+            'arguments': []
         },
 
         'ironic': {
@@ -112,10 +98,7 @@ class Deployment(Model):
         },
         'storage': {
             'attr_type': Storage,
-            'arguments': [Argument(name='--cinder-backend', arg_type=str,
-                                   func='get_deployment', nargs='*',
-                                   description="Cinder backend used in the "
-                                               "deployment")]
+            'arguments': []
         },
         'stages': {
             'attr_type': Stage,

--- a/cibyl/plugins/openstack/network.py
+++ b/cibyl/plugins/openstack/network.py
@@ -15,6 +15,7 @@
 """
 from typing import Optional
 
+from cibyl.cli.argument import Argument
 from cibyl.models.model import Model
 
 # pylint: disable=no-member
@@ -26,11 +27,17 @@ class Network(Model):
     API = {
         'ip_version': {
             'attr_type': str,
-            'arguments': []
+            'arguments': [Argument(name='--ip-version', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   description="Ip version used in the "
+                                               "deployment")]
         },
         'ml2_driver': {
             'attr_type': str,
-            'arguments': []
+            'arguments': [Argument(name='--ml2-driver', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   description="ML2 driver used in the "
+                                               "deployment")]
         },
         'dvr': {
             'arguments': []
@@ -43,7 +50,10 @@ class Network(Model):
         },
         'network_backend': {
             'attr_type': str,
-            'arguments': []
+            'arguments': [Argument(name='--network-backend', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   description="Network backend used in the "
+                                               "deployment")]
         },
     }
 

--- a/cibyl/plugins/openstack/storage.py
+++ b/cibyl/plugins/openstack/storage.py
@@ -15,6 +15,7 @@
 """
 from typing import Optional
 
+from cibyl.cli.argument import Argument
 from cibyl.models.model import Model
 
 # pylint: disable=no-member
@@ -26,7 +27,10 @@ class Storage(Model):
     API = {
         'cinder_backend': {
             'attr_type': str,
-            'arguments': []
+            'arguments': [Argument(name='--cinder-backend', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   description="Cinder backend used in the "
+                                               "deployment")]
         }
     }
 


### PR DESCRIPTION
Move the network and storage-related arguments to the new models to get
a neater help message.
