### PR TITLE
Add --overcloud-templates cli argument

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -87,7 +87,10 @@ class Deployment(Model):
             'arguments': []
         },
         'overcloud_templates': {
-            'arguments': []
+            'arguments': [Argument(name='--overcloud-templates', arg_type=str,
+                                   func='get_deployment', nargs='*',
+                                   description="TripleO templates use in the "
+                                               "deployment")]
         },
         'test_collection': {
             'attr_type': TestCollection,


### PR DESCRIPTION
In a previous change, support for --overcloud-templates was added to the
Jenkins source, but the cli argument was not included. This changes
introduces the cli argument to prepare its support in other sources like
Elasticsearch.
