### PR TITLE
Add type hints

### DIFF
--- a/cibyl/outputs/cli/ci/env/factory.py
+++ b/cibyl/outputs/cli/ci/env/factory.py
@@ -14,8 +14,10 @@
 #    under the License.
 """
 from cibyl.cli.output import OutputStyle
+from cibyl.cli.query import QueryType
 from cibyl.outputs.cli.ci.env.impl.colored import CIColoredPrinter
 from cibyl.outputs.cli.ci.env.impl.serialized import JSONPrinter
+from cibyl.outputs.cli.ci.env.printer import CIPrinter
 from cibyl.utils.colors import ClearText
 
 
@@ -24,17 +26,14 @@ class CIPrinterFactory:
     """
 
     @staticmethod
-    def from_style(style, query, verbosity):
+    def from_style(style: OutputStyle, query: QueryType,
+                   verbosity: int) -> CIPrinter:
         """Builds the appropriate printer for the desired output style.
 
         :param style: The desired output style.
-        :type style: :class:`OutputStyle`
         :param query: How far the hierarchy the printer shall go.
-        :type query: :class:`cibyl.models.cli.QueryType`
         :param verbosity: Verbosity level.
-        :type verbosity: int
         :return: The printer.
-        :rtype: :class:`cibyl.models.ci.printers.CIPrinter`
         :raise NotImplementedError: If there is no printer for the
             desired style.
         """

--- a/cibyl/outputs/cli/ci/env/impl/colored.py
+++ b/cibyl/outputs/cli/ci/env/impl/colored.py
@@ -17,7 +17,8 @@ import logging
 
 from overrides import overrides
 
-from cibyl.models.ci.base.system import JobsSystem
+from cibyl.models.ci.base.environment import Environment
+from cibyl.models.ci.base.system import JobsSystem, System
 from cibyl.models.ci.zuul.system import ZuulSystem
 from cibyl.outputs.cli.ci.env.printer import CIPrinter
 from cibyl.outputs.cli.ci.system.impls.base.colored import \
@@ -38,7 +39,7 @@ class CIColoredPrinter(ColoredPrinter, CIPrinter):
     """
 
     @overrides
-    def print_environment(self, env):
+    def print_environment(self, env: Environment) -> str:
         printer = IndentedTextBuilder()
 
         printer.add(self._palette.blue('Environment: '), 0)
@@ -49,15 +50,13 @@ class CIColoredPrinter(ColoredPrinter, CIPrinter):
 
         return printer.build()
 
-    def print_system(self, system):
+    def print_system(self, system: System) -> str:
         """
         :param system: The system.
-        :type system: :class:`cibyl.models.ci.base.system.System`
         :return: Textual representation of the system.
-        :rtype: str
         """
 
-        def get_printer():
+        def get_printer() -> ColoredBaseSystemPrinter:
             # Check specialized printers
             if isinstance(system, ZuulSystem):
                 return ColoredZuulSystemPrinter(

--- a/cibyl/outputs/cli/ci/env/impl/serialized.py
+++ b/cibyl/outputs/cli/ci/env/impl/serialized.py
@@ -16,11 +16,13 @@
 import json
 import logging
 from abc import ABC, abstractmethod
+from typing import Callable, Union
 
 from overrides import overrides
 
 from cibyl.cli.query import QueryType
-from cibyl.models.ci.base.system import JobsSystem
+from cibyl.models.ci.base.environment import Environment
+from cibyl.models.ci.base.system import JobsSystem, System
 from cibyl.outputs.cli.ci.env.printer import CIPrinter
 from cibyl.outputs.cli.ci.system.impls.base.serialized import \
     JSONBaseSystemPrinter
@@ -36,20 +38,18 @@ class SerializedDataPrinter(CIPrinter, ABC):
     """
 
     def __init__(self,
-                 load_function,
-                 dump_function,
-                 query=QueryType.NONE,
-                 verbosity=0):
+                 load_function: Callable[[str], dict],
+                 dump_function: Callable[[dict], str],
+                 query: QueryType = QueryType.NONE,
+                 verbosity: int = 0):
         """Constructor. See parent for more information.
 
         :param load_function: Function that transforms machine-readable text
             into a Python structure. Used to unmarshall output of sub-parts
             of the module.
-        :type load_function: (str) -> dict
         :param dump_function: Function that transforms a Python structure into
             machine-readable text. Used to marshall the data from the
             hierarchy.
-        :type dump_function: (dict) -> str
         """
         super().__init__(query, verbosity)
 
