### PR TITLE
Update/zuul printer output based on arguments

### DIFF
--- a/cibyl/models/ci/zuul/job.py
+++ b/cibyl/models/ci/zuul/job.py
@@ -123,6 +123,16 @@ class Job(BaseJob):
 
     API = {
         **subset(BaseJob.API, ['name', 'url', 'builds']),
+        'output_mode': {
+            'arguments': [
+                Argument(
+                    name='--complete', arg_type=str, nargs=0, default=False,
+                    func='get_jobs', description='Shows the projects and '
+                                                 'pipelines hierarchy for '
+                                                 'the jobs'
+                ),
+            ],
+        },
         'variants': {
             'attr_type': Variant,
             'attribute_value_class': AttributeListValue,

--- a/cibyl/models/ci/zuul/job.py
+++ b/cibyl/models/ci/zuul/job.py
@@ -126,10 +126,9 @@ class Job(BaseJob):
         'output_mode': {
             'arguments': [
                 Argument(
-                    name='--complete', arg_type=str, nargs=0, default=False,
-                    func='get_jobs', description='Shows the projects and '
-                                                 'pipelines hierarchy for '
-                                                 'the jobs'
+                    name='--complete', arg_type=bool, nargs=0,
+                    description='Shows the projects and pipelines hierarchy '
+                                'for the jobs'
                 ),
             ],
         },

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -327,4 +327,5 @@ class Orchestrator:
                 environment=env,
                 style=output_style,
                 query=get_query_type(**self.parser.ci_args),
-                verbosity=self.parser.app_args.get('verbosity'))
+                verbosity=self.parser.app_args.get('verbosity'),
+                complete=self.parser.app_args.get('complete', None))

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -327,5 +327,5 @@ class Orchestrator:
                 environment=env,
                 style=output_style,
                 query=get_query_type(**self.parser.ci_args),
-                verbosity=self.parser.app_args.get('verbosity'),
-                complete=self.parser.app_args.get('complete', None))
+                verbosity=self.parser.app_args.get('verbosity', 0),
+                complete='complete' in self.parser.ci_args)

--- a/cibyl/outputs/cli/ci/env/factory.py
+++ b/cibyl/outputs/cli/ci/env/factory.py
@@ -24,7 +24,7 @@ class CIPrinterFactory:
     """
 
     @staticmethod
-    def from_style(style, query, verbosity):
+    def from_style(style, query, verbosity, complete):
         """Builds the appropriate printer for the desired output style.
 
         :param style: The desired output style.
@@ -33,6 +33,8 @@ class CIPrinterFactory:
         :type query: :class:`cibyl.models.cli.QueryType`
         :param verbosity: Verbosity level.
         :type verbosity: int
+        :param complete: Output mode. If enabled, prints extra information
+        :type complete: bool
         :return: The printer.
         :rtype: :class:`cibyl.models.ci.printers.CIPrinter`
         :raise NotImplementedError: If there is no printer for the
@@ -42,13 +44,15 @@ class CIPrinterFactory:
             return CIColoredPrinter(
                 query=query,
                 verbosity=verbosity,
-                palette=ClearText()
+                palette=ClearText(),
+                complete=complete
             )
 
         if style == OutputStyle.COLORIZED:
             return CIColoredPrinter(
                 query=query,
-                verbosity=verbosity
+                verbosity=verbosity,
+                complete=complete
             )
 
         if style == OutputStyle.JSON:

--- a/cibyl/outputs/cli/ci/env/factory.py
+++ b/cibyl/outputs/cli/ci/env/factory.py
@@ -24,7 +24,7 @@ class CIPrinterFactory:
     """
 
     @staticmethod
-    def from_style(style, query, verbosity, complete):
+    def from_style(style, query, verbosity, complete=False):
         """Builds the appropriate printer for the desired output style.
 
         :param style: The desired output style.

--- a/cibyl/outputs/cli/ci/env/factory.py
+++ b/cibyl/outputs/cli/ci/env/factory.py
@@ -24,7 +24,7 @@ class CIPrinterFactory:
     """
 
     @staticmethod
-    def from_style(style, query, verbosity, complete=False):
+    def from_style(style, query, verbosity, complete):
         """Builds the appropriate printer for the desired output style.
 
         :param style: The desired output style.

--- a/cibyl/outputs/cli/ci/env/impl/colored.py
+++ b/cibyl/outputs/cli/ci/env/impl/colored.py
@@ -61,7 +61,8 @@ class CIColoredPrinter(ColoredPrinter, CIPrinter):
             # Check specialized printers
             if isinstance(system, ZuulSystem):
                 return ColoredZuulSystemPrinter(
-                    self.query, self.verbosity, self.palette, complete=self.complete
+                    self.query, self.verbosity, self.palette,
+                    complete=self.complete
                 )
 
             if isinstance(system, JobsSystem):

