### PR TITLE
Passing the custom nodes file of a job to TripleO Insights.

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/deployments/outlines.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/outlines.py
@@ -190,7 +190,9 @@ class FilesFetcher:
 
         _, value = nodes
 
-        return self.tools.quickstart_paths.create_nodes_path(value)
+        return self.tools.quickstart_paths.create_nodes_path(
+            self.tools.quickstart_files.create_nodes(value)
+        )
 
 
 class OutlineCreator:

--- a/cibyl/plugins/openstack/sources/zuul/deployments/outlines.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/outlines.py
@@ -19,7 +19,8 @@ from typing import Any, Tuple
 from cibyl.plugins.openstack.sources.zuul.tripleo import (
     QuickStartFileCreator, QuickStartPathCreator)
 from cibyl.plugins.openstack.sources.zuul.variants import (FeatureSetSearch,
-                                                           InfraTypeSearch)
+                                                           InfraTypeSearch,
+                                                           NodesSearch)
 from cibyl.sources.zuul.transactions import VariantResponse as Variant
 from tripleo.insights import DeploymentOutline
 
@@ -122,13 +123,13 @@ class OverridesCollector:
         _dict[key] = val
 
 
-class FeatureSetFetcher:
-    """Tool used to find any custom featureset a job may define.
+class FilesFetcher:
+    """Tool used to find the files that describe a deployment.
     """
 
     @dataclass
     class Tools:
-        """Tools the factory will use to do its task.
+        """Tools this will use to do its task.
         """
         quickstart_files = QuickStartFileCreator()
         """Factory for creating the name of files at the QuickStart repo."""
@@ -136,6 +137,8 @@ class FeatureSetFetcher:
         """Factory for creating paths relative to the QuickStart repo root."""
         featureset_search = FeatureSetSearch()
         """Takes care of finding the featureset of the outline."""
+        nodes_search = NodesSearch()
+        """Takes care of finding the nodes of the outline."""
 
     def __init__(self, tools: Tools = Tools()):
         """Constructor.
@@ -171,6 +174,24 @@ class FeatureSetFetcher:
             self.tools.quickstart_files.create_featureset(value)
         )
 
+    def fetch_nodes(self, variant: Variant, default: str) -> str:
+        """Studies a variant in order to determine the nodes file on
+        TripleO QuickStart that its deployment uses.
+
+        :param variant: The variant to fetch data from.
+        :param default: Path to the default nodes file that will be
+            returned in case the variant has no custom one.
+        :return: Path to the nodes file of the variant.
+        """
+        nodes = self.tools.nodes_search.search(variant)
+
+        if not nodes:
+            return default
+
+        _, value = nodes
+
+        return self.tools.quickstart_paths.create_nodes_path(value)
+
 
 class OutlineCreator:
     """Factory for generation of :class:`DeploymentOutline`.
@@ -180,7 +201,7 @@ class OutlineCreator:
     class Tools:
         """Tools the factory will use to do its task.
         """
-        featureset_fetcher = FeatureSetFetcher()
+        files_fetcher = FilesFetcher()
         overrides_collector = OverridesCollector()
 
     def __init__(self, tools: Tools = Tools()):
@@ -205,13 +226,18 @@ class OutlineCreator:
         :return: The outline to be passed to TripleO Insights for such variant.
         """
         result = DeploymentOutline()
+
         result.featureset = self._get_featureset(variant, result.featureset)
+        result.nodes = self._get_nodes(variant, result.nodes)
         result.overrides = self._get_overrides(variant)
 
         return result
 
     def _get_featureset(self, variant: Variant, default: str) -> str:
-        return self.tools.featureset_fetcher.fetch_featureset(variant, default)
+        return self.tools.files_fetcher.fetch_featureset(variant, default)
+
+    def _get_nodes(self, variant: Variant, default: str) -> str:
+        return self.tools.files_fetcher.fetch_nodes(variant, default)
 
     def _get_overrides(self, variant: Variant) -> dict:
         return self.tools.overrides_collector.collect_overrides_for(variant)

--- a/cibyl/plugins/openstack/sources/zuul/tripleo.py
+++ b/cibyl/plugins/openstack/sources/zuul/tripleo.py
@@ -22,17 +22,24 @@ class QuickStartFileCreator:
     """
     DEFAULT_FEATURESET_TEMPLATE = Template('featureset$number.yml')
     """Default template used to generate the name of featureset files."""
