### PR TITLE
Adjust speed_index for Jenkins and Elasticsearch

### DIFF
--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -250,7 +250,9 @@ class Jenkins(SourceExtension):
                 return True
         return False
 
-    @speed_index({'base': 2})
+    @speed_index({'base': 2, 'release': 3, 'infra_type': 3, 'spec': 3,
+                  'ironic_inspector': 3, 'controllers': 3, 'computes': 3,
+                  'ml2_driver': 3, 'containers': 3, 'services': 3})
     def get_deployment(self, **kwargs) -> AttributeDictValue:
         """Get deployment information for jobs from jenkins server.
 


### PR DESCRIPTION
In the initial release of Cibyl the Jenkins source supports querying
for more information. Because of that, we want Jenkins to be the
preferred source over Elasticsearch.

This change modifies the speed_index for both Jenkins and Elasticsearch
source so that Jenkins is always preferred over Elasticsearch (except
when --overcloud-templates is used).