### PR TITLE
Outputting topology as part of the deployment.

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/actions.py
+++ b/cibyl/plugins/openstack/sources/zuul/actions.py
@@ -22,6 +22,8 @@ from cibyl.plugins.openstack import Deployment
 from cibyl.plugins.openstack.network import Network
 from cibyl.plugins.openstack.sources.zuul.deployments.filtering import \
     DeploymentFiltering
+from cibyl.plugins.openstack.sources.zuul.deployments.formatting import \
+    TopologyPrinter
 from cibyl.plugins.openstack.sources.zuul.deployments.outlines import \
     OutlineCreator
 from cibyl.plugins.openstack.sources.zuul.variants import ReleaseSearch
@@ -132,6 +134,8 @@ class DeploymentGenerator:
         """Gets additional information on the deployment from TripleO."""
         release_search = ReleaseSearch()
         """Takes care of finding the release of the deployment."""
+        topology_printer = TopologyPrinter()
+        """Used to go from a topology to string that can be outputted."""
 
     def __init__(self, tools: Tools = Tools()):
         """Constructor.
@@ -164,6 +168,7 @@ class DeploymentGenerator:
         return Deployment(
             release=self._get_release(variant, **kwargs),
             infra_type=summary.infra_type,
+            topology=self.tools.topology_printer.print(summary.topology),
             network=Network(
                 ip_version=summary.ip_version
             )

--- a/cibyl/plugins/openstack/sources/zuul/deployments/formatting.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/formatting.py
@@ -1,0 +1,58 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from string import Template
+
+from tripleo.insights.io import Topology
+
+
+class TopologyPrinter:
+    """Utility used to produce a textual description of a topology model.
+    """
+    DEFAULT_TEMPLATE: Template = Template(
+        'compute:$compute,'
+        'controller:$ctrl,'
+        'ceph:$ceph'
+    )
+    """Default output format."""
+
+    def __init__(self, template: Template = DEFAULT_TEMPLATE):
+        """Constructor.
+
+        :param template: Template this will use to generate the text out of
+            the model. This template takes as many parameters as the model
+            has items, all of them following the same name.
+        """
+        self._template = template
+
+    @property
+    def template(self):
+        """
+        :return: Template this will use to generate the text out of
+            the model.
+        """
+        return self._template
+
+    def print(self, topology: Topology) -> str:
+        """Generate a textual representation of the topology model.
+
+        :param topology: The model to translate.
+        :return: A description of the model.
+        """
+        return self._template.substitute(
+            compute=topology.compute,
+            ctrl=topology.ctrl,
+            ceph=topology.ceph
+        )

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_formatting.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_formatting.py
@@ -1,0 +1,40 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.plugins.openstack.sources.zuul.deployments.formatting import \
+    TopologyPrinter
+
+
+class TestTopologyPrinter(TestCase):
+    """Tests for :class:`TopologyPrinter`.
+    """
+
+    def test_default_template(self):
+        """Test the default format this class outputs in.
+        """
+        model = Mock()
+        model.compute = 2
+        model.ctrl = 1
+        model.ceph = 4
+
+        printer = TopologyPrinter()
+
+        self.assertEqual(
+            'compute:2,controller:1,ceph:4',
+            printer.print(model)
+        )


### PR DESCRIPTION
Performing the last step to support the '--topology' argument. On this PR I return the topology created by the TripleO library as part of the deployment.