### PR TITLE
Returning nodes as part of the deployment summary.

### DIFF
--- a/tests/tripleo/intr/insights/test_interpreters.py
+++ b/tests/tripleo/intr/insights/test_interpreters.py
@@ -63,7 +63,7 @@ class TestNodesInterpreter(TestCase):
         not follow the schema.
         """
         data = {
-            NodesInterpreter.Keys().topology: False  # Must be an object
+            NodesInterpreter.Keys().root.topology: False  # Must be an object
         }
 
         with self.assertRaises(IllegibleData):

--- a/tests/tripleo/unit/insights/test_interpreters.py
+++ b/tests/tripleo/unit/insights/test_interpreters.py
@@ -459,7 +459,7 @@ class TestNodesInterpreter(TestCase):
         keys = NodesInterpreter.Keys()
 
         data = {
-            keys.overcloud: [
+            keys.root.overcloud: [
                 {
                     'name': 'compute_0',
                     'flavor': 'compute'
@@ -532,7 +532,7 @@ class TestNodesInterpreter(TestCase):
 
         data = {}
         overrides = {
-            keys.overcloud: [
+            keys.root.overcloud: [
                 {
                     'name': 'compute_0',
                     'flavor': 'compute'

--- a/tests/tripleo/unit/insights/test_interpreters.py
+++ b/tests/tripleo/unit/insights/test_interpreters.py
@@ -459,17 +459,32 @@ class TestNodesInterpreter(TestCase):
         keys = NodesInterpreter.Keys()
 
         data = {
-            keys.topology: {
-                'Controller': {
-                    'scale': 1
+            keys.overcloud: [
+                {
+                    'name': 'compute_0',
+                    'flavor': 'compute'
                 },
-                'Compute': {
-                    'scale': 3
+                {
+                    'name': 'compute_1',
+                    'flavor': 'compute'
                 },
-                'CephStorage': {
-                    'scale': 2
+                {
+                    'name': 'compute_2',
+                    'flavor': 'compute'
+                },
+                {
+                    'name': 'control_0',
+                    'flavor': 'control'
+                },
+                {
+                    'name': 'ceph_0',
+                    'flavor': 'ceph'
+                },
+                {
+                    'name': 'ceph_1',
+                    'flavor': 'ceph'
                 }
-            }
+            ]
         }
 
         schema = Mock()
@@ -494,16 +509,16 @@ class TestNodesInterpreter(TestCase):
             Topology(
                 nodes=Topology.Nodes(
                     compute=(
-                        Node('N/A'),
-                        Node('N/A'),
-                        Node('N/A')
+                        Node('compute_0'),
+                        Node('compute_1'),
+                        Node('compute_2')
                     ),
                     controller=(
-                        Node('N/A'),
+                        Node('control_0'),
                     ),
                     ceph=(
-                        Node('N/A'),
-                        Node('N/A'),
+                        Node('ceph_0'),
+                        Node('ceph_1'),
                     )
                 )
             ),
@@ -517,17 +532,32 @@ class TestNodesInterpreter(TestCase):
 
         data = {}
         overrides = {
-            keys.topology: {
-                'Controller': {
-                    'scale': 1
+            keys.overcloud: [
+                {
+                    'name': 'compute_0',
+                    'flavor': 'compute'
                 },
-                'Compute': {
-                    'scale': 3
+                {
+                    'name': 'compute_1',
+                    'flavor': 'compute'
                 },
-                'CephStorage': {
-                    'scale': 2
+                {
+                    'name': 'compute_2',
+                    'flavor': 'compute'
+                },
+                {
+                    'name': 'control_0',
+                    'flavor': 'control'
+                },
+                {
+                    'name': 'ceph_0',
+                    'flavor': 'ceph'
+                },
+                {
+                    'name': 'ceph_1',
+                    'flavor': 'ceph'
                 }
-            }
+            ]
         }
 
         schema = Mock()
@@ -553,16 +583,16 @@ class TestNodesInterpreter(TestCase):
             Topology(
                 nodes=Topology.Nodes(
                     compute=(
-                        Node('N/A'),
-                        Node('N/A'),
-                        Node('N/A')
+                        Node('compute_0'),
+                        Node('compute_1'),
+                        Node('compute_2')
                     ),
                     controller=(
-                        Node('N/A'),
+                        Node('control_0'),
                     ),
                     ceph=(
-                        Node('N/A'),
-                        Node('N/A'),
+                        Node('ceph_0'),
+                        Node('ceph_1'),
                     )
                 )
             ),

--- a/tests/tripleo/unit/insights/test_topology.py
+++ b/tests/tripleo/unit/insights/test_topology.py
@@ -15,7 +15,7 @@
 """
 from unittest import TestCase
 
-from tripleo.insights.topology import Topology, Node
+from tripleo.insights.topology import Node, Topology
 
 
 class TestTopology(TestCase):

