### PR TITLE
Fixing a bug where the TripleO library failed to clone repositories.

### DIFF
--- a/tests/tripleo/e2e/__init__.py
+++ b/tests/tripleo/e2e/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/tripleo/e2e/test_git.py
+++ b/tests/tripleo/e2e/test_git.py
@@ -1,0 +1,40 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+from tripleo.insights import DeploymentLookUp, DeploymentOutline
+from tripleo.utils.git import GitError
+from tripleo.utils.urls import URL
+
+
+class TestOpenDev(TestCase):
+    """Verifies that the library is capable of working with repositories
+    hosted on OpenDev.
+    """
+
+    def test_no_error_on_clone(self):
+        """Checks that the library does not crash when trying to clone an
+        OpenDev repository.
+        """
+        url = URL('https://opendev.org/openstack/tripleo-quickstart.git')
+        outline = DeploymentOutline(quickstart=url)
+
+        lookup = DeploymentLookUp()
+
+        try:
+            lookup.run(outline)
+        except GitError as ex:
+            self.fail(f"Test threw an unwanted error: '{type(ex).__name__}'.")

--- a/tests/tripleo/intr/utils/test_fs.py
+++ b/tests/tripleo/intr/utils/test_fs.py
@@ -68,6 +68,53 @@ class TestDir(TestCase):
             with NamedTemporaryFile(dir=directory):
                 self.assertFalse(directory.is_empty())
 
+    def test_cd(self):
+        """Checks that a path to a subdirectory is created as expected.
+        """
+        subfolder = 'folder'
+
+        with TemporaryDirectory() as folder:
+            directory = Dir(folder)
+
+            self.assertEqual(
+                f'{directory}/{subfolder}',
+                directory.cd(subfolder)
+            )
+
+    def test_mkdir_error(self):
+        """Checks that an error is raised if the directory's parents do not
+        exist.
+        """
+        directory = Dir('path/to/some/dir')
+
+        with self.assertRaises(FileNotFoundError):
+            directory.mkdir(recursive=False)
+
+    def test_simple_mkdir(self):
+        """Checks that a folder can be created under a parent directory.
+        """
+        with TemporaryDirectory() as folder:
+            directory = Dir(f'{folder}/dir')
+
+            self.assertFalse(directory.exists())
+
+            directory.mkdir(recursive=False)
+
+            self.assertTrue(directory.exists())
+
+    def test_recursive_mkdir(self):
+        """Checks that all the folders leading to a directory can be
+        created.
+        """
+        with TemporaryDirectory() as folder:
+            directory = Dir(f'{folder}/dir/subdir')
+
+            self.assertFalse(directory.exists())
+
+            directory.mkdir(recursive=True)
+
+            self.assertTrue(directory.exists())
+
     def test_as_path(self):
         """Checks that the type can be converted into a path.
         """
@@ -115,40 +162,6 @@ class TestFile(TestCase):
             file = File(folder)
 
             self.assertFalse(file.exists())
-
-    def test_mkdir_error(self):
-        """Checks that an error is raised if the directory's parents do not
-        exist.
-        """
-        directory = Dir('path/to/some/dir')
-
-        with self.assertRaises(FileNotFoundError):
-            directory.mkdir(recursive=False)
-
-    def test_simple_mkdir(self):
-        """Checks that a folder can be created under a parent directory.
-        """
-        with TemporaryDirectory() as folder:
-            directory = Dir(f'{folder}/dir')
-
-            self.assertFalse(directory.exists())
-
-            directory.mkdir(recursive=False)
-
-            self.assertTrue(directory.exists())
-
-    def test_recursive_mkdir(self):
-        """Checks that all the folders leading to a directory can be
-        created.
-        """
-        with TemporaryDirectory() as folder:
-            directory = Dir(f'{folder}/dir/subdir')
-
-            self.assertFalse(directory.exists())
-
-            directory.mkdir(recursive=True)
-
-            self.assertTrue(directory.exists())
 
     def test_as_path(self):
         """Checks that the type can be converted into a path.

--- a/tripleo/insights/git.py
+++ b/tripleo/insights/git.py
@@ -29,6 +29,7 @@ from tripleo.utils.github import GitHub, GitHubError
 from tripleo.utils.github import Repository as GitHubRepo
 from tripleo.utils.github.pygithub import PyGitHub
 from tripleo.utils.paths import resolve_home
+from tripleo.utils.rng import get_new_uuid
 from tripleo.utils.urls import URL, is_git, is_github
 from tripleo.utils.yaml import YAML, StandardYAMLParser, YAMLError, YAMLParser
 
@@ -198,19 +199,20 @@ class GitDownloaderFetcher:
     URL.
     """
     DEFAULT_CLONE_PATH = Dir('~/.cre', resolve_home)
