### PR TITLE
Reorganizing keys on the nodes interpreter.

### DIFF
--- a/tests/tripleo/intr/insights/test_deployment.py
+++ b/tests/tripleo/intr/insights/test_deployment.py
@@ -62,7 +62,7 @@ class TestNodesInterpreter(TestCase):
         not follow the schema.
         """
         data = {
-            NodesInterpreter.KEYS.topology: False  # Must be an object
+            NodesInterpreter.KEYS.root.topology: False  # Must be an object
         }
 
         with self.assertRaises(IllegibleData):

--- a/tests/tripleo/unit/insights/test_deployment.py
+++ b/tests/tripleo/unit/insights/test_deployment.py
@@ -457,7 +457,7 @@ class TestNodesInterpreter(TestCase):
         keys = NodesInterpreter.KEYS
 
         data = {
-            keys.topology: {
+            keys.root.topology: {
                 'Controller': {
                     'scale': 1
                 },
@@ -503,7 +503,7 @@ class TestNodesInterpreter(TestCase):
 
         data = {}
         overrides = {
-            keys.topology: {
+            keys.root.topology: {
                 'Controller': {
                     'scale': 1
                 },


### PR DESCRIPTION
Seeing that I am going to need data from two completely different sections of the same file, I have taken the time to reorganize the keys of the section I am already using so that it is easier to add the other one later on.