### PR TITLE
Adding support for '--nodes' on Zuul-CI source

### DIFF
--- a/cibyl/plugins/openstack/node.py
+++ b/cibyl/plugins/openstack/node.py
@@ -28,6 +28,8 @@ from cibyl.plugins.openstack.package import Package
 class Node(Model):
     """
     This a model for your typical node used on Openstack deployment.
+
+    @DynamicAttrs: Contains attributes added on runtime.
     """
 
     API = {

--- a/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
@@ -43,7 +43,7 @@ class ArgumentReview:
     def is_nodes_requested(self, **kwargs: Any) -> bool:
         """
         :param kwargs: Arguments coming from the CLI.
-        :return: True is the user requested the nodes to be part of the
+        :return: True if the user requested the nodes to be part of the
             deployment, False if not.
         """
         return any(arg in kwargs for arg in ('spec', 'nodes'))

--- a/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
@@ -40,6 +40,9 @@ class ArgumentReview:
         """
         return any(arg in kwargs for arg in ('spec', 'infra_type'))
 
+    def is_nodes_requested(self, **kwargs: Any) -> bool:
+        return any(arg in kwargs for arg in ('spec', 'nodes'))
+
     def is_topology_requested(self, **kwargs: Any) -> bool:
         """
         :param kwargs: Arguments coming from the CLI.

--- a/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
@@ -41,6 +41,11 @@ class ArgumentReview:
         return any(arg in kwargs for arg in ('spec', 'infra_type'))
 
     def is_nodes_requested(self, **kwargs: Any) -> bool:
+        """
+        :param kwargs: Arguments coming from the CLI.
+        :return: True is the user requested the nodes to be part of the
+            deployment, False if not.
+        """
         return any(arg in kwargs for arg in ('spec', 'nodes'))
 
     def is_topology_requested(self, **kwargs: Any) -> bool:

--- a/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
@@ -14,7 +14,7 @@
 #    under the License.
 """
 import functools
-from typing import Callable, Iterable, Dict
+from typing import Callable, Dict, Iterable
 
 from cibyl.cli.argument import Argument
 from cibyl.models.attribute import AttributeValue

--- a/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
@@ -53,9 +53,6 @@ class DeploymentFiltering:
 
         :param kwargs: The command line arguments.
         """
-        self._add_str_filters(**kwargs)
-
-    def _add_str_filters(self, **kwargs):
         deployment_args = (
             'release',
             'infra_type',
@@ -63,7 +60,7 @@ class DeploymentFiltering:
         )
 
         for arg in deployment_args:
-            self._add_str_filter(
+            self._handle_arg_filter(
                 arg,
                 lambda dpl: dpl,
                 **kwargs
@@ -75,7 +72,7 @@ class DeploymentFiltering:
         )
 
         for arg in network_args:
-            self._add_str_filter(
+            self._handle_arg_filter(
                 arg,
                 lambda dpl: dpl.network.value,
                 **kwargs
@@ -86,13 +83,13 @@ class DeploymentFiltering:
         )
 
         for arg in storage_args:
-            self._add_str_filter(
+            self._handle_arg_filter(
                 arg,
                 lambda dpl: dpl.storage.value,
                 **kwargs
             )
 
-    def _add_str_filter(
+    def _handle_arg_filter(
         self,
         arg: str,
         attr: Callable[[Deployment], Model],

--- a/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
@@ -23,11 +23,14 @@ from cibyl.plugins.openstack import Deployment
 from cibyl.utils.filtering import matches_regex
 
 Arguments = Dict[str, Argument]
+"""Structure where the input arguments are stored in."""
 
 Pattern = str
+"""Regex pattern to filter by."""
 Check = Callable[[Deployment, Pattern], bool]
+"""Test that a filter performs."""
 Filter = Callable[[Deployment], bool]
-"""Type of the filters stored in this class."""
+"""Type of filters stored in this class."""
 
 
 class DeploymentFiltering:
@@ -49,6 +52,9 @@ class DeploymentFiltering:
 
     @property
     def filters(self) -> Iterable[Filter]:
+        """
+        :return: Collection of filters hold by this.
+        """
         return self._filters
 
     def add_filters_from(self, **kwargs):
@@ -69,7 +75,7 @@ class DeploymentFiltering:
         )
 
         for arg in deployment_args:
-            self._handle_filter_for_str_arg(
+            self._handle_filter_for_simple_arg(
                 arg,
                 kwargs,
                 lambda dpl: dpl
@@ -81,7 +87,7 @@ class DeploymentFiltering:
         )
 
         for arg in network_args:
-            self._handle_filter_for_str_arg(
+            self._handle_filter_for_simple_arg(
                 arg,
                 kwargs,
                 lambda dpl: dpl.network.value
@@ -92,7 +98,7 @@ class DeploymentFiltering:
         )
 
         for arg in storage_args:
-            self._handle_filter_for_str_arg(
+            self._handle_filter_for_simple_arg(
                 arg,
                 kwargs,
                 lambda dpl: dpl.storage.value
@@ -111,14 +117,14 @@ class DeploymentFiltering:
                 lambda mdl: mdl.name
             )
 
-    def _handle_filter_for_str_arg(
+    def _handle_filter_for_simple_arg(
         self,
         arg: str,
         args: Arguments,
         get_model: Callable[[Deployment], Model]
     ):
         for pattern in self._get_patterns(arg, args):
-            self._add_filter_for_str_arg(arg, pattern, get_model)
+            self._add_filter_for_simple_arg(arg, pattern, get_model)
 
     def _handle_filter_for_dict_arg(
         self,
@@ -130,7 +136,7 @@ class DeploymentFiltering:
         for pattern in self._get_patterns(arg, args):
             self._add_filter_for_dict_arg(arg, pattern, get_model, get_attr)
 
-    def _add_filter_for_str_arg(
+    def _add_filter_for_simple_arg(
         self,
         arg: str,
         pattern: Pattern,

--- a/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
@@ -53,6 +53,9 @@ class DeploymentFiltering:
 
         :param kwargs: The command line arguments.
         """
+        self._add_str_filters(**kwargs)
+
+    def _add_str_filters(self, **kwargs):
         deployment_args = (
             'release',
             'infra_type',
@@ -60,7 +63,7 @@ class DeploymentFiltering:
         )
 
         for arg in deployment_args:
-            self._handle_arg_filter(
+            self._add_str_filter(
                 arg,
                 lambda dpl: dpl,
                 **kwargs
@@ -72,7 +75,7 @@ class DeploymentFiltering:
         )
 
         for arg in network_args:
-            self._handle_arg_filter(
+            self._add_str_filter(
                 arg,
                 lambda dpl: dpl.network.value,
                 **kwargs
@@ -83,13 +86,13 @@ class DeploymentFiltering:
         )
 
         for arg in storage_args:
-            self._handle_arg_filter(
+            self._add_str_filter(
                 arg,
                 lambda dpl: dpl.storage.value,
                 **kwargs
             )
 
-    def _handle_arg_filter(
+    def _add_str_filter(
         self,
         arg: str,
         attr: Callable[[Deployment], Model],

--- a/cibyl/plugins/openstack/sources/zuul/deployments/generator.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/generator.py
@@ -14,10 +14,11 @@
 #    under the License.
 """
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, Dict
 
 from cibyl.plugins.openstack import Deployment
 from cibyl.plugins.openstack.network import Network
+from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.sources.zuul.deployments.arguments import \
     ArgumentReview
 from cibyl.plugins.openstack.sources.zuul.deployments.summary import (
@@ -68,14 +69,15 @@ class DeploymentGenerator:
         return Deployment(
             release=self._get_release(summary, **kwargs),
             infra_type=self._get_infra_type(summary, **kwargs),
+            nodes=self._get_nodes(summary, **kwargs),
             topology=self._get_topology(summary, **kwargs),
+            network=Network(
+                ip_version=self._get_ip_version(summary, **kwargs),
+                network_backend=self._get_neutron_backend(summary, **kwargs),
+                tls_everywhere=self._get_tls_everywhere(summary, **kwargs)
+            ),
             storage=Storage(
                 cinder_backend=self._get_cinder_backend(summary, **kwargs)
-            ),
-            network=Network(
-                network_backend=self._get_neutron_backend(summary, **kwargs),
-                ip_version=self._get_ip_version(summary, **kwargs),
-                tls_everywhere=self._get_tls_everywhere(summary, **kwargs)
             )
         )
 
@@ -103,6 +105,28 @@ class DeploymentGenerator:
 
         return summary.get_infra_type()
 
+    def _get_nodes(
+        self,
+        summary: VariantDeployment,
+        **kwargs: Any
+    ) -> Optional[Dict[str, Node]]:
+        arguments = self.tools.argument_review
+
+        if not arguments.is_nodes_requested(**kwargs):
+            return None
+
+        nodes = summary.get_nodes()
+
+        if not nodes:
+            return None
+
+        result = {}
+
+        for node in nodes:
+            result[node.name.value] = node
+
+        return result
+
     def _get_topology(
         self,
         summary: VariantDeployment,
@@ -114,30 +138,6 @@ class DeploymentGenerator:
             return None
 
         return summary.get_topology()
-
-    def _get_cinder_backend(
-        self,
-        summary: VariantDeployment,
-        **kwargs: Any
-    ) -> Optional[str]:
-        arguments = self.tools.argument_review
-
-        if not arguments.is_cinder_backend_requested(**kwargs):
-            return None
-
-        return summary.get_cinder_backend()
-
-    def _get_neutron_backend(
-        self,
-        summary: VariantDeployment,
-        **kwargs: Any
-    ) -> Optional[str]:
-        arguments = self.tools.argument_review
-
-        if not arguments.is_network_backend_requested(**kwargs):
-            return None
-
-        return summary.get_neutron_backend()
 
     def _get_ip_version(
         self,
@@ -151,6 +151,18 @@ class DeploymentGenerator:
 
         return summary.get_ip_version()
 
+    def _get_neutron_backend(
+        self,
+        summary: VariantDeployment,
+        **kwargs: Any
+    ) -> Optional[str]:
+        arguments = self.tools.argument_review
+
+        if not arguments.is_network_backend_requested(**kwargs):
+            return None
+
+        return summary.get_neutron_backend()
+
     def _get_tls_everywhere(
         self,
         summary: VariantDeployment,
@@ -162,3 +174,15 @@ class DeploymentGenerator:
             return None
 
         return summary.get_tls_everywhere()
+
+    def _get_cinder_backend(
+        self,
+        summary: VariantDeployment,
+        **kwargs: Any
+    ) -> Optional[str]:
+        arguments = self.tools.argument_review
+
+        if not arguments.is_cinder_backend_requested(**kwargs):
+            return None
+
+        return summary.get_cinder_backend()

--- a/cibyl/plugins/openstack/sources/zuul/deployments/generator.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/generator.py
@@ -14,7 +14,7 @@
 #    under the License.
 """
 from dataclasses import dataclass
-from typing import Any, Optional, Dict
+from typing import Any, Dict, Optional
 
 from cibyl.plugins.openstack import Deployment
 from cibyl.plugins.openstack.network import Network

--- a/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
@@ -14,7 +14,7 @@
 #    under the License.
 """
 from dataclasses import dataclass
-from typing import Optional, Iterable
+from typing import Iterable, Optional
 
 from cached_property import cached_property
 

--- a/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
@@ -101,6 +101,10 @@ class VariantDeployment:
         return self._summary.infra_type
 
     def get_nodes(self) -> Optional[Iterable[Node]]:
+        """
+        :return: Collection of nodes that form the topology. 'None' is they
+            were not defined.
+        """
         topology = self._summary.topology
 
         if not topology:

--- a/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
@@ -108,8 +108,8 @@ class VariantDeployment:
 
         result = []
 
-        for nodes in topology.nodes:
-            for node in nodes:
+        for collection in topology.nodes:
+            for node in collection:
                 result.append(Node(name=node.name))
 
         return result

--- a/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
@@ -14,10 +14,11 @@
 #    under the License.
 """
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Iterable
 
 from cached_property import cached_property
 
+from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.sources.zuul.deployments.outlines import \
     OutlineCreator
 from cibyl.plugins.openstack.sources.zuul.variants import ReleaseSearch
@@ -99,26 +100,26 @@ class VariantDeployment:
         """
         return self._summary.infra_type
 
+    def get_nodes(self) -> Optional[Iterable[Node]]:
+        topology = self._summary.topology
+
+        if not topology:
+            return None
+
+        result = []
+
+        for nodes in topology.nodes:
+            for node in nodes:
+                result.append(Node(name=node.name))
+
+        return result
+
     def get_topology(self) -> Optional[str]:
         """
         :return: Description of the topology of the deployment. 'None' if it
             is not defined.
         """
         return str(self._summary.topology)
-
-    def get_cinder_backend(self) -> Optional[str]:
-        """
-        :return: Name of the backend that supports the Cinder component.
-            'None' if it is not defined.
-        """
-        return self._summary.cinder_backend
-
-    def get_neutron_backend(self) -> Optional[str]:
-        """
-        :return: Name of the backend that supports the Neutron component.
-            'None' if it is not defined.
-        """
-        return self._summary.neutron_backend
 
     def get_ip_version(self) -> Optional[str]:
         """
@@ -127,12 +128,26 @@ class VariantDeployment:
         """
         return self._summary.ip_version
 
+    def get_neutron_backend(self) -> Optional[str]:
+        """
+        :return: Name of the backend that supports the Neutron component.
+            'None' if it is not defined.
+        """
+        return self._summary.neutron_backend
+
     def get_tls_everywhere(self) -> Optional[str]:
         """
         :return: State of TLS-Everywhere on the deployment. 'None' if it is
             not defined.
         """
         return self._summary.tls_everywhere
+
+    def get_cinder_backend(self) -> Optional[str]:
+        """
+        :return: Name of the backend that supports the Cinder component.
+            'None' if it is not defined.
+        """
+        return self._summary.cinder_backend
 
 
 class VariantDeploymentFactory:

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_arguments.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_arguments.py
@@ -24,7 +24,7 @@ class TestArgumentReview(TestCase):
     """
 
     def test_is_release_requested(self):
-        """Checks the conditions requires for the release to be requested.
+        """Checks the conditions required for the release to be requested.
         """
         review = ArgumentReview()
 
@@ -34,7 +34,7 @@ class TestArgumentReview(TestCase):
         self.assertTrue(review.is_release_requested(**{'spec': None}))
 
     def test_is_infra_type_requested(self):
-        """Checks the conditions requires for the infra type to be requested.
+        """Checks the conditions required for the infra type to be requested.
         """
         review = ArgumentReview()
 
@@ -43,8 +43,19 @@ class TestArgumentReview(TestCase):
         self.assertTrue(review.is_infra_type_requested(**{'infra_type': None}))
         self.assertTrue(review.is_infra_type_requested(**{'spec': None}))
 
+    def test_is_nodes_requested(self):
+        """Checks the conditions required for the nodes list to be
+        requested.
+        """
+        review = ArgumentReview()
+
+        self.assertFalse(review.is_nodes_requested(**{}))
+
+        self.assertTrue(review.is_nodes_requested(**{'nodes': None}))
+        self.assertTrue(review.is_nodes_requested(**{'spec': None}))
+
     def test_is_topology_requested(self):
-        """Checks the conditions requires for the topology to be requested.
+        """Checks the conditions required for the topology to be requested.
         """
         review = ArgumentReview()
 
@@ -54,7 +65,7 @@ class TestArgumentReview(TestCase):
         self.assertTrue(review.is_topology_requested(**{'spec': None}))
 
     def test_is_cinder_backend_requested(self):
-        """Checks the conditions requires for the cinder backend to be
+        """Checks the conditions required for the cinder backend to be
         requested.
         """
         review = ArgumentReview()
@@ -72,7 +83,7 @@ class TestArgumentReview(TestCase):
         )
 
     def test_is_network_backend_requested(self):
-        """Checks the conditions requires for the network backend to be
+        """Checks the conditions required for the network backend to be
         requested.
         """
         review = ArgumentReview()
@@ -90,7 +101,7 @@ class TestArgumentReview(TestCase):
         )
 
     def test_is_ip_version_requested(self):
-        """Checks the conditions requires for the ip version to be requested.
+        """Checks the conditions required for the ip version to be requested.
         """
         review = ArgumentReview()
 

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_filtering.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_filtering.py
@@ -74,6 +74,39 @@ class TestDeploymentFiltering(TestCase):
         self.assertTrue(filtering.is_valid_deployment(deployment1))
         self.assertFalse(filtering.is_valid_deployment(deployment2))
 
+    def test_applies_nodes_filter(self):
+        """Checks that the filter for nodes is generated and applied.
+        """
+        node1 = 'ctrl_1'
+        node2 = 'ctrl_2'
+
+        model1 = Mock()
+        model1.name = Mock()
+        model1.name.value = node1
+
+        model2 = Mock()
+        model2.name = Mock()
+        model2.name.value = node2
+
+        nodes_arg = Mock()
+        nodes_arg.value = [node1]
+
+        kwargs = {
+            'nodes': nodes_arg
+        }
+
+        deployment1 = Mock()
+        deployment1.nodes.value = {node1: model1}
+
+        deployment2 = Mock()
+        deployment2.nodes.value = {node2: model2}
+
+        filtering = DeploymentFiltering()
+        filtering.add_filters_from(**kwargs)
+
+        self.assertTrue(filtering.is_valid_deployment(deployment1))
+        self.assertFalse(filtering.is_valid_deployment(deployment2))
+
     def test_applies_topology_filter(self):
         """Checks that the filter for topology is generated and applied.
         """

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_generator.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_generator.py
@@ -26,6 +26,7 @@ class TestDeploymentGenerator(TestCase):
 
     def setUp(self):
         self.arguments = Mock()
+        self.arguments.is_nodes_requested.return_value = False
 
         self.summary = Mock()
 
@@ -71,6 +72,23 @@ class TestDeploymentGenerator(TestCase):
 
         self.arguments.is_infra_type_requested \
             .assert_called_once_with(**kwargs)
+
+    def test_no_nodes(self):
+        """Checks that the nodes are ignored if it is not requested.
+        """
+        kwargs = {'key': 'val'}
+        variant = Mock()
+
+        self.arguments.is_nodes_requested = Mock()
+        self.arguments.is_nodes_requested.return_value = False
+
+        generator = DeploymentGenerator(tools=self.tools)
+
+        result = generator.generate_deployment_for(variant, **kwargs)
+
+        self.assertEqual({}, result.nodes.value)
+
+        self.arguments.is_nodes_requested.assert_called_once_with(**kwargs)
 
     def test_no_topology(self):
         """Checks that the topology is ignored if it is not requested.
@@ -168,6 +186,35 @@ class TestDeploymentGenerator(TestCase):
 
         self.summaries.create_for.assert_called_once_with(variant)
         self.summary.get_infra_type.assert_called_once()
+
+    def test_nodes(self):
+        """Checks that the nodes are returned if requested.
+        """
+        node = Mock()
+        node.name.value = 'node'
+
+        variant = Mock()
+
+        self.arguments.is_nodes_requested = Mock()
+        self.arguments.is_nodes_requested.return_value = True
+
+        self.summary.get_nodes = Mock()
+
+        generator = DeploymentGenerator(tools=self.tools)
+
+        self.summary.get_nodes.return_value = None
+
+        self.assertEqual(
+            {},
+            generator.generate_deployment_for(variant).nodes.value
+        )
+
+        self.summary.get_nodes.return_value = (node,)
+
+        self.assertEqual(
+            {node.name.value: node},
+            generator.generate_deployment_for(variant).nodes.value
+        )
 
     def test_topology(self):
         """Checks that the topology is returned if requested.

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_summary.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_summary.py
@@ -66,6 +66,29 @@ class TestVariantDeployment(TestCase):
 
         self.release.search.assert_called_with(self.variant)
 
+    def test_get_nodes(self):
+        """Checks that the nodes are returned as a list.
+        """
+        node = Mock()
+        node.name = 'node'
+
+        nodes = ((node,),)
+
+        topology = Mock()
+        topology.nodes = Mock()
+        topology.nodes.__iter__ = Mock()
+        topology.nodes.__iter__.return_value = iter(nodes)
+
+        self.summary.topology = topology
+
+        deployment = VariantDeployment(self.variant, tools=self.tools)
+
+        result = deployment.get_nodes()
+
+        self.assertIsNotNone(result)
+        self.assertEqual(1, len(result))
+        self.assertEqual(node.name, result[0].name.value)
+
     def test_get_topology(self):
         """Checks that the topology is returned as a string.
         """


### PR DESCRIPTION
- Displaying list of nodes under the --spec and --nodes arguments.
- Allowing filtering on --nodes argument.