### PR TITLE
Fix a bug where an inaccessible GitHub crashed Cibyl

### DIFF
--- a/tripleo/insights/git.py
+++ b/tripleo/insights/git.py
@@ -25,7 +25,7 @@ from tripleo.utils.git import Git
 from tripleo.utils.git import Repository as GitRepo
 from tripleo.utils.git.gitpython import GitPython
 from tripleo.utils.git.utils import get_repository_fullname
-from tripleo.utils.github import GitHub
+from tripleo.utils.github import GitHub, GitHubError
 from tripleo.utils.github import Repository as GitHubRepo
 from tripleo.utils.github.pygithub import PyGitHub
 from tripleo.utils.paths import resolve_home
@@ -169,12 +169,16 @@ class GitHubDownloader(GitDownloader):
 
     @overrides
     def download_as_text(self, file: str) -> str:
-        repo = self._get_repository()
+        try:
+            repo = self._get_repository()
 
-        if self.branch:
-            repo.checkout(self.branch)
+            if self.branch:
+                repo.checkout(self.branch)
 
-        return repo.download_as_text(file)
+            return repo.download_as_text(file)
+        except GitHubError as ex:
+            msg = f"GitHub failed with error: '{ex}'."
+            raise DownloadError(msg) from ex
 
     def _get_repository(self) -> GitHubRepo:
         def get_repository_owner():


### PR DESCRIPTION
Transforming a GitHubError into a DownloadError so that the TripleO library can handle it and try a different API if the GitHub one is not available.