### PR TITLE
Returning release name as part of the deployment summary

### DIFF
--- a/tests/tripleo/intr/insights/test_deployment.py
+++ b/tests/tripleo/intr/insights/test_deployment.py
@@ -16,7 +16,8 @@
 from unittest import TestCase
 
 from tripleo.insights.deployment import (EnvironmentInterpreter,
-                                         FeatureSetInterpreter)
+                                         FeatureSetInterpreter,
+                                         NodesInterpreter, ReleaseInterpreter)
 from tripleo.insights.exceptions import IllegibleData
 
 
@@ -40,7 +41,7 @@ class TestFeatureSetInterpreter(TestCase):
     """Tests for :class:`FeatureSetInterpreter`.
     """
 
-    def tests_error_on_invalid_ipv6(self):
+    def test_error_on_invalid_ipv6(self):
         """Tests that an error is thrown if the ipv6 field does not follow the
         schema.
         """
@@ -50,3 +51,43 @@ class TestFeatureSetInterpreter(TestCase):
 
         with self.assertRaises(IllegibleData):
             FeatureSetInterpreter(data)
+
+
+class TestNodesInterpreter(TestCase):
+    """Tests for :class:`NodesInterpreter`.
+    """
+
+    def test_error_on_invalid_topology(self):
+        """Tests that an error is thrown if the 'topology_map' field does
+        not follow the schema.
+        """
+        data = {
+            NodesInterpreter.KEYS.topology: False  # Must be an object
+        }
+
+        with self.assertRaises(IllegibleData):
+            NodesInterpreter(data)
+
+
+class TestReleaseInterpreter(TestCase):
+    """Tests for :class:`TestReleaseInterpreter`.
+    """
+
+    def test_error_on_missing_release(self):
+        """Tests that an error if the release field is not present.
+        """
+        data = {
+        }
+
+        with self.assertRaises(IllegibleData):
+            ReleaseInterpreter(data)
+
+    def test_error_on_invalid_release(self):
+        """Tests that an error if the release field is not present.
+        """
+        data = {
+            ReleaseInterpreter.KEYS.release: False  # Must be string
+        }
+
+        with self.assertRaises(IllegibleData):
+            ReleaseInterpreter(data)

--- a/tests/tripleo/intr/insights/test_deployment.py
+++ b/tests/tripleo/intr/insights/test_deployment.py
@@ -73,15 +73,6 @@ class TestReleaseInterpreter(TestCase):
     """Tests for :class:`TestReleaseInterpreter`.
     """
 
-    def test_error_on_missing_release(self):
-        """Tests that an error if the release field is not present.
-        """
-        data = {
-        }
-
-        with self.assertRaises(IllegibleData):
-            ReleaseInterpreter(data)
-
     def test_error_on_invalid_release(self):
         """Tests that an error if the release field is not present.
         """

--- a/tests/tripleo/unit/insights/test_deployment.py
+++ b/tests/tripleo/unit/insights/test_deployment.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock, call
 
 from tripleo.insights.deployment import (EnvironmentInterpreter,
                                          FeatureSetInterpreter,
-                                         NodesInterpreter)
+                                         NodesInterpreter, ReleaseInterpreter)
 from tripleo.insights.exceptions import IllegibleData
 from tripleo.insights.io import Topology
 
@@ -416,3 +416,68 @@ class TestNodesInterpreter(TestCase):
             Topology(3, 1, 2, 1),
             result
         )
+
+
+class TestReleaseInterpreter(TestCase):
+    """Tests for :class:`ReleaseInterpreter`.
+    """
+
+    def test_get_release_name(self):
+        """Checks that it is possible to get the release name from the file.
+        """
+        value = 'release'
+
+        keys = ReleaseInterpreter.KEYS
+
+        data = {
+            keys.release: value
+        }
+
+        schema = Mock()
+
+        validator = Mock()
+        validator.is_valid = Mock()
+        validator.is_valid.return_value = True
+
+        factory = Mock()
+        factory.from_file = Mock()
+        factory.from_file.return_value = validator
+
+        release = ReleaseInterpreter(
+            data,
+            schema=schema,
+            validator_factory=factory
+        )
+
+        self.assertEqual(value, release.get_release_name())
+
+    def test_overrides_get_release_name(self):
+        """Checks that it is possible override the release name from the file.
+        """
+        value = 'release'
+
+        keys = ReleaseInterpreter.KEYS
+
+        data = {}
+        overrides = {
+            keys.release: value
+        }
+
+        schema = Mock()
+
+        validator = Mock()
+        validator.is_valid = Mock()
+        validator.is_valid.return_value = True
+
+        factory = Mock()
+        factory.from_file = Mock()
+        factory.from_file.return_value = validator
+
+        release = ReleaseInterpreter(
+            data,
+            schema=schema,
+            overrides=overrides,
+            validator_factory=factory
+        )
+
+        self.assertEqual(value, release.get_release_name())

