### PR TITLE
Filtering by --topology

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
@@ -53,7 +53,8 @@ class DeploymentFiltering:
         """
         deployment_args = (
             'release',
-            'infra_type'
+            'infra_type',
+            'topology'
         )
 
         for arg in deployment_args:

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_filtering.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_filtering.py
@@ -74,6 +74,31 @@ class TestDeploymentFiltering(TestCase):
         self.assertTrue(filtering.is_valid_deployment(deployment1))
         self.assertFalse(filtering.is_valid_deployment(deployment2))
 
+    def test_applies_topology_filter(self):
+        """Checks that the filter for topology is generated and applied.
+        """
+        topology1 = 'ctrl1;'
+        topology2 = 'ctrl2;'
+
+        topology_arg = Mock()
+        topology_arg.value = [topology1]
+
+        kwargs = {
+            'topology': topology_arg
+        }
+
+        deployment1 = Mock()
+        deployment1.topology.value = topology1
+
+        deployment2 = Mock()
+        deployment2.topology.value = topology2
+
+        filtering = DeploymentFiltering()
+        filtering.add_filters_from(**kwargs)
+
+        self.assertTrue(filtering.is_valid_deployment(deployment1))
+        self.assertFalse(filtering.is_valid_deployment(deployment2))
+
     def test_applies_ip_version_filter(self):
         """Checks that the filter for ip version is generated and applied.
         """


### PR DESCRIPTION
Allows the user to filter deployments by their 'topology' value.