### PR TITLE
Allow to select the Git branch to download files from.

### DIFF
--- a/tests/tripleo/intr/utils/git/test_gitpython.py
+++ b/tests/tripleo/intr/utils/git/test_gitpython.py
@@ -25,6 +25,25 @@ class TestGitPython(TestCase):
     """Tests for :class:'GitPython'.
     """
 
+    def test_checkout_branch(self):
+        """Checks that it is possible to change the branch of the
+        repository.
+        """
+        branch = 'devel'
+
+        cibyl = URL('https://github.com/rhos-infra/cibyl.git')
+
+        with TemporaryDirectory() as folder:
+            git = GitPython()
+            directory = Dir(folder)
+
+            with git.clone(cibyl, directory) as repo:
+                self.assertNotEqual(branch, repo.branch)
+
+                repo.checkout(branch)
+
+                self.assertEqual(branch, repo.branch)
+
     def test_get_as_text(self):
         """Checks that it is possible to get the contents of a file in the
         repository as text.
@@ -32,7 +51,7 @@ class TestGitPython(TestCase):
         file = 'README.rst'
         cibyl = URL('https://github.com/rhos-infra/cibyl.git')
 
-        with open(file, 'r') as target:
+        with open(file, 'r', encoding='utf-8') as target:
             with TemporaryDirectory() as folder:
                 git = GitPython()
                 directory = Dir(folder)

--- a/tests/tripleo/unit/utils/github/test_pygithub.py
+++ b/tests/tripleo/unit/utils/github/test_pygithub.py
@@ -54,10 +54,13 @@ class TestRepository(TestCase):
         path = 'path/to/file'
         contents = 'file_contents'
 
+        branch = 'master'
+
         file = Mock()
         file.decoded_content = bytes(contents, encoding)
 
         api = Mock()
+        api.default_branch = branch
         api.get_contents = Mock()
         api.get_contents.return_value = file
 
@@ -68,4 +71,33 @@ class TestRepository(TestCase):
             repo.download_as_text(path, encoding)
         )
 
-        api.get_contents.assert_called_once_with(path)
+        api.get_contents.assert_called_once_with(path, ref=branch)
+
+    def test_downloads_from_custom_branch(self):
+        """Checks that it is capable of retrieving the text from a file
+        in a branch different from the default one.
+        """
+        encoding = 'utf-8'
+
+        path = 'path/to/file'
+        contents = 'file_contents'
+
+        branch = 'branch'
+
+        file = Mock()
+        file.decoded_content = bytes(contents, encoding)
+
+        api = Mock()
+        api.default_branch = 'master'
+        api.get_contents = Mock()
+        api.get_contents.return_value = file
+
+        repo = Repository(api)
+        repo.checkout(branch)
+
+        self.assertEqual(
+            contents,
+            repo.download_as_text(path, encoding)
+        )
+
+        api.get_contents.assert_called_once_with(path, ref=branch)

--- a/tripleo/utils/git/__init__.py
+++ b/tripleo/utils/git/__init__.py
@@ -27,7 +27,7 @@ class GitError(Exception):
 
 class Repository(Closeable, ABC):
     @abstractmethod
-    def get_as_text(self, file: str) -> str:
+    def get_as_text(self, file: str, encoding: str = 'utf-8') -> str:
         raise NotImplementedError
 
 

--- a/tripleo/utils/git/__init__.py
+++ b/tripleo/utils/git/__init__.py
@@ -26,8 +26,36 @@ class GitError(Exception):
 
 
 class Repository(Closeable, ABC):
+    """Interface that defines interactions with a Git repository.
+    """
+
+    @property
+    @abstractmethod
+    def branch(self) -> str:
+        """
+        :return: The active branch on the repository.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def checkout(self, branch: str) -> None:
+        """Changes the active branch on the repository.
+
+        :param branch: Name of the branch to move to.
+        :raises GitError: If the branch does not exist.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def get_as_text(self, file: str, encoding: str = 'utf-8') -> str:
+        """Downloads a file on the repository as text.
+
+        :param file: Path, relative to the repository's root, to the file
+            to download.
+        :param encoding: Encoding of the file, following the same naming as the
+            builtin 'open' function.
+        :return: The contents of the file as text.
+        """
         raise NotImplementedError
 
 

--- a/tripleo/utils/git/gitpython.py
+++ b/tripleo/utils/git/gitpython.py
@@ -50,6 +50,20 @@ class Repository(IRepository):
         """
         return self._handler
 