@@ -57,7 +57,7 @@ class SerializedDataPrinter(CIPrinter, ABC):
         self._dump = dump_function
 
     @overrides
-    def print_environment(self, env):
+    def print_environment(self, env: Environment) -> str:
         def get_systems():
             systems = {}
 
@@ -75,12 +75,10 @@ class SerializedDataPrinter(CIPrinter, ABC):
         return self._dump(result)
 
     @abstractmethod
-    def print_system(self, system):
+    def print_system(self, system: System) -> str:
         """
         :param system: The system.
-        :type system: :class:`cibyl.models.ci.base.system.System`
         :return: Textual representation of the system.
-        :rtype: str
         """
         raise NotImplementedError
 
@@ -90,14 +88,13 @@ class JSONPrinter(SerializedDataPrinter):
     """
 
     def __init__(self,
-                 query=QueryType.NONE,
-                 verbosity=0,
-                 indentation=4):
+                 query: QueryType = QueryType.NONE,
+                 verbosity: int = 0,
+                 indentation: int = 4):
         """Constructor. See parent for more information.
 
         :param indentation: Number of spaces indenting each level of the
             JSON output.
-        :type indentation: int
         """
         super().__init__(
             load_function=self._from_json,
@@ -109,15 +106,14 @@ class JSONPrinter(SerializedDataPrinter):
         self._indentation = indentation
 
     @property
-    def indentation(self):
+    def indentation(self) -> int:
         """
         :return: Number of spaces preceding every level of the JSON output.
-        :rtype: int
         """
         return self._indentation
 
     @overrides
-    def print_system(self, system):
+    def print_system(self, system: System) -> str:
         def get_printer():
             # Check specialized printers
             if isinstance(system, JobsSystem):
@@ -137,8 +133,8 @@ class JSONPrinter(SerializedDataPrinter):
 
         return get_printer().print_system(system)
 
-    def _from_json(self, obj):
+    def _from_json(self, obj: Union[str, bytes, bytearray]) -> dict:
         return json.loads(obj)
 
-    def _to_json(self, obj):
+    def _to_json(self, obj: object) -> str:
         return json.dumps(obj, indent=self._indentation)

--- a/cibyl/outputs/cli/ci/env/printer.py
+++ b/cibyl/outputs/cli/ci/env/printer.py
@@ -15,6 +15,7 @@
 """
 from abc import ABC, abstractmethod
 
+from cibyl.models.ci.base.environment import Environment
 from cibyl.outputs.cli.printer import Printer
 
 
@@ -23,11 +24,9 @@ class CIPrinter(Printer, ABC):
     """
 
     @abstractmethod
-    def print_environment(self, env):
+    def print_environment(self, env: Environment) -> str:
         """
         :param env: The environment.
-        :type env: :class:`cibyl.models.ci.base.environment.Environment`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         raise NotImplementedError

--- a/cibyl/outputs/cli/ci/system/common/builds.py
+++ b/cibyl/outputs/cli/ci/system/common/builds.py
@@ -13,32 +13,29 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.models.ci.base.build import Build
 from cibyl.outputs.cli.ci.system.common.status import get_status_colored
+from cibyl.utils.colors import ColorPalette
 from cibyl.utils.strings import IndentedTextBuilder
 from cibyl.utils.time import as_minutes
 
 
-def has_status_section(build):
+def has_status_section(build: Build) -> bool:
     """Checks whether a build has enough data to build a status entry for
     its description.
 
     :param build: The build to check.
-    :type build: :class:`cibyl.models.ci.base.build.Build`
     :return: True if a status section can be built, False if not.
-    :rtype: bool
     """
     return build.status.value
 
 