--- a/cibyl/outputs/cli/ci/env/impl/colored.py
+++ b/cibyl/outputs/cli/ci/env/impl/colored.py
@@ -61,7 +61,7 @@ class CIColoredPrinter(ColoredPrinter, CIPrinter):
             # Check specialized printers
             if isinstance(system, ZuulSystem):
                 return ColoredZuulSystemPrinter(
-                    self.query, self.verbosity, self.palette
+                    self.query, self.verbosity, self.palette, complete=self.complete
                 )
 
             if isinstance(system, JobsSystem):

--- a/cibyl/outputs/cli/ci/system/impls/base/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/colored.py
@@ -39,7 +39,8 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
                  verbosity=0,
                  palette=DefaultPalette(),
                  job_sorter=BubbleSortAlgorithm(SortJobsByName()),
-                 build_sorter=BubbleSortAlgorithm(SortBuildsByUUID())):
+                 build_sorter=BubbleSortAlgorithm(SortBuildsByUUID()),
+                 complete=False):
         """Constructor. See parent for more information.
 
         :param job_sorter: Determines the order on which jobs are printed.
@@ -47,7 +48,7 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
         :param build_sorter: Determines the order on which builds are printed.
         :type build_sorter: :class:`cibyl.utils.sorting.SortingAlgorithm`
         """
-        super().__init__(query, verbosity, palette)
+        super().__init__(query, verbosity, palette, complete)
 
         self._job_sorter = job_sorter
         self._build_sorter = build_sorter

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -187,7 +187,8 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
 
             return result.build()
 
-        def print_variables(self, items: Any, result: IndentedTextBuilder, level: int = 2) -> None:
+        def print_variables(self, items: Any, result: IndentedTextBuilder,
+                            level: int = 2) -> None:
             """
             Print the variables in a recursive way, respecting the hierarchy
             """

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -14,7 +14,6 @@
 #    under the License.
 """
 import logging
-from typing import Any
 
 from overrides import overrides
 
@@ -178,38 +177,14 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
                 result[-1].append(branch)
 
             result.add(self.palette.blue('Variables: '), 1)
-            # Parse the variables recursively to present them in
-            # hierarchical fashion
-            self.print_variables(variant.variables, result, 2)
+            for key, value in variant.variables.items():
+                result.add(self.palette.blue(f'{key}: '), 2)
+                result[-1].append(value)
 
             if has_plugin_section(variant):
                 result.add(get_plugin_section(self, variant), 1)
 
             return result.build()
-
-        def print_variables(self, items: Any, result: IndentedTextBuilder,
-                            level: int = 2) -> None:
-            """
-            Print the variables in a recursive way, respecting the hierarchy
-            """
-            if type(items) is list:
-                for value in items:
-                    if type(value) in [dict, list]:
-                        self.print_variables(value, result, level + 1)
-                        continue
-
-                    result.add('- ', level)
-                    result[-1].append(value)
-            else:
-                for key in items:
-                    value = items[key]
-                    if type(value) in [dict, list]:
-                        result.add(self._palette.blue(f'{key}: '), level)
-                        self.print_variables(value, result, level + 1)
-                        continue
-
-                    result.add(self._palette.blue(f'{key}: '), level)
-                    result[-1].append(value)
 
         def print_build(self, build):
             result = IndentedTextBuilder()

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -310,7 +310,7 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
         result.add(self.palette.blue('Tenant: '), 0)
         result[-1].append(tenant.name)
 
-        if self.query >= QueryType.PROJECTS and self.complete is not False:
+        if self.query >= QueryType.PROJECTS and self.complete:
             print_projects()
 
         if self.query >= QueryType.JOBS:

--- a/cibyl/outputs/cli/printer.py
+++ b/cibyl/outputs/cli/printer.py
@@ -62,7 +62,8 @@ class ColoredPrinter(Printer, ABC):
     def __init__(self,
                  query=QueryType.NONE,
                  verbosity=0,
-                 palette=DefaultPalette()):
+                 palette=DefaultPalette(),
+                 complete=False):
         """Constructor.
 
         See parents for more information.
@@ -73,6 +74,7 @@ class ColoredPrinter(Printer, ABC):
         super().__init__(query, verbosity)
 
         self._palette = palette
+        self._complete = complete
 
     @property
     def palette(self):