+    @property
+    def branch(self) -> str:
+        return self.handler.active_branch.name
+
+    @overrides
+    def checkout(self, branch: str) -> None:
+        remote = self.handler.remote()
+
+        # Check that the branch exists.
+        if branch not in remote.refs:
+            raise GitError(f"Unknown branch: '{branch}'")
+
+        self.handler.git.checkout(branch)
+
     @overrides
     def get_as_text(self, file: str, encoding: str = 'utf-8') -> str:
         abs_path = self._get_absolute_path(file)

--- a/tripleo/utils/git/gitpython.py
+++ b/tripleo/utils/git/gitpython.py
@@ -51,11 +51,11 @@ class Repository(IRepository):
         return self._handler
 
     @overrides
-    def get_as_text(self, file: str) -> str:
+    def get_as_text(self, file: str, encoding: str = 'utf-8') -> str:
         abs_path = self._get_absolute_path(file)
 
         try:
-            with open(abs_path, 'r') as buffer:
+            with open(abs_path, 'r', encoding=encoding) as buffer:
                 return buffer.read()
         except IOError as ex:
             msg = f"Failed to open file at: '{abs_path}'."

--- a/tripleo/utils/github/__init__.py
+++ b/tripleo/utils/github/__init__.py
@@ -24,6 +24,27 @@ class Repository(ABC):
     """API that allows interactivity with a GitHub repository.
     """
 
+    def __init__(self, branch: str):
+        """Constructor.
+
+        :param branch: Name of the branch the repository is checked out at.
+        """
+        self._branch = branch
+
+    @property
+    def branch(self) -> str:
+        """
+        :return: Name of the checked out branch.
+        """
+        return self._branch
+
+    def checkout(self, branch: str) -> None:
+        """Changes the branch the repository works in.
+
+        :param branch: The branch to move to.
+        """
+        self._branch = branch
+
     @abstractmethod
     def download_as_text(self, file: str, encoding: str = 'utf-8') -> str:
         """Downloads a file and decodes it as text.

--- a/tripleo/utils/github/pygithub.py
+++ b/tripleo/utils/github/pygithub.py
@@ -33,6 +33,8 @@ class Repository(IRepository):
 
         :param api: PyGithub session used to interact with GitHub.
         """
+        super().__init__(branch=api.default_branch)
+
         self._api = api
 
     @property
@@ -45,7 +47,7 @@ class Repository(IRepository):
     @overrides
     def download_as_text(self, file: str, encoding: str = 'utf-8') -> str:
         try:
-            file = self.api.get_contents(file)
+            file = self.api.get_contents(file, ref=self.branch)
 
             # Decoded content is still in binary,
             # it has to be passed to string yet

--- a/tripleo/utils/github/pygithub.py
+++ b/tripleo/utils/github/pygithub.py
@@ -15,15 +15,12 @@
 """
 from github import Github as GitHubAPIv3
 from github import GithubException
-from github.Repository import Repository
+from github.Repository import Repository as RepoAPIv3
 from overrides import overrides
 
 from tripleo.utils.github import GitHub as IGitHub
 from tripleo.utils.github import GitHubError
 from tripleo.utils.github import Repository as IRepository
-
-RepoAPIv3 = Repository
-"""PyGitHub's representation of a repository."""
 
 
 class Repository(IRepository):


### PR DESCRIPTION
- Allowing Git interfaces to checkout a different branch than the main one.
- Allowing Git downloaders to download files from a branch other than the default one.
- Fixing some PyLint errors.

If the branch is left as None, then the old behavior is kept.