### PR TITLE
Change default release to 'master'

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/actions.py
+++ b/cibyl/plugins/openstack/sources/zuul/actions.py
@@ -177,7 +177,8 @@ class DeploymentGenerator:
             release = release_search.search(variant)
 
             if not release:
-                return 'N/A'
+                # Fall back to the default value
+                return 'master'
 
             _, value = release
 


### PR DESCRIPTION
If a Zuul job does not explicitly declare the release version, then it is most likely referring to 'master'. 

This PR will make a Zuul deployment use 'master' as the default release for a job.