### PR TITLE
Adding logging to the TripleO library

### DIFF
--- a/cibyl/utils/logger.py
+++ b/cibyl/utils/logger.py
@@ -19,6 +19,9 @@ import sys
 
 import colorlog
 
+from tripleo.conf import enable_logging as tripleo_enable_logging
+from tripleo.conf import LogOutput
+
 FORMAT_STR = '{}%(levelname)-8s %(name)-20s %(message)s'
 FILE_LOGGER_FORMATER = logging.Formatter(fmt=FORMAT_STR.format(""))
 TERMINAL_LOGGER_FORMATTER = colorlog.ColoredFormatter(
@@ -74,8 +77,13 @@ def configure_logging(
 
     if log_mode == "terminal":
         configure_terminal_logging(level)
+        tripleo_enable_logging(level, LogOutput.StdOut)
     elif log_mode == "file":
         configure_file_logging(log_file, level)
+        tripleo_enable_logging(level, LogOutput.ToFile, file=log_file)
     else:
         configure_terminal_logging(level)
         configure_file_logging(log_file, level)
+
+        tripleo_enable_logging(level, LogOutput.StdOut)
+        tripleo_enable_logging(level, LogOutput.ToFile, file=log_file)

--- a/cibyl/utils/logger.py
+++ b/cibyl/utils/logger.py
@@ -19,8 +19,8 @@ import sys
 
 import colorlog
 
-from tripleo.conf import enable_logging as tripleo_enable_logging
 from tripleo.conf import LogOutput
+from tripleo.conf import enable_logging as tripleo_enable_logging
 
 FORMAT_STR = '{}%(levelname)-8s %(name)-20s %(message)s'
 FILE_LOGGER_FORMATER = logging.Formatter(fmt=FORMAT_STR.format(""))

--- a/cibyl/utils/logger.py
+++ b/cibyl/utils/logger.py
@@ -77,7 +77,7 @@ def configure_logging(
 
     if log_mode == "terminal":
         configure_terminal_logging(level)
-        tripleo_enable_logging(level, LogOutput.StdOut)
+        tripleo_enable_logging(level, LogOutput.ToStream, stream=sys.stderr)
     elif log_mode == "file":
         configure_file_logging(log_file, level)
         tripleo_enable_logging(level, LogOutput.ToFile, file=log_file)
@@ -85,5 +85,5 @@ def configure_logging(
         configure_terminal_logging(level)
         configure_file_logging(log_file, level)
 
-        tripleo_enable_logging(level, LogOutput.StdOut)
+        tripleo_enable_logging(level, LogOutput.ToStream, stream=sys.stderr)
         tripleo_enable_logging(level, LogOutput.ToFile, file=log_file)

--- a/tripleo/conf.py
+++ b/tripleo/conf.py
@@ -13,7 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from tripleo.utils.logging import enable_logging, LogOutput
+from tripleo.utils.logging import LogOutput, enable_logging
 
 __all__ = (
     'enable_logging',

--- a/tripleo/conf.py
+++ b/tripleo/conf.py
@@ -1,0 +1,21 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from tripleo.utils.logging import enable_logging, LogOutput
+
+__all__ = (
+    'enable_logging',
+    'LogOutput'
+)

--- a/tripleo/utils/logging.py
+++ b/tripleo/utils/logging.py
@@ -44,25 +44,24 @@ class LogOutput(Enum):
     ToFile = 1
 
 
-def enable_logging(level: int, *output: LogOutput, **kwargs: Any) -> None:
+def enable_logging(level: int, output: LogOutput, **kwargs: Any) -> None:
     logger = logging.getLogger('tripleo')
     logger.setLevel(level)
 
-    for option in output:
-        if option == LogOutput.StdOut:
-            _configure_logger_for_std_out(logger)
-            continue
+    if output == LogOutput.StdOut:
+        _configure_logger_for_std_out(logger)
+        return
 
-        if option == LogOutput.ToFile:
-            if 'file' not in kwargs:
-                msg = "Log output 'ToFile' requires key 'file'."
-                raise ValueError(msg)
+    if output == LogOutput.ToFile:
+        if 'file' not in kwargs:
+            msg = "Log output 'ToFile' requires key 'file'."
+            raise ValueError(msg)
 
-            file = File(kwargs['file'])
-            file.check_exists()
+        file = File(kwargs['file'])
+        file.check_exists()
 
-            _configure_logger_for_file_out(logger, file)
-            continue
+        _configure_logger_for_file_out(logger, file)
+        return
 
 
 def _configure_logger_for_std_out(logger: Logger) -> None:

--- a/tripleo/utils/logging.py
+++ b/tripleo/utils/logging.py
@@ -1,0 +1,81 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import logging
+import sys
+from enum import Enum
+from logging import FileHandler, Logger, StreamHandler
+from typing import Any
+
+import colorlog
+
+from tripleo.utils.fs import File
+
+GENERIC_LOG_FORMAT = '{}%(levelname)-8s %(name)-20s %(message)s'
+
+STDOUT_LOG_FORMAT = colorlog.ColoredFormatter(
+    fmt='\r' + GENERIC_LOG_FORMAT.format('%(log_color)s'),
+    log_colors={
+        'DEBUG': 'blue',
+        'INFO': 'green',
+        'WARNING': 'yellow',
+        'ERROR': 'red',
+        'CRITICAL': 'bold_red,bg_white'
+    }
+)
+
+FILE_LOG_FORMAT = logging.Formatter(fmt=GENERIC_LOG_FORMAT.format(''))
+
+
+class LogOutput(Enum):
+    StdOut = 0
+    ToFile = 1
+
+
+def enable_logging(level: int, *output: LogOutput, **kwargs: Any) -> None:
+    logger = logging.getLogger('tripleo')
+    logger.setLevel(level)
+
+    for option in output:
+        if option == LogOutput.StdOut:
+            _configure_logger_for_std_out(logger)
+            continue
+
+        if option == LogOutput.ToFile:
+            if 'file' not in kwargs:
+                msg = "Log output 'ToFile' requires key 'file'."
+                raise ValueError(msg)
+
+            file = File(kwargs['file'])
+            file.check_exists()
+
+            _configure_logger_for_file_out(logger, file)
+            continue
+
+
+def _configure_logger_for_std_out(logger: Logger) -> None:
+    stream_handler = StreamHandler(sys.stdout)
+    stream_handler.setFormatter(STDOUT_LOG_FORMAT)
+    stream_handler.setLevel(logger.getEffectiveLevel())
+
+    logger.addHandler(stream_handler)
+
+
+def _configure_logger_for_file_out(logger: Logger, file: File) -> None:
+    file_handler = FileHandler(file, mode='w')
+    file_handler.setFormatter(FILE_LOG_FORMAT)
+    file_handler.setLevel(logger.getEffectiveLevel())
+
+    logger.addHandler(file_handler)


### PR DESCRIPTION
This PR adds a logging module on the TripleO library that imitates the equivalent one on Cibyl. The log format will be similar and the output target too. Logging on the library is optional, so I have made Cibyl enable and configure it just as it does to itself. Some logging messages regarding Git access will now be printed on the console.