### PR TITLE
Enable the --nodes argument

### DIFF
--- a/cibyl/plugins/openstack/deployment.py
+++ b/cibyl/plugins/openstack/deployment.py
@@ -53,7 +53,7 @@ class Deployment(Model):
             'attr_type': Node,
             'attribute_value_class': AttributeDictValue,
             'arguments': [Argument(name='--nodes', arg_type=str,
-                                   nargs='*',
+                                   func='get_deployment', nargs='*',
                                    description="Nodes on the deployment"),
                           Argument(name='--controllers', arg_type=str,
                                    func='get_deployment', nargs='*',

--- a/cibyl/plugins/openstack/node.py
+++ b/cibyl/plugins/openstack/node.py
@@ -33,8 +33,7 @@ class Node(Model):
     API = {
         'name': {
             'attr_type': str,
-            'arguments': [Argument(name='--node-name', arg_type=str,
-                                   description="Node name")]
+            'arguments': []
         },
         'role': {
             'attr_type': str,

--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -89,7 +89,7 @@ Arguments Matrix
      - |:black_square_button:|
      - |:black_square_button:|
    * - --infra-type
-     - | The infrstructure on which
+     - | The infrastructure on which
        | OS is deployed (e.g. ovb,
        | baremetal, virthost)
      - |:ballot_box_with_check:|
@@ -105,8 +105,15 @@ Arguments Matrix
      - |:ballot_box_with_check:|
      - |:black_square_button:|
      - |:black_square_button:|
+   * - --nodes
+     - | List of nodes on the topology.
+     - |:ballot_box_with_check:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
+     - |:black_square_button:|
    * - --controllers
-     - | Number of controlllers
+     - | Number of controllers
        | (Can be also range: ">=3")
      - |:ballot_box_with_check:|
      - |:black_square_button:|


### PR DESCRIPTION
Up until this point, the --nodes argument was defined on Cibyl, but it did nothing as we did not have a meaning for it yet.  Now we do, the idea of this argument is for it to print the list of nodes present on a deployment's topology. On this PR I am routing the argument to 'get_deployment' so that that can be done.

I have also taken the liberty to remove '--node-name', which was redundant.