-    """Default directory where Git repositories are cloned to if needed."""
+    """Default directory where repositories are cloned into if required."""
 
     def __init__(self, clone_path: Dir = DEFAULT_CLONE_PATH):
         """
-        :param clone_path: Directory where Git repositories are cloned in if
-            required.
+        :param clone_path: Directory where cloned repositories will hang
+            from if required.
         """
         self._clone_path = clone_path
 
     @property
     def clone_path(self) -> Dir:
         """
-        :return: Directory where Git repositories are cloned in if required.
+        :return: Directory where cloned repositories will hang from if
+            required.
         """
         return self._clone_path
 
@@ -245,7 +247,7 @@ class GitDownloaderFetcher:
         return GitCLIDownloader(
             repository=url,
             branch=branch,
-            working_dir=self.clone_path
+            working_dir=self.clone_path.cd(get_new_uuid())
         )
 
     def _get_new_github_downloader(

--- a/tripleo/insights/git.py
+++ b/tripleo/insights/git.py
@@ -197,7 +197,7 @@ class GitDownloaderFetcher:
     """Tool used to find the downloaders that are compatible with a certain
     URL.
     """
-    DEFAULT_CLONE_PATH = Dir('~/.cibyl', resolve_home)
+    DEFAULT_CLONE_PATH = Dir('~/.cre', resolve_home)
     """Default directory where Git repositories are cloned to if needed."""
 
     def __init__(self, clone_path: Dir = DEFAULT_CLONE_PATH):

--- a/tripleo/utils/fs.py
+++ b/tripleo/utils/fs.py
@@ -115,12 +115,6 @@ class File(FSPath):
             msg = f"Path is not a file or does not exist: '{self}'."
             raise IOError(msg)
 
-    @staticmethod
-    def from_existing(path: RawPath) -> 'File':
-        result = File(path)
-
-        return result
-
     @overrides
     def exists(self) -> bool:
         return self.as_path().is_file()

--- a/tripleo/utils/fs.py
+++ b/tripleo/utils/fs.py
@@ -94,6 +94,15 @@ class Dir(FSPath):
 
         return not any(self.as_path().iterdir())
 
+    def cd(self, path: RawPath) -> 'Dir':
+        """Combines this path with the one passed as an argument. Useful to
+        represent subdirectories.
+
+        :param path: The path to append.
+        :return: A new directory handler, pointing to the combined path.
+        """
+        return Dir(self.as_path() / path)
+
     def mkdir(self, recursive: bool = False) -> None:
         """Creates the directory on the filesystem.
 

--- a/tripleo/utils/git/gitpython.py
+++ b/tripleo/utils/git/gitpython.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+import logging
 import os
 
 from git import InvalidGitRepositoryError, NoSuchPathError, Repo
@@ -23,6 +24,8 @@ from tripleo.utils.git import Git as IGit
 from tripleo.utils.git import GitError
 from tripleo.utils.git import Repository as IRepository
 from tripleo.utils.urls import URL
+
+LOG = logging.getLogger(__name__)
 
 
 class Repository(IRepository):
@@ -98,8 +101,8 @@ class GitPython(IGit):
     @overrides
     def open(self, working_dir: Dir) -> Repository:
         try:
+            LOG.info("Opening repository at: '%s'.", working_dir)
             repo = Repo(working_dir.as_path())
-
             return Repository(repo)
         except InvalidGitRepositoryError as ex:
             msg = f"Failed to open repository at: '{working_dir}'."
@@ -110,6 +113,6 @@ class GitPython(IGit):
 
     @overrides
     def clone(self, url: URL, working_dir: Dir) -> Repository:
+        LOG.info("Cloning repository: '%s' into: '%s'.", url, working_dir)
         repo = Repo.clone_from(url, working_dir.as_path())
-
         return Repository(repo)

--- a/tripleo/utils/rng.py
+++ b/tripleo/utils/rng.py
@@ -1,0 +1,23 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import uuid
+
+
+def get_new_uuid() -> str:
+    """
+    :return: A new unique identifier.
+    """
+    return str(uuid.uuid4())


### PR DESCRIPTION
- Moved default clone path to '~/.cre' from '~/.cibyl' as the library is supposed to be independent.
- Extended 'Dir' so that I can create new paths from it.
- Added a new module 'rng' that handles things related to random numbers.
- Have each repository be cloned on its own random folder, avoiding the conflict that was happening due to them sharing the same folder.
- Adding a test that verifies that the problem no longer happens.

This change will provide support for repositories hosted on OpenDev.