### PR TITLE
Add tripleo to packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifier =
 [files]
 packages =
     cibyl
+    tripleo
 
 [entry_points]
 console_scripts =


### PR DESCRIPTION
An error pops up on missing tripleo when running cibyl.
This change fixes it by adding tripleo to setup.cfg