-def get_status_section(palette, build):
+def get_status_section(palette: ColorPalette, build: Build) -> str:
     """Generates the text describing the status of a build.
 
     :param palette: The palette of colors to follow.
-    :type palette: :class:`cibyl.utils.colors.ColorPalette`
     :param build: The build to get the data from.
-    :type build: :class:`cibyl.models.ci.base.build.Build`
     :return: The text with the status of the build.
-    :rtype: str
     """
     if not has_status_section(build):
         raise ValueError('Build has no status to create a section for.')
@@ -51,27 +48,22 @@ def get_status_section(palette, build):
     return text.build()
 
 
-def has_duration_section(build):
+def has_duration_section(build: Build) -> bool:
     """Checks whether a build has enough data to build a duration entry for
     its description.
 
     :param build: The build to check.
-    :type build: :class:`cibyl.models.ci.base.build.Build`
     :return: True if a duration section can be built, False if not.
-    :rtype: bool
     """
     return build.duration.value
 
 
-def get_duration_section(palette, build):
+def get_duration_section(palette: ColorPalette, build: Build) -> str:
     """Generates the text describing the duration of a build.
 
     :param palette: The palette of colors to follow.
-    :type palette: :class:`cibyl.utils.colors.ColorPalette`
     :param build: The build to get the data from.
-    :type build: :class:`cibyl.models.ci.base.build.Build`
     :return: The text with the duration of the build.
-    :rtype: str
     """
     if not has_duration_section(build):
         raise ValueError('Build has no duration to create a section for.')

--- a/cibyl/outputs/cli/ci/system/common/models.py
+++ b/cibyl/outputs/cli/ci/system/common/models.py
@@ -17,6 +17,8 @@ import logging
 
 from cibyl.models.attribute import (AttributeDictValue, AttributeListValue,
                                     AttributeValue)
+from cibyl.models.model import Model
+from cibyl.outputs.cli.printer import ColoredPrinter
 from cibyl.plugins.openstack import Deployment
 from cibyl.plugins.openstack.printers.colored import OSColoredPrinter
 from cibyl.utils.strings import IndentedTextBuilder
@@ -24,14 +26,12 @@ from cibyl.utils.strings import IndentedTextBuilder
 LOG = logging.getLogger(__name__)
 
 
-def has_plugin_section(model):
+def has_plugin_section(model: Model) -> bool:
     """Checks whether a model is worth having a plugins' section for.
 
     :param model: The model to check.
-    :type model: :class:`cibyl.models.model.Model`
     :return: True if the model has enough data to build
         a plugins' section with, False if not.
-    :rtype: bool
     """
     if not model.plugin_attributes:
         return False
@@ -47,7 +47,7 @@ def has_plugin_section(model):
     return has_plugin_attribute
 
 
-def get_plugin_section(printer, model):
+def get_plugin_section(printer: ColoredPrinter, model: Model) -> str:
     """Gets the text describing the plugins that affect a model.
 
     ..  seealso::
@@ -55,11 +55,8 @@ def get_plugin_section(printer, model):
 
     :param printer: The printer the text will be based on. The output of
         this function will follow the styling of this.
-    :type printer: :class:`cibyl.outputs.cli.printer.ColoredPrinter`
     :param model: The model to get the description for.
-    :type model: :class:`cibyl.models.model.Model`
     :return: The description.
-    :rtype: str
     :raises ValueError: If the model does not have enough data to build the
         section.
     """

--- a/cibyl/outputs/cli/ci/system/common/stages.py
+++ b/cibyl/outputs/cli/ci/system/common/stages.py
@@ -13,23 +13,22 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.models.ci.base.stage import Stage
 from cibyl.outputs.cli.ci.system.common.status import get_status_colored
+from cibyl.utils.colors import ColorPalette
 from cibyl.utils.strings import IndentedTextBuilder
 from cibyl.utils.time import as_minutes
 
 
