### PR TITLE
Fix 'No query performed' error message for Zuul system

### DIFF
--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -229,17 +229,16 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
         # Continue with text specific for this system type
         if self.query >= QueryType.TENANTS:
             if hasattr(system, 'tenants'):
-                if system.tenants.value:
+                if not system.is_queried():
+                    msg = 'No query performed.'
+                    printer.add(self.palette.blue(msg), 1)
+                elif system.tenants.value:
                     for tenant in system.tenants.values():
                         printer.add(self.print_tenant(tenant), 1)
 
-                    if system.is_queried():
-                        header = 'Total tenants found in query: '
-                        printer.add(self.palette.blue(header), 1)
-                        printer[-1].append(len(system.tenants))
-                    else:
-                        msg = 'No query performed.'
-                        printer.add(self.palette.blue(msg), 1)
+                    header = 'Total tenants found in query: '
+                    printer.add(self.palette.blue(header), 1)
+                    printer[-1].append(len(system.tenants))
                 else:
                     msg = 'No tenants found in query.'
                     printer.add(self.palette.red(msg), 1)


### PR DESCRIPTION
Currently, the ZuulD source does not implement the get_deployment()
function. Even though the get_deployment() function is not implemented
for ZuulD source the error message that is displayed for 'cibyl
--spec ABC' is 'No tenants found in query'.

More accurate error message is 'No query performed' as the ZuulD source
is not even queried.