+    DEFAULT_NODES_TEMPLATE = Template('$name.yml')
+    """Default template used to generate the name nodes files."""
 
     def __init__(self,
-                 featureset_template: Template = DEFAULT_FEATURESET_TEMPLATE):
+                 featureset_template: Template = DEFAULT_FEATURESET_TEMPLATE,
+                 nodes_template: Template = DEFAULT_NODES_TEMPLATE
+                 ):
         """Constructor.
 
         :param featureset_template: Template that will be used to generate
             the name of featureset files. The template only takes one argument,
-            $number, which is the ID of the featureset. The template must
-            also provide the file's extension, like '.yml'.
+            $number, which is the ID of the featureset.
+        :param nodes_template: Template that will be used to generate the
+            name of nodes files. The template only takes one argument,
+            $name, which is the name of the file without its extension.
         """
         self._featureset_template = featureset_template
+        self._nodes_template = nodes_template
 
     @property
     def featureset_template(self) -> Template:
@@ -40,6 +47,13 @@ class QuickStartFileCreator:
         :return: Template of featureset files.
         """
         return self._featureset_template
+
+    @property
+    def nodes_template(self):
+        """
+        :return: Template for node files.
+        """
+        return self._nodes_template
 
     def create_featureset(self, number: str) -> str:
         """Generate a new featureset file name from the given parameters.
@@ -49,6 +63,9 @@ class QuickStartFileCreator:
             QuickStart repository.
         """
         return self.featureset_template.substitute(number=number)
+
+    def create_nodes(self, name: str) -> str:
+        return self.nodes_template.substitute(name=name)
 
 
 class QuickStartPathCreator:

--- a/cibyl/plugins/openstack/sources/zuul/variants.py
+++ b/cibyl/plugins/openstack/sources/zuul/variants.py
@@ -133,6 +133,23 @@ class FeatureSetOverridesSearch(VariableSearch):
         return super().search(variant)
 
 
+class NodesSearch(VariableSearch):
+    """Utility designed to make finding the nodes for a job easier.
+    """
+    DEFAULT_SEARCH_TERMS = ('nodes',)
+
+    def __init__(self, search_terms: Iterable[str] = DEFAULT_SEARCH_TERMS):
+        """Constructor. See parent for more information.
+        """
+        super().__init__(search_terms)
+
+    @overrides
+    def search(self, variant: VariantResponse) -> Optional[Tuple[str, str]]:
+        LOG.debug("Searching for nodes on variant: '%s'.", variant.name)
+
+        return super().search(variant)
+
+
 class InfraTypeSearch(VariableSearch):
     """Utility designed to make finding the infra type for a job
     easier.

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
@@ -174,9 +174,14 @@ class TestFilesFetcher(TestCase):
         variant's variables.
         """
         nodes = 'ctrl1'
+        file = 'some_file.yml'
         path = 'path/to/some_file.yml'
 
         variant = Mock()
+
+        files = Mock()
+        files.create_nodes = Mock()
+        files.create_nodes.return_value = file
 
         paths = Mock()
         paths.create_nodes_path = Mock()
@@ -187,6 +192,7 @@ class TestFilesFetcher(TestCase):
         search.search.return_value = ('var', nodes)
 
         tools = Mock()
+        tools.quickstart_files = files
         tools.quickstart_paths = paths
         tools.nodes_search = search
 
@@ -197,7 +203,8 @@ class TestFilesFetcher(TestCase):
         self.assertEqual(path, result)
 
         search.search.assert_called_once_with(variant)
-        paths.create_nodes_path.assert_called_once_with(nodes)
+        files.create_nodes.assert_called_once_with(nodes)
+        paths.create_nodes_path.assert_called_once_with(file)
 
 
 class TestOutlineCreator(TestCase):

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_outlines.py
@@ -17,8 +17,9 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from cibyl.plugins.openstack.sources.zuul.deployments.outlines import (
-    FeatureSetFetcher, OutlineCreator, OverridesCollector)
-from tripleo.insights.defaults import DEFAULT_FEATURESET_FILE
+    FilesFetcher, OutlineCreator, OverridesCollector)
+from tripleo.insights.defaults import (DEFAULT_FEATURESET_FILE,
+                                       DEFAULT_NODES_FILE)
 
 
 class TestOverridesCollector(TestCase):
@@ -85,13 +86,13 @@ class TestOverridesCollector(TestCase):
         search.search.assert_called_once_with(variant)
 
 
-class TestFeatureSetFetcher(TestCase):
-    """Tests for :class:`FeatureSetFetcher`.
+class TestFilesFetcher(TestCase):
+    """Tests for :class:`FilesFetcher`.
     """
 
     def test_no_custom_featureset(self):
         """Checks that the default value is returned if the variant has no
-        custom featureset.
+        custom featureset file.
         """
         default = 'path'
 
@@ -104,14 +105,14 @@ class TestFeatureSetFetcher(TestCase):
         tools = Mock()
         tools.featureset_search = search
 