@@ -81,3 +83,12 @@ class ColoredPrinter(Printer, ABC):
         :rtype: :class:`cibyl.utils.colors.ColorPalette`
         """
         return self._palette
+
+    @property
+    def complete(self):
+        """
+        :return: The output mode. When enabled, shows the projects and
+            pipelines hierarchy
+        :rtype: bool
+        """
+        return self._complete

--- a/cibyl/publisher.py
+++ b/cibyl/publisher.py
@@ -34,10 +34,11 @@ class Publisher:
                 target: str = "terminal",
                 style: OutputStyle = OutputStyle.TEXT,
                 query: QueryType = QueryType.NONE,
-                verbosity: int = 0) -> None:
+                verbosity: int = 0,
+                complete: bool = False) -> None:
         """Publishes the data of the given environments to the
         chosen destination.
         """
         if target == "terminal":
-            printer = CIPrinterFactory.from_style(style, query, verbosity)
+            printer = CIPrinterFactory.from_style(style, query, verbosity, complete)
             print(printer.print_environment(environment))

--- a/cibyl/publisher.py
+++ b/cibyl/publisher.py
@@ -40,5 +40,6 @@ class Publisher:
         chosen destination.
         """
         if target == "terminal":
-            printer = CIPrinterFactory.from_style(style, query, verbosity, complete)
+            printer = CIPrinterFactory.from_style(style, query, verbosity,
+                                                  complete)
             print(printer.print_environment(environment))

--- a/tests/cibyl/intr/outputs/test_output_colored_openstack.py
+++ b/tests/cibyl/intr/outputs/test_output_colored_openstack.py
@@ -80,7 +80,8 @@ class TestOutputZuulSystemWithOpenstackPlugin(OpenstackPluginWithZuulSystem):
         palette.underline.side_effect = lambda text: text
 
         printer = zuul_colored.ColoredZuulSystemPrinter(palette=palette,
-                                                        query=QueryType.JOBS)
+                                                        query=QueryType.JOBS,
+                                                        complete=True)
         output = printer.print_system(system)
         # check that output is five lines long(system line, one line per job
         # and the line for total number of jobs)

--- a/tests/cibyl/unit/outputs/cli/ci/env/test_factory.py
+++ b/tests/cibyl/unit/outputs/cli/ci/env/test_factory.py
@@ -29,7 +29,7 @@ class TestCIPrinterFactory(TestCase):
         factory = CIPrinterFactory()
 
         with self.assertRaises(NotImplementedError):
-            factory.from_style(-1, query, verbosity)
+            factory.from_style(-1, query, verbosity, False)
 
     def test_returns_clear_text_printer(self):
         query = Mock()
@@ -37,7 +37,7 @@ class TestCIPrinterFactory(TestCase):
 
         factory = CIPrinterFactory()
 
-        result = factory.from_style(OutputStyle.TEXT, query, verbosity)
+        result = factory.from_style(OutputStyle.TEXT, query, verbosity, False)
 
         self.assertEqual(query, result.query)
         self.assertEqual(verbosity, result.verbosity)
@@ -50,7 +50,7 @@ class TestCIPrinterFactory(TestCase):
 
         factory = CIPrinterFactory()
 
-        result = factory.from_style(OutputStyle.COLORIZED, query, verbosity)
+        result = factory.from_style(OutputStyle.COLORIZED, query, verbosity, False)
 
         self.assertEqual(query, result.query)
         self.assertEqual(verbosity, result.verbosity)

--- a/tests/cibyl/unit/outputs/cli/ci/env/test_factory.py
+++ b/tests/cibyl/unit/outputs/cli/ci/env/test_factory.py
@@ -37,7 +37,8 @@ class TestCIPrinterFactory(TestCase):
 
         factory = CIPrinterFactory()
 
-        result = factory.from_style(OutputStyle.TEXT, query, verbosity, False)
+        result = factory.from_style(OutputStyle.TEXT, query, verbosity,
+                                    False)
 
         self.assertEqual(query, result.query)
         self.assertEqual(verbosity, result.verbosity)
@@ -50,7 +51,8 @@ class TestCIPrinterFactory(TestCase):
 
         factory = CIPrinterFactory()
 
-        result = factory.from_style(OutputStyle.COLORIZED, query, verbosity, False)
+        result = factory.from_style(OutputStyle.COLORIZED, query, verbosity,
+                                    False)
 
         self.assertEqual(query, result.query)
         self.assertEqual(verbosity, result.verbosity)


### PR DESCRIPTION
I created this draft PR to show my proposal for the Zuul printer, to not show the whole tenant -> project -> pipeline -> job hierarchy when only querying for jobs.

My proposal is to add a new CLI argument `--complete` (other naming proposals are welcome) that, when enabled, will show the whole Zuul hierarchy + the actual list of jobs when querying for jobs.
Example when enabled:
```
Environment: env
  System: system
    Tenant: local
      Projects: 
        Project: project1
          Pipeline: check
            Job: some-job
            Job: another-job
            Total jobs found in query for pipeline 'check': 2
      Jobs: 
        Job: some-job
        Job: another-job
```
Example when disabled:
```
Environment: env
  System: system
    Tenant: local
      Jobs: 
        Job: some-job
        Job: another-job
```

The default value of the argument is False, so in order to get the Zuul hierarchy users must ask for it explicitly.