-def print_stage(stage, palette, verbosity=0):
+def print_stage(stage: Stage, palette: ColorPalette,
+                verbosity: int = 0) -> str:
     """
         Generate string representation of a Stage model.
 
         :param test: The stage.
-        :type test: :class:`cibyl.models.ci.base.stage.Stage`
         :param palette: The palette of colors to follow.
-        :type palette: :class:`cibyl.utils.colors.ColorPalette`
         :param verbosity: The verbosity level to use.
-        :type verbosity: int
         :return: Textual representation of the provided model.
-        :rtype: str
     """
     printer = IndentedTextBuilder()
 

--- a/cibyl/outputs/cli/ci/system/common/status.py
+++ b/cibyl/outputs/cli/ci/system/common/status.py
@@ -13,17 +13,15 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.utils.colors import ColorPalette
 
 
-def get_status_colored(palette, status):
+def get_status_colored(palette: ColorPalette, status: str) -> str:
     """Generates the text describing the status of a build.
 
     :param palette: The palette of colors to follow.
-    :type palette: :class:`cibyl.utils.colors.ColorPalette`
     :param status: The status to color.
-    :type status: str
     :return: The text with the status colored.
-    :rtype: str
     """
 
     status_x_color_map = {

--- a/cibyl/outputs/cli/ci/system/impls/base/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/colored.py
@@ -18,12 +18,14 @@ import logging
 from overrides import overrides
 
 from cibyl.cli.query import QueryType
+from cibyl.models.ci.base.system import System
+from cibyl.models.product.feature import Feature
 from cibyl.outputs.cli.ci.system.printer import CISystemPrinter
 from cibyl.outputs.cli.ci.system.utils.sorting.builds import SortBuildsByUUID
 from cibyl.outputs.cli.ci.system.utils.sorting.jobs import SortJobsByName
 from cibyl.outputs.cli.printer import ColoredPrinter
-from cibyl.utils.colors import DefaultPalette
-from cibyl.utils.sorting import BubbleSortAlgorithm
+from cibyl.utils.colors import ColorPalette, DefaultPalette
+from cibyl.utils.sorting import BubbleSortAlgorithm, SortingAlgorithm
 from cibyl.utils.strings import IndentedTextBuilder
 
 LOG = logging.getLogger(__name__)
@@ -35,17 +37,17 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
     """
 
     def __init__(self,
-                 query=QueryType.NONE,
-                 verbosity=0,
-                 palette=DefaultPalette(),
-                 job_sorter=BubbleSortAlgorithm(SortJobsByName()),
-                 build_sorter=BubbleSortAlgorithm(SortBuildsByUUID())):
+                 query: QueryType = QueryType.NONE,
+                 verbosity: int = 0,
+                 palette: ColorPalette = DefaultPalette(),
+                 job_sorter: SortingAlgorithm
+                 = BubbleSortAlgorithm(SortJobsByName()),
+                 build_sorter: SortingAlgorithm
+                 = BubbleSortAlgorithm(SortBuildsByUUID())):
         """Constructor. See parent for more information.
 
         :param job_sorter: Determines the order on which jobs are printed.
-        :type job_sorter: :class:`cibyl.utils.sorting.SortingAlgorithm`
         :param build_sorter: Determines the order on which builds are printed.
-        :type build_sorter: :class:`cibyl.utils.sorting.SortingAlgorithm`
         """
         super().__init__(query, verbosity, palette)
 
@@ -53,7 +55,7 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
         self._build_sorter = build_sorter
 
     @overrides
-    def print_system(self, system):
+    def print_system(self, system: System) -> str:
         printer = IndentedTextBuilder()
 
         printer.add(self._palette.blue('System: '), 0)
@@ -68,12 +70,11 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
 
         return printer.build()
 
-    def print_feature(self, feature):
+    def print_feature(self, feature: Feature) -> str:
         """Print a feature present in a system.
         :param feature: The feature.
         :type feature: :class:`cibyl.models.ci.base.feature.Feature`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         printer = IndentedTextBuilder()
         name = feature.name.value

--- a/cibyl/outputs/cli/ci/system/impls/base/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/serialized.py
@@ -15,10 +15,13 @@
 """
 import json
 from abc import ABC
+from typing import Callable, Union
 
 from overrides import overrides
 
 from cibyl.cli.query import QueryType
+from cibyl.models.ci.base.system import System
+from cibyl.models.product.feature import Feature
 from cibyl.outputs.cli.ci.system.printer import CISystemPrinter
 
 
@@ -27,20 +30,18 @@ class SerializedBaseSystemPrinter(CISystemPrinter, ABC):
     """
 
     def __init__(self,
-                 load_function,
-                 dump_function,
-                 query=QueryType.NONE,
-                 verbosity=0):
+                 load_function: Callable[[str], dict],
+                 dump_function: Callable[[dict], str],
+                 query: QueryType = QueryType.NONE,
+                 verbosity: int = 0):
         """Constructor. See parent for more information.
 
         :param load_function: Function that transforms machine-readable text
             into a Python structure. Used to unmarshall output of sub-parts
             of the module.
-        :type load_function: (str) -> dict
         :param dump_function: Function that transforms a Python structure into
             machine-readable text. Used to marshall the data from the
             hierarchy.
-        :type dump_function: (dict) -> str
         """
         super().__init__(query, verbosity)
 
