### PR TITLE
Fixing a bug where the TripleO library failed to check out the master branch

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/actions.py
+++ b/cibyl/plugins/openstack/sources/zuul/actions.py
@@ -164,7 +164,7 @@ class DeploymentGenerator:
         return Deployment(
             release=self._get_release(variant, **kwargs),
             infra_type=summary.infra_type,
-            topology=summary.topology,
+            topology=str(summary.topology),
             network=Network(
                 ip_version=summary.ip_version
             )

--- a/cibyl/plugins/openstack/sources/zuul/actions.py
+++ b/cibyl/plugins/openstack/sources/zuul/actions.py
@@ -177,7 +177,8 @@ class DeploymentGenerator:
             release = release_search.search(variant)
 
             if not release:
-                return 'N/A'
+                # Fall back to the default value
+                return 'master'
 
             _, value = release
 

--- a/tests/tripleo/unit/insights/test_tripleo.py
+++ b/tests/tripleo/unit/insights/test_tripleo.py
@@ -22,6 +22,18 @@ class TestTHTBranchCreator(TestCase):
     """Tests for :class:`THTBranchCreator`.
     """
 
+    def test_ignores_master(self):
+        """Checks that the master branch is, by default, returned untouched.
+        """
+        release = 'master'
+
+        creator = THTBranchCreator()
+
+        self.assertEqual(
+            f'{release}',
+            creator.create_release_branch(release)
+        )
+
     def test_creates_release_branch(self):
         """Checks the default template for a release branch.
         """

--- a/tripleo/insights/tripleo.py
+++ b/tripleo/insights/tripleo.py
@@ -14,26 +14,44 @@
 #    under the License.
 """
 from string import Template
+from typing import Iterable
 
 
 class THTBranchCreator:
     """Utility to ease the creation of branch names inside the Heat
     Templates repository.
     """
+    DEFAULT_IGNORED_RELEASES = ('master',)
     DEFAULT_RELEASE_TEMPLATE = Template('stable/$release')
     """Default template used to generate the branch assigned to a release."""
 
-    def __init__(self, release_template: Template = DEFAULT_RELEASE_TEMPLATE):
+    def __init__(
+        self,
+        ignored_releases: Iterable[str] = DEFAULT_IGNORED_RELEASES,
+        release_template: Template = DEFAULT_RELEASE_TEMPLATE
+    ):
         """Constructor.
 
+        :param ignored_releases: Collection of release names that map 1-to-1
+            to their branch and thus need no processing. If one of this is
+            seen, then it will be returned as is.
         :param release_template: Template used to generate branch names from
             a RHOS release name. It only takes one argument, $release,
             which is the name of the RHOS release.
         """
+        self._ignored_releases = ignored_releases
         self._release_template = release_template
 
     @property
-    def release_template(self):
+    def ignored_releases(self) -> Iterable[str]:
+        """
+        :return: The releases that require no processing to be mapped to
+            their branch.
+        """
+        return self._ignored_releases
+
+    @property
+    def release_template(self) -> Template:
         """
         :return: Template used to generate branch names from a RHOS release
             name.
@@ -48,10 +66,16 @@ class THTBranchCreator:
         >>> creator = THTBranchCreator()
         ... creator.create_release_branch('wallaby')
         'stable/wallaby'
+        >>> creator = THTBranchCreator(ignored_releases=('master',))
+        ... creator.create_release_branch('master')
+        'master'
 
         :param release: Name of the RHOS release. For example: 'wallaby'.
         :return: The branch assigned to that release.
         """
+        if release in self.ignored_releases:
+            return release
+
         return self.release_template.substitute(release=release)
 
 
@@ -75,7 +99,7 @@ class THTPathCreator:
         self._scenario_template = scenario_template
 
     @property
-    def scenario_template(self):
+    def scenario_template(self) -> Template:
         """
         :return: Template this will use to generate paths to scenario files
         inside the repository.


### PR DESCRIPTION
Adding a collection of excluded releases that are considered to point without change to their branch. This is meant specially for the 'master' branch, which was getting turned into 'stable/master' and was impossible to check out. 