--- a/tripleo/_data/schemas/release.json
+++ b/tripleo/_data/schemas/release.json
@@ -2,9 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "required": [
-    "release"
-  ],
   "properties": {
     "release": {
       "type": "string"

--- a/tripleo/_data/schemas/release.json
+++ b/tripleo/_data/schemas/release.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": [
+    "release"
+  ],
+  "properties": {
+    "release": {
+      "type": "string"
+    }
+  }
+}

--- a/tripleo/insights/deployment.py
+++ b/tripleo/insights/deployment.py
@@ -258,9 +258,10 @@ class ReleaseInterpreter(FileInterpreter):
     ):
         super().__init__(data, schema, overrides, validator_factory)
 
-    def get_release_name(self) -> str:
+    def get_release_name(self) -> Optional[str]:
         """
-        :return: Name of the release, for example: 'wallaby'.
+        :return: Name of the release, for example: 'wallaby'. None if the
+            field is not present.
         """
         key = self.KEYS.release
 
@@ -268,7 +269,4 @@ class ReleaseInterpreter(FileInterpreter):
             if key in provider:
                 return provider[key]
 
-        raise NotImplementedError(
-            "Unexpected path. "
-            "The release name is a must on the release file."
-        )
+        return None

--- a/tripleo/insights/deployment.py
+++ b/tripleo/insights/deployment.py
@@ -25,6 +25,10 @@ from tripleo.utils.yaml import YAML
 
 
 class FileInterpreter(ABC):
+    """Base class for all interpreters that take care of giving meaning to
+    the contents of the files that outline a deployment.
+    """
+
     def __init__(
         self,
         data: YAML,
@@ -48,8 +52,8 @@ class FileInterpreter(ABC):
             If the 'overrides' dictionary does not match the schema.
         """
 
-        def validate_data(__data):
-            if not validator.is_valid(__data):
+        def validate_data(instance):
+            if not validator.is_valid(instance):
                 raise IllegibleData('Data does not conform to its schema.')
 
         if overrides is None:

--- a/tripleo/insights/deployment.py
+++ b/tripleo/insights/deployment.py
@@ -233,3 +233,42 @@ class NodesInterpreter(FileInterpreter):
             result.cell = topology_map[keys.cell][keys.scale]
 
         return result
+
+
+class ReleaseInterpreter(FileInterpreter):
+    """Takes care of making sense out of the contents of a release file.
+    """
+
+    @dataclass
+    class Keys:
+        """Defines the fields of interest contained by a release file.
+        """
+        release: str = 'release'
+        """Field that holds the release name."""
+
+    KEYS = Keys()
+    """Knowledge that this has about the release file's contents."""
+
+    def __init__(
+        self,
+        data: YAML,
+        schema: File = File('tripleo/_data/schemas/release.json'),
+        overrides: Optional[Dict] = None,
+        validator_factory: JSONValidatorFactory = Draft7ValidatorFactory()
+    ):
+        super().__init__(data, schema, overrides, validator_factory)
+
+    def get_release_name(self) -> str:
+        """
+        :return: Name of the release, for example: 'wallaby'.
+        """
+        key = self.KEYS.release
+
+        for provider in (self.overrides, self.data):
+            if key in provider:
+                return provider[key]
+
+        raise NotImplementedError(
+            "Unexpected path. "
+            "The release name is a must on the release file."
+        )

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -94,6 +94,8 @@ class DeploymentSummary:
     Every field left as 'None' indicates that no information related to it
     could be found. Interpret it as missing content.
     """
+    release: Optional[str] = None
+    """Name of the OpenStack release deployed."""
     ip_version: Optional[str] = None
     """Name of the IP protocol used on the deployment."""
     infra_type: Optional[str] = None

--- a/tripleo/insights/lookup.py
+++ b/tripleo/insights/lookup.py
@@ -120,7 +120,8 @@ class DeploymentLookUp:
                 self.downloader.download_as_yaml(
                     repo=outline.quickstart,
                     file=outline.release
-                )
+                ),
+                overrides=outline.overrides
             )
 
             result.release = release.get_release_name()

--- a/tripleo/insights/lookup.py
+++ b/tripleo/insights/lookup.py
@@ -17,7 +17,7 @@ import logging
 
 from tripleo.insights.deployment import (EnvironmentInterpreter,
                                          FeatureSetInterpreter,
-                                         NodesInterpreter)
+                                         NodesInterpreter, ReleaseInterpreter)
 from tripleo.insights.git import GitDownload
 from tripleo.insights.io import DeploymentOutline, DeploymentSummary
 from tripleo.insights.validation import OutlineValidator
@@ -115,10 +115,21 @@ class DeploymentLookUp:
 
             result.topology = nodes.get_topology()
 
+        def handle_release():
+            release = ReleaseInterpreter(
+                self.downloader.download_as_yaml(
+                    repo=outline.quickstart,
+                    file=outline.release
+                )
+            )
+
+            result.release = release.get_release_name()
+
         result = DeploymentSummary()
 
         handle_environment()
         handle_featureset()
         handle_nodes()
+        handle_release()
 
         return result


### PR DESCRIPTION
On this PR:
- Fixing some Pylint comments.
- Adding ReleaseInterpreter, which will extract the release name from the relative file.
- Returning the release name as part of the summary.