@@ -48,7 +49,7 @@ class SerializedBaseSystemPrinter(CISystemPrinter, ABC):
         self._dump = dump_function
 
     @overrides
-    def print_system(self, system):
+    def print_system(self, system: System) -> str:
         result = {
             'name': system.name.value,
             'type': system.system_type.value
@@ -66,13 +67,11 @@ class SerializedBaseSystemPrinter(CISystemPrinter, ABC):
 
         return self._dump(result)
 
-    def print_feature(self, feature):
+    def print_feature(self, feature: Feature) -> str:
         """Print a feature present in a system.
 
         :param feature: The feature.
-        :type feature: :class:`cibyl.models.ci.base.feature.Feature`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         result = {
             'name': feature.name.value,
@@ -87,14 +86,13 @@ class JSONBaseSystemPrinter(SerializedBaseSystemPrinter):
     """
 
     def __init__(self,
-                 query=QueryType.NONE,
-                 verbosity=0,
-                 indentation=4):
+                 query: QueryType = QueryType.NONE,
+                 verbosity: int = 0,
+                 indentation: int = 4):
         """Constructor. See parent for more information.
 
         :param indentation: Number of spaces indenting each level of the
             JSON output.
-        :type indentation: int
         """
         super().__init__(
             load_function=self._from_json,
@@ -106,15 +104,14 @@ class JSONBaseSystemPrinter(SerializedBaseSystemPrinter):
         self._indentation = indentation
 
     @property
-    def indentation(self):
+    def indentation(self) -> int:
         """
         :return: Number of spaces preceding every level of the JSON output.
-        :rtype: int
         """
         return self._indentation
 
-    def _from_json(self, obj):
+    def _from_json(self, obj: Union[str, bytes, bytearray]) -> dict:
         return json.loads(obj)
 
-    def _to_json(self, obj):
+    def _to_json(self, obj: object) -> str:
         return json.dumps(obj, indent=self._indentation)

--- a/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
@@ -16,6 +16,10 @@
 from overrides import overrides
 
 from cibyl.cli.query import QueryType
+from cibyl.models.ci.base.build import Build
+from cibyl.models.ci.base.job import Job
+from cibyl.models.ci.base.system import System
+from cibyl.models.ci.base.test import Test
 from cibyl.outputs.cli.ci.system.common.builds import (get_duration_section,
                                                        get_status_section)
 from cibyl.outputs.cli.ci.system.common.models import (get_plugin_section,
@@ -34,7 +38,7 @@ class ColoredJobsSystemPrinter(ColoredBaseSystemPrinter):
     """
 
     @overrides
-    def print_system(self, system):
+    def print_system(self, system: System) -> str:
         printer = IndentedTextBuilder()
 
         # Begin with the text common to all systems
@@ -54,12 +58,10 @@ class ColoredJobsSystemPrinter(ColoredBaseSystemPrinter):
 
         return printer.build()
 
-    def print_job(self, job):
+    def print_job(self, job: Job) -> str:
         """
         :param job: The job.
-        :type job: :class:`cibyl.models.ci.base.job.Job`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         printer = IndentedTextBuilder()
 
@@ -88,12 +90,10 @@ class ColoredJobsSystemPrinter(ColoredBaseSystemPrinter):
 
         return printer.build()
 
-    def print_build(self, build):
+    def print_build(self, build: Build) -> str:
         """
         :param build: The build.
-        :type build: :class:`cibyl.models.ci.base.build.Build`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         printer = IndentedTextBuilder()
 
@@ -123,12 +123,10 @@ class ColoredJobsSystemPrinter(ColoredBaseSystemPrinter):
 
         return printer.build()
 
-    def print_test(self, test):
+    def print_test(self, test: Test) -> str:
         """
         :param test: The test.
-        :type test: :class:`cibyl.models.ci.base.test.Test`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         printer = IndentedTextBuilder()
 

--- a/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
@@ -15,10 +15,15 @@
 """
 import json
 from abc import ABC
+from typing import Union
 
 from overrides import overrides
 
 from cibyl.cli.query import QueryType
+from cibyl.models.ci.base.build import Build, Test
+from cibyl.models.ci.base.job import Job
+from cibyl.models.ci.base.stage import Stage
+from cibyl.models.ci.base.system import System
 from cibyl.outputs.cli.ci.system.impls.base.serialized import \
     SerializedBaseSystemPrinter
 
@@ -29,7 +34,7 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
     """
 
     @overrides
-    def print_system(self, system):
+    def print_system(self, system: System) -> str:
         # Build on top of the base answer
         result = self._load(super().print_system(system))
 
@@ -41,12 +46,10 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
 
         return self._dump(result)
 
-    def print_job(self, job):
+    def print_job(self, job: Job) -> str:
         """
         :param job: The job.
-        :type job: :class:`cibyl.models.ci.base.job.Job`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         result = {
             'name': job.name.value
@@ -63,12 +66,10 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
 
         return self._dump(result)
 
-    def print_build(self, build):
+    def print_build(self, build: Build) -> str:
         """
         :param build: The build.
-        :type build: :class:`cibyl.models.ci.base.build.Build`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         result = {
             'uuid': build.build_id.value,
@@ -86,12 +87,10 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
 
         return self._dump(result)
 
-    def print_test(self, test):
+    def print_test(self, test: Test) -> str:
         """
         :param test: The test.
-        :type test: :class:`cibyl.models.ci.base.test.Test`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         result = {
             'name': test.name.value,
@@ -102,12 +101,10 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
 
         return self._dump(result)
 
-    def print_stage(self, stage):
+    def print_stage(self, stage: Stage) -> str:
         """
         :param stage: The stage.
-        :type stage: :class:`cibyl.models.ci.base.stage.Stage`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         result = {
             'name': stage.name.value,
@@ -123,14 +120,13 @@ class JSONJobsSystemPrinter(SerializedJobsSystemPrinter):
     """
 
     def __init__(self,
-                 query=QueryType.NONE,
-                 verbosity=0,
-                 indentation=4):
+                 query: QueryType = QueryType.NONE,
+                 verbosity: int = 0,
+                 indentation: int = 4):
         """Constructor. See parent for more information.
 
         :param indentation: Number of spaces indenting each level of the
             JSON output.
-        :type indentation: int
         """
         super().__init__(
             load_function=self._from_json,
@@ -142,15 +138,14 @@ class JSONJobsSystemPrinter(SerializedJobsSystemPrinter):
         self._indentation = indentation
 
     @property
-    def indentation(self):
+    def indentation(self) -> int:
         """
         :return: Number of spaces preceding every level of the JSON output.
-        :rtype: int
         """
         return self._indentation
 
-    def _from_json(self, obj):
+    def _from_json(self, obj: Union[str, bytes, bytearray]) -> dict:
         return json.loads(obj)
 
-    def _to_json(self, obj):
+    def _to_json(self, obj: object) -> str:
         return json.dumps(obj, indent=self._indentation)

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -18,6 +18,12 @@ import logging
 from overrides import overrides
 
 from cibyl.cli.query import QueryType
+from cibyl.models.ci.base.build import Build
+from cibyl.models.ci.base.system import System
+from cibyl.models.ci.zuul.job import Job
+from cibyl.models.ci.zuul.pipeline import Pipeline
+from cibyl.models.ci.zuul.project import Project
+from cibyl.models.ci.zuul.tenant import Tenant
 from cibyl.outputs.cli.ci.system.common.builds import (get_duration_section,
                                                        get_status_section)
 from cibyl.outputs.cli.ci.system.common.models import (get_plugin_section,
@@ -43,7 +49,7 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
         relationship between elements more than their details.
         """
 
-        def print_project(self, project):
+        def print_project(self, project: Project) -> str:
             result = IndentedTextBuilder()
 
             result.add(self.palette.blue('Project: '), 0)
@@ -69,7 +75,7 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
 
             return result.build()
 
-        def print_pipeline(self, project, pipeline):
+        def print_pipeline(self, project: Project, pipeline: Pipeline) -> str:
             result = IndentedTextBuilder()
 
             result.add(self.palette.blue('Pipeline: '), 0)
@@ -91,7 +97,8 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
 
             return result.build()
 
-        def print_job(self, project, pipeline, job):
+        def print_job(self, project: Project, pipeline: Pipeline,
+                      job: Job) -> str:
             result = IndentedTextBuilder()
 
             result.add(self.palette.blue('Job: '), 0)
@@ -114,7 +121,8 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
 
             return result.build()
 
-        def print_build(self, project, pipeline, job, build):
+        def print_build(self, project: Project, pipeline: Pipeline, job: Job,
+                        build: Build) -> str:
             result = IndentedTextBuilder()
 
             result.add(self.palette.blue('Build: '), 1)
@@ -131,7 +139,7 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
         element.
         """
 
-        def print_job(self, job):
+        def print_job(self, job: Job) -> str:
             result = IndentedTextBuilder()
 
             result.add(self.palette.blue('Job: '), 0)
@@ -160,9 +168,8 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
 
             return result.build()
 
-        def print_variant(self, variant):
+        def print_variant(self, variant: Job.Variant) -> str:
             result = IndentedTextBuilder()
-
             result.add(self.palette.blue('Variant: '), 0)
 
             result.add(self.palette.blue('Description: '), 1)
@@ -186,9 +193,8 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
 
             return result.build()
 
-        def print_build(self, build):
+        def print_build(self, build: Build) -> str:
             result = IndentedTextBuilder()
-
             result.add(self.palette.blue('Build: '), 0)
             result[0].append(build.build_id.value)
 
@@ -210,7 +216,7 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
             return result.build()
 
     @overrides
-    def print_system(self, system):
+    def print_system(self, system: System) -> str:
         printer = IndentedTextBuilder()
 
         # Begin with the text common to all systems
@@ -245,16 +251,14 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
 
         return printer.build()
 
-    def print_tenant(self, tenant):
+    def print_tenant(self, tenant: Tenant) -> str:
         """
         :param tenant: The tenant.
-        :type tenant: :class:`cibyl.models.ci.zuul.tenant.Tenant`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
 
-        def print_projects():
-            def create_printer():
+        def print_projects() -> None:
+            def create_printer() -> ColoredZuulSystemPrinter.ProjectCascade:
                 return ColoredZuulSystemPrinter.ProjectCascade(
                     self.query, self.verbosity, self.palette
                 )
@@ -278,8 +282,8 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
                 msg = 'No projects found in query.'
                 result.add(self.palette.red(msg), 2)
 
-        def print_jobs():
-            def create_printer():
+        def print_jobs() -> None:
+            def create_printer() -> ColoredZuulSystemPrinter.JobCascade:
                 return ColoredZuulSystemPrinter.JobCascade(
                     self.query, self.verbosity, self.palette
                 )

--- a/cibyl/outputs/cli/ci/system/printer.py
+++ b/cibyl/outputs/cli/ci/system/printer.py
@@ -15,6 +15,7 @@
 """
 from abc import ABC, abstractmethod
 
+from cibyl.models.ci.base.system import System
 from cibyl.outputs.cli.printer import Printer
 
 
@@ -23,11 +24,9 @@ class CISystemPrinter(Printer, ABC):
     """
 
     @abstractmethod
-    def print_system(self, system):
+    def print_system(self, system: System) -> str:
         """
         :param system: The system.
-        :type system: :class:`cibyl.models.ci.base.system.System`
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         raise NotImplementedError

--- a/cibyl/outputs/cli/ci/system/utils/sorting/builds.py
+++ b/cibyl/outputs/cli/ci/system/utils/sorting/builds.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.models.ci.base.build import Build
 from cibyl.utils.sorting import Comparator
 
 
@@ -20,12 +21,8 @@ class SortBuildsByUUID(Comparator):
     """Sorts builds in alphabetical order based on their uuid.
     """
 
-    def compare(self, left, right):
-        """See parent function for more information.
-
-        :type left: :class:`cibyl.models.ci.base.build.Build`
-        :type right: :class:`cibyl.models.ci.base.build.Build`
-        """
+    def compare(self, left: Build, right: Build) -> int:
+        """See parent function for more information."""
         uuid_left = left.build_id.value.lower()
         uuid_right = right.build_id.value.lower()
 

--- a/cibyl/outputs/cli/ci/system/utils/sorting/jobs.py
+++ b/cibyl/outputs/cli/ci/system/utils/sorting/jobs.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from cibyl.models.ci.base.job import Job
 from cibyl.utils.sorting import Comparator
 
 
@@ -20,12 +21,8 @@ class SortJobsByName(Comparator):
     """Sorts jobs in alphabetical order based on their name.
     """
 
-    def compare(self, left, right):
-        """See parent function for more information.
-
-        :type left: :class:`cibyl.models.ci.base.job.Job`
-        :type right: :class:`cibyl.models.ci.base.job.Job`
-        """
+    def compare(self, left: Job, right: Job) -> int:
+        """See parent function for more information."""
         name_left = left.name.value.lower()
         name_right = right.name.value.lower()
 

--- a/cibyl/outputs/cli/printer.py
+++ b/cibyl/outputs/cli/printer.py
@@ -16,7 +16,7 @@
 from abc import ABC
 
 from cibyl.cli.query import QueryType
-from cibyl.utils.colors import DefaultPalette
+from cibyl.utils.colors import ColorPalette, DefaultPalette
 
 
 class Printer(ABC):
@@ -24,25 +24,22 @@ class Printer(ABC):
     """
 
     def __init__(self,
-                 query=QueryType.NONE,
-                 verbosity=0):
+                 query: QueryType = QueryType.NONE,
+                 verbosity: int = 0):
         """Constructor.
 
         :param query: Type of query requested by the user. Determines how
             far down the model hierarchy the printer will go.
-        :type query: :class:`QueryType`
         :param verbosity: How verbose the output is to be expected. The
             bigger this is, the more is printed for each hierarchy level.
-        :type verbosity: int
         """
         self._query = query
         self._verbosity = verbosity
 
     @property
-    def query(self):
+    def query(self) -> QueryType:
         """
         :return: Query type requested by user.
-        :rtype: :class:`QueryType`
         """
         return self._query
 
@@ -60,24 +57,22 @@ class ColoredPrinter(Printer, ABC):
     """
 
     def __init__(self,
-                 query=QueryType.NONE,
-                 verbosity=0,
-                 palette=DefaultPalette()):
+                 query: QueryType = QueryType.NONE,
+                 verbosity: int = 0,
+                 palette: ColorPalette = DefaultPalette()):
         """Constructor.
 
         See parents for more information.
 
         :param palette: Palette of colors to be used.
-        :type palette: :class:`cibyl.utils.colors.ColorPalette`
         """
         super().__init__(query, verbosity)
 
         self._palette = palette
 
     @property
-    def palette(self):
+    def palette(self) -> ColorPalette:
         """
         :return: The palette currently in use.
-        :rtype: :class:`cibyl.utils.colors.ColorPalette`
         """
         return self._palette


### PR DESCRIPTION
Add type hints to functions according to PEP-484 [1] in the
outputs subpackage.

This patch also removes now redundant type hints from
docstrings in the modified files.

[1] https://peps.python.org/pep-0484/