-        fetcher = FeatureSetFetcher(tools)
+        fetcher = FilesFetcher(tools)
 
         result = fetcher.fetch_featureset(variant, default)
 
         self.assertEqual(default, result)
 
     def test_custom_featureset(self):
-        """Checks that this generates the featureset path from the
+        """Checks that this generates the featureset file path from the
         variant's variables.
         """
         fs = '001'
@@ -137,7 +138,7 @@ class TestFeatureSetFetcher(TestCase):
         tools.quickstart_paths = paths
         tools.featureset_search = search
 
-        fetcher = FeatureSetFetcher(tools)
+        fetcher = FilesFetcher(tools)
 
         result = fetcher.fetch_featureset(variant, 'unused')
 
@@ -147,15 +148,66 @@ class TestFeatureSetFetcher(TestCase):
         files.create_featureset.assert_called_once_with(fs)
         paths.create_featureset_path.assert_called_once_with(file)
 
+    def test_no_custom_nodes(self):
+        """Checks that the default value is returned if the variant has no
+        custom nodes file.
+        """
+        default = 'path'
+
+        variant = Mock()
+
+        search = Mock()
+        search.search = Mock()
+        search.search.return_value = None
+
+        tools = Mock()
+        tools.nodes_search = search
+
+        fetcher = FilesFetcher(tools)
+
+        result = fetcher.fetch_nodes(variant, default)
+
+        self.assertEqual(default, result)
+
+    def test_custom_nodes(self):
+        """Checks that this generates the nodes file path from the
+        variant's variables.
+        """
+        nodes = 'ctrl1'
+        path = 'path/to/some_file.yml'
+
+        variant = Mock()
+
+        paths = Mock()
+        paths.create_nodes_path = Mock()
+        paths.create_nodes_path.return_value = path
+
+        search = Mock()
+        search.search = Mock()
+        search.search.return_value = ('var', nodes)
+
+        tools = Mock()
+        tools.quickstart_paths = paths
+        tools.nodes_search = search
+
+        fetcher = FilesFetcher(tools)
+
+        result = fetcher.fetch_nodes(variant, 'unused')
+
+        self.assertEqual(path, result)
+
+        search.search.assert_called_once_with(variant)
+        paths.create_nodes_path.assert_called_once_with(nodes)
+
 
 class TestOutlineCreator(TestCase):
     """Tests for :class:`OutlineCreator`.
     """
 
     def test_fetches_featureset(self):
-        """Checks that this will read the featureset from the variant. Also
-        checks the default value it will use if there is no custom
-        featureset on the variant.
+        """Checks that this will read the featureset file from the variant.
+        Also checks the default value it will use if there is no custom file
+        on it.
         """
         featureset = 'some_value'
 
@@ -166,7 +218,7 @@ class TestOutlineCreator(TestCase):
         fetcher.fetch_featureset.return_value = featureset
 
         tools = Mock()
-        tools.featureset_fetcher = fetcher
+        tools.files_fetcher = fetcher
 
         creator = OutlineCreator(tools)
 
@@ -177,6 +229,32 @@ class TestOutlineCreator(TestCase):
         fetcher.fetch_featureset.assert_called_once_with(
             variant,
             DEFAULT_FEATURESET_FILE
+        )
+
+    def test_fetches_nodes(self):
+        """Checks that this will read the nodes file from the variant. Also
+        checks the default value it will use if there is no custom file on it.
+        """
+        nodes = 'some_value'
+
+        variant = Mock()
+
+        fetcher = Mock()
+        fetcher.fetch_nodes = Mock()
+        fetcher.fetch_nodes.return_value = nodes
+
+        tools = Mock()
+        tools.files_fetcher = fetcher
+
+        creator = OutlineCreator(tools)
+
+        result = creator.new_outline_for(variant)
+
+        self.assertEqual(nodes, result.nodes)
+
+        fetcher.fetch_nodes.assert_called_once_with(
+            variant,
+            DEFAULT_NODES_FILE
         )
 
     def test_fetches_overrides(self):

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/test_tripleo.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/test_tripleo.py
@@ -36,6 +36,19 @@ class TestQuickStartFileCreator(TestCase):
             creator.create_featureset(number)
         )
 
+    def test_default_nodes_template(self):
+        """Checks that the default nodes template produces the desired file
+        names.
+        """
+        node = 'node'
+
+        creator = QuickStartFileCreator()
+
+        self.assertEqual(
+            f'{node}.yml',
+            creator.create_nodes(node)
+        )
+
 
 class TestQuickStartPathCreator(TestCase):
     """Tests for :class:`QuickStartPathCreator`.


### PR DESCRIPTION
On this PR:
- Read the 'nodes' variable of a job.
- Generate from the variable the path to the nodes file.
- Give that path to the TripleO Insights library to get information about the topology.