### PR TITLE
Returning TLS-Everywhere as part of the deployment summary.

### DIFF
--- a/tests/tripleo/e2e/test_insights.py
+++ b/tests/tripleo/e2e/test_insights.py
@@ -30,6 +30,16 @@ class TestInsights(TestCase):
         # Enable output into console
         enable_logging(logging.DEBUG, LogOutput.ToStream, stream=sys.stdout)
 
+    def test_tls_everywhere(self):
+        """Checks that the state of TLS-Everywhere is extracted from a
+        scenario file.
+        """
+        outline = Outline(featureset='config/general_config/featureset039.yml')
+        lookup = DeploymentLookUp()
+        result = lookup.run(outline)
+
+        self.assertEqual('On', result.tls_everywhere)
+
     def test_cinder_backend(self):
         """Checks that the cinder backend is extracted from a scenario
         file.

--- a/tests/tripleo/unit/insights/test_deployment.py
+++ b/tests/tripleo/unit/insights/test_deployment.py
@@ -267,6 +267,70 @@ class TestFeatureSetInterpreter(TestCase):
 
         self.assertEqual(False, featureset.is_ipv6())
 
+    def test_is_tls_everywhere_enabled(self):
+        """Checks whether it is able to tell if TLS everywhere is enabled.
+        """
+        keys = FeatureSetInterpreter.KEYS
+
+        data = {}
+
+        schema = Mock()
+
+        validator = Mock()
+        validator.is_valid = Mock()
+        validator.is_valid.return_value = True
+
+        factory = Mock()
+        factory.from_file = Mock()
+        factory.from_file.return_value = validator
+
+        featureset = FeatureSetInterpreter(
+            data,
+            schema=schema,
+            validator_factory=factory
+        )
+
+        self.assertFalse(featureset.is_tls_everywhere_enabled())
+
+        data[keys.tls_everywhere] = False
+
+        self.assertFalse(featureset.is_tls_everywhere_enabled())
+
+        data[keys.tls_everywhere] = True
+
+        self.assertTrue(featureset.is_tls_everywhere_enabled())
+
+    def test_overrides_tls_everywhere_enabled(self):
+        """Checks that the value of the 'overrides' dictionary is chosen
+        before the one from the file.
+        """
+        keys = FeatureSetInterpreter.KEYS
+
+        tls_everywhere = False
+        override = True
+
+        data = {keys.tls_everywhere: tls_everywhere}
+        overrides = {keys.tls_everywhere: override}
+
+        schema = Mock()
+
+        validator = Mock()
+        validator.is_valid = Mock()
+        validator.is_valid.return_value = True
+
+        factory = Mock()
+        factory.from_file = Mock()
+        factory.from_file.return_value = validator
+
+        featureset = FeatureSetInterpreter(
+            data,
+            schema=schema,
+            overrides=overrides,
+            validator_factory=factory
+        )
+
+        self.assertTrue(featureset.is_tls_everywhere_enabled())
+
     def test_get_scenario(self):
         """Checks that it is possible to get the scenario from the
         featureset file.

--- a/tripleo/insights/deployment.py
+++ b/tripleo/insights/deployment.py
@@ -134,6 +134,8 @@ class FeatureSetInterpreter(FileInterpreter):
         """Indicates IP version of deployment."""
         scenario: str = 'composable_scenario'
         """Indicates the scenario of this deployment."""
+        tls_everywhere: str = 'enable_tls_everywhere'
+        """Indicates whether TLS everywhere is enabled."""
 
     KEYS = Keys()
     """Knowledge that this has about the featureset file's contents."""
@@ -153,6 +155,19 @@ class FeatureSetInterpreter(FileInterpreter):
             under IPv4. If the field is not present, then IPv4 is assumed.
         """
         key = self.KEYS.ipv6
+
+        for provider in (self.overrides, self.data):
+            if key in provider:
+                return provider[key]
+
+        return False
+
+    def is_tls_everywhere_enabled(self) -> bool:
+        """
+        :return: True if the deployment uses tls everywhere, False if it does
+            not. If the field is not present, then False is returned too.
+        """
+        key = self.KEYS.tls_everywhere
 
         for provider in (self.overrides, self.data):
             if key in provider:

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -106,3 +106,5 @@ class DeploymentSummary:
     """Backend supporting the cinder component."""
     neutron_backend: Optional[str] = None
     """Backend supporting the neutron component."""
+    tls_everywhere: Optional[str] = None
+    """State (On / Off) of TLS-Everywhere on the deployment."""

--- a/tripleo/insights/lookup.py
+++ b/tripleo/insights/lookup.py
@@ -184,10 +184,18 @@ class DeploymentLookUp:
 
         result = DeploymentSummary()
 
-        result.infra_type = environment.get_intra_type()
-        result.ip_version = '6' if featureset.is_ipv6() else '4'
-        result.topology = nodes.get_topology()
         result.release = release.get_release_name()
+        result.infra_type = environment.get_intra_type()
+        result.topology = nodes.get_topology()
+
+        result.ip_version = '4'
+        result.tls_everywhere = 'Off'
+
+        if featureset.is_ipv6():
+            result.ip_version = '6'
+
+        if featureset.is_tls_everywhere_enabled():
+            result.tls_everywhere = 'On'
 
         # Take care of the scenario file too
         if featureset.get_scenario():


### PR DESCRIPTION
Adding a new entry to the TripleO library, 'tls_everywhere', which tells the state of the feature on the deployment.