### PR TITLE
Hiding 'Topology' output is there is no information on it.

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/actions.py
+++ b/cibyl/plugins/openstack/sources/zuul/actions.py
@@ -164,7 +164,7 @@ class DeploymentGenerator:
         return Deployment(
             release=self._get_release(variant, **kwargs),
             infra_type=summary.infra_type,
-            topology=summary.topology,
+            topology=str(summary.topology),
             network=Network(
                 ip_version=summary.ip_version
             )


### PR DESCRIPTION
Fixing an error where the 'Topology: ' entry was appearing on the deployment's output even if it had no data attached. The error was harmless, but this will clean things up a bit.