--- a/tripleo/_data/schemas/nodes.json
+++ b/tripleo/_data/schemas/nodes.json
@@ -3,6 +3,24 @@
   "$id": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "overcloud_nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "flavor"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "flavor": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "topology_map": {
       "type": "object",
       "properties": {

--- a/tripleo/insights/interpreters.py
+++ b/tripleo/insights/interpreters.py
@@ -15,7 +15,7 @@
 """
 from abc import ABC
 from enum import Enum
-from typing import Dict, NamedTuple, Optional, Sequence, Iterable
+from typing import Dict, Iterable, NamedTuple, Optional, Sequence
 
 from tripleo.insights.exceptions import IllegibleData
 from tripleo.insights.io import Topology

--- a/tripleo/insights/interpreters.py
+++ b/tripleo/insights/interpreters.py
@@ -14,7 +14,7 @@
 #    under the License.
 """
 from abc import ABC
-from typing import Dict, NamedTuple, Optional, Sequence
+from typing import Dict, NamedTuple, Optional, Sequence, Iterable
 
 from tripleo.insights.exceptions import IllegibleData
 from tripleo.insights.io import Topology
@@ -255,28 +255,15 @@ class NodesInterpreter(FileInterpreter):
 
         return None
 
-    def _new_topology_from(self, topology_map: dict) -> Topology:
-        """
-        :param topology_map: Take a look at the 'topology_map' level on the
-            'Keys' dictionary for the set of keys expected on this dictionary.
-        """
+    def _new_topology_from(self, overcloud_nodes: Iterable[dict]) -> Topology:
         keys = self.keys
 
         controller_nodes = []
         compute_nodes = []
         ceph_nodes = []
 
-        if keys.controller in topology_map:
-            for _ in range(topology_map[keys.controller][keys.scale]):
-                controller_nodes.append(Node('N/A'))
-
-        if keys.compute in topology_map:
-            for _ in range(topology_map[keys.compute][keys.scale]):
-                compute_nodes.append(Node('N/A'))
-
-        if keys.ceph in topology_map:
-            for _ in range(topology_map[keys.ceph][keys.scale]):
-                ceph_nodes.append(Node('N/A'))
+        for node in overcloud_nodes:
+            pass
 
         return Topology(
             nodes=Topology.Nodes(

--- a/tripleo/insights/interpreters.py
+++ b/tripleo/insights/interpreters.py
@@ -201,8 +201,16 @@ class NodesInterpreter(FileInterpreter):
         """Defines the fields of interest contained by a nodes file.
         """
         # Root level
+        overcloud: str = 'overcloud_nodes'
+        """Section giving an outline of the to be deployed cloud."""
         topology: str = 'topology_map'
-        """Field that defines the deployment's topology."""
+        """Section providing configuration on the to be deployed cloud."""
+
+        # 'overcloud_nodes' level
+        name: str = 'name'
+        """Name of the node."""
+        flavor: str = 'flavor'
+        """Type of the node."""
 
         # 'topology_map' level
         compute: str = 'Compute'
@@ -214,7 +222,7 @@ class NodesInterpreter(FileInterpreter):
         cell: str = 'CellController'
         """Contains data on cell nodes."""
 
-        # 'node' level
+        # 'topology_map' node level
         scale: str = 'scale'
         """Number of nodes of a certain type."""
 

--- a/tripleo/insights/interpreters.py
+++ b/tripleo/insights/interpreters.py
@@ -103,7 +103,7 @@ class EnvironmentInterpreter(FileInterpreter):
         super().__init__(data, schema, overrides, validator_factory)
 
     @property
-    def keys(self):
+    def keys(self) -> 'EnvironmentInterpreter.Keys':
         """
         :return: Knowledge that this has about the environment file's contents.
         """
@@ -147,7 +147,7 @@ class FeatureSetInterpreter(FileInterpreter):
         super().__init__(data, schema, overrides, validator_factory)
 
     @property
-    def keys(self):
+    def keys(self) -> 'FeatureSetInterpreter.Keys':
         """
         :return: Knowledge that this has about the featureset file's contents.
         """
@@ -228,7 +228,7 @@ class NodesInterpreter(FileInterpreter):
         super().__init__(data, schema, overrides, validator_factory)
 
     @property
-    def keys(self):
+    def keys(self) -> 'NodesInterpreter.Keys':
         """
         :return: Knowledge that this has about the nodes file's contents.
         """
@@ -299,7 +299,7 @@ class ReleaseInterpreter(FileInterpreter):
         super().__init__(data, schema, overrides, validator_factory)
 
     @property
-    def keys(self):
+    def keys(self) -> 'ReleaseInterpreter.Keys':
         """
         :return: Knowledge that this has about the release file's contents.
         """
@@ -428,21 +428,21 @@ class ScenarioInterpreter(FileInterpreter):
         super().__init__(data, schema, overrides, validator_factory)
 
     @property
-    def keys(self):
+    def keys(self) -> 'ScenarioInterpreter.Keys':
         """
         :return: Knowledge this has on the scenario file.
         """
         return self.Keys()
 
     @property
-    def mappings(self):
+    def mappings(self) -> 'ScenarioInterpreter.Mappings':
         """
         :return: Output for each of the keys.
         """
         return self.Mappings(self.keys)
 
     @property
-    def defaults(self):
+    def defaults(self) -> 'ScenarioInterpreter.Defaults':
         """
         :return: Values returned by the interpreter when wanted data
             is not present.

--- a/tripleo/insights/topology.py
+++ b/tripleo/insights/topology.py
@@ -13,7 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from typing import NamedTuple, Iterable
+from typing import Iterable, NamedTuple
 
 
 class Node(NamedTuple):


### PR DESCRIPTION
On this PR:
- Extracting topology from 'overcloud_nodes' section of the nodes file. Through this change I am now able to list the names of the deployed node, just as '--nodes' requests.