### PR TITLE
Fix bug unable to find tripleo schemas outside repo

### DIFF
--- a/tests/tripleo/intr/insights/test_interpreters.py
+++ b/tests/tripleo/intr/insights/test_interpreters.py
@@ -16,12 +16,12 @@
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
-from tests.tripleo.intr.utils import cd_context_manager
 from tripleo.insights.exceptions import IllegibleData
 from tripleo.insights.interpreters import (EnvironmentInterpreter,
                                            FeatureSetInterpreter,
                                            NodesInterpreter,
                                            ReleaseInterpreter)
+from tripleo.utils.fs import cd_context_manager
 
 
 class TestEnvironmentInterpreter(TestCase):

--- a/tests/tripleo/intr/insights/test_interpreters.py
+++ b/tests/tripleo/intr/insights/test_interpreters.py
@@ -13,8 +13,10 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from tempfile import TemporaryDirectory
 from unittest import TestCase
 
+from tests.tripleo.intr.utils import cd_context_manager
 from tripleo.insights.exceptions import IllegibleData
 from tripleo.insights.interpreters import (EnvironmentInterpreter,
                                            FeatureSetInterpreter,
@@ -37,6 +39,16 @@ class TestEnvironmentInterpreter(TestCase):
         with self.assertRaises(IllegibleData):
             EnvironmentInterpreter(data)
 
+    def test_default_schema_path_outside_repo(self):
+        """Test that the default path for the schema file can be read properly
+        from a random directory, different from the cibyl source directory."""
+
+        data = {}
+
+        with TemporaryDirectory() as tempdir:
+            with cd_context_manager(tempdir):
+                EnvironmentInterpreter(data)
+
 
 class TestFeatureSetInterpreter(TestCase):
     """Tests for :class:`FeatureSetInterpreter`.
@@ -52,6 +64,16 @@ class TestFeatureSetInterpreter(TestCase):
 
         with self.assertRaises(IllegibleData):
             FeatureSetInterpreter(data)
+
+    def test_default_schema_path_outside_repo(self):
+        """Test that the default path for the schema file can be read properly
+        from a random directory, different from the cibyl source directory."""
+
+        data = {}
+
+        with TemporaryDirectory() as tempdir:
+            with cd_context_manager(tempdir):
+                FeatureSetInterpreter(data)
 
 
 class TestNodesInterpreter(TestCase):
@@ -69,6 +91,16 @@ class TestNodesInterpreter(TestCase):
         with self.assertRaises(IllegibleData):
             NodesInterpreter(data)
 
+    def test_default_schema_path_outside_repo(self):
+        """Test that the default path for the schema file can be read properly
+        from a random directory, different from the cibyl source directory."""
+
+        data = {}
+
+        with TemporaryDirectory() as tempdir:
+            with cd_context_manager(tempdir):
+                NodesInterpreter(data)
+
 
 class TestReleaseInterpreter(TestCase):
     """Tests for :class:`TestReleaseInterpreter`.
@@ -83,3 +115,13 @@ class TestReleaseInterpreter(TestCase):
 
         with self.assertRaises(IllegibleData):
             ReleaseInterpreter(data)
+
+    def test_default_schema_path_outside_repo(self):
+        """Test that the default path for the schema file can be read properly
+        from a random directory, different from the cibyl source directory."""
+
+        data = {}
+
+        with TemporaryDirectory() as tempdir:
+            with cd_context_manager(tempdir):
+                ReleaseInterpreter(data)

--- a/tests/tripleo/intr/utils/__init__.py
+++ b/tests/tripleo/intr/utils/__init__.py
@@ -13,3 +13,16 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+
+import os
+from contextlib import contextmanager
+
+
+@contextmanager
+def cd_context_manager(path):
+    old_dir = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old_dir)

--- a/tests/tripleo/intr/utils/__init__.py
+++ b/tests/tripleo/intr/utils/__init__.py
@@ -13,16 +13,3 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-
-import os
-from contextlib import contextmanager
-
-
-@contextmanager
-def cd_context_manager(path):
-    old_dir = os.getcwd()
-    os.chdir(path)
-    try:
-        yield
-    finally:
-        os.chdir(old_dir)

--- a/tripleo/insights/interpreters.py
+++ b/tripleo/insights/interpreters.py
@@ -17,12 +17,15 @@ from abc import ABC
 from enum import Enum
 from typing import Dict, Iterable, NamedTuple, Optional, Sequence
 
+from tripleo import __path__ as tripleo_package_path
 from tripleo.insights.exceptions import IllegibleData
 from tripleo.insights.io import Topology
 from tripleo.insights.topology import Node
 from tripleo.utils.fs import File
 from tripleo.utils.json import Draft7ValidatorFactory, JSONValidatorFactory
 from tripleo.utils.yaml import YAML
+
+TRIPLEO_PATH = tripleo_package_path[0]
 
 
 class FileInterpreter(ABC):
@@ -97,7 +100,7 @@ class EnvironmentInterpreter(FileInterpreter):
     def __init__(
         self,
         data: YAML,
-        schema: File = File('tripleo/_data/schemas/environment.json'),
+        schema: File = File(f'{TRIPLEO_PATH}/_data/schemas/environment.json'),
         overrides: Optional[Dict] = None,
         validator_factory: JSONValidatorFactory = Draft7ValidatorFactory()
     ):
@@ -141,7 +144,7 @@ class FeatureSetInterpreter(FileInterpreter):
     def __init__(
         self,
         data: YAML,
-        schema: File = File('tripleo/_data/schemas/featureset.json'),
+        schema: File = File(f'{TRIPLEO_PATH}/_data/schemas/featureset.json'),
         overrides: Optional[Dict] = None,
         validator_factory: JSONValidatorFactory = Draft7ValidatorFactory()
     ):
@@ -253,7 +256,7 @@ class NodesInterpreter(FileInterpreter):
     def __init__(
         self,
         data: YAML,
-        schema: File = File('tripleo/_data/schemas/nodes.json'),
+        schema: File = File(f'{TRIPLEO_PATH}/_data/schemas/nodes.json'),
         overrides: Optional[Dict] = None,
         validator_factory: JSONValidatorFactory = Draft7ValidatorFactory()
     ):
@@ -325,7 +328,7 @@ class ReleaseInterpreter(FileInterpreter):
     def __init__(
         self,
         data: YAML,
-        schema: File = File('tripleo/_data/schemas/release.json'),
+        schema: File = File(f'{TRIPLEO_PATH}/_data/schemas/release.json'),
         overrides: Optional[Dict] = None,
         validator_factory: JSONValidatorFactory = Draft7ValidatorFactory()
     ):
@@ -454,7 +457,7 @@ class ScenarioInterpreter(FileInterpreter):
     def __init__(
         self,
         data: YAML,
-        schema: File = File('tripleo/_data/schemas/scenario.json'),
+        schema: File = File(f'{TRIPLEO_PATH}/_data/schemas/scenario.json'),
         overrides: Optional[Dict] = None,
         validator_factory: JSONValidatorFactory = Draft7ValidatorFactory()
     ):

--- a/tripleo/insights/interpreters.py
+++ b/tripleo/insights/interpreters.py
@@ -21,11 +21,9 @@ from tripleo import __path__ as tripleo_package_path
 from tripleo.insights.exceptions import IllegibleData
 from tripleo.insights.io import Topology
 from tripleo.insights.topology import Node
-from tripleo.utils.fs import File
+from tripleo.utils.fs import File, cd_context_manager
 from tripleo.utils.json import Draft7ValidatorFactory, JSONValidatorFactory
 from tripleo.utils.yaml import YAML
-
-TRIPLEO_PATH = tripleo_package_path[0]
 
 
 class FileInterpreter(ABC):
@@ -63,10 +61,14 @@ class FileInterpreter(ABC):
         if overrides is None:
             overrides = {}
 
-        validator = validator_factory.from_file(schema)
+        with cd_context_manager(tripleo_package_path[0]):
+            # the default schemas path are stored in a path relative to the
+            # root of the tripleo package. In case the working directory is
+            # different, we want them to be reachable
+            validator = validator_factory.from_file(schema)
 
-        validate_data(data)
-        validate_data(overrides)
+            validate_data(data)
+            validate_data(overrides)
 
         self._data = data
         self._overrides = overrides
@@ -100,7 +102,7 @@ class EnvironmentInterpreter(FileInterpreter):
     def __init__(
         self,
         data: YAML,
-        schema: File = File(f'{TRIPLEO_PATH}/_data/schemas/environment.json'),
+        schema: File = File('_data/schemas/environment.json'),
         overrides: Optional[Dict] = None,
         validator_factory: JSONValidatorFactory = Draft7ValidatorFactory()
     ):
@@ -144,7 +146,7 @@ class FeatureSetInterpreter(FileInterpreter):
     def __init__(
         self,
         data: YAML,
-        schema: File = File(f'{TRIPLEO_PATH}/_data/schemas/featureset.json'),
+        schema: File = File('_data/schemas/featureset.json'),
         overrides: Optional[Dict] = None,
         validator_factory: JSONValidatorFactory = Draft7ValidatorFactory()
     ):
@@ -256,7 +258,7 @@ class NodesInterpreter(FileInterpreter):
     def __init__(
         self,
         data: YAML,
-        schema: File = File(f'{TRIPLEO_PATH}/_data/schemas/nodes.json'),
+        schema: File = File('_data/schemas/nodes.json'),
         overrides: Optional[Dict] = None,
         validator_factory: JSONValidatorFactory = Draft7ValidatorFactory()
     ):
@@ -328,7 +330,7 @@ class ReleaseInterpreter(FileInterpreter):
     def __init__(
         self,
         data: YAML,
-        schema: File = File(f'{TRIPLEO_PATH}/_data/schemas/release.json'),
+        schema: File = File('_data/schemas/release.json'),
         overrides: Optional[Dict] = None,
         validator_factory: JSONValidatorFactory = Draft7ValidatorFactory()
     ):
@@ -457,7 +459,7 @@ class ScenarioInterpreter(FileInterpreter):
     def __init__(
         self,
         data: YAML,
-        schema: File = File(f'{TRIPLEO_PATH}/_data/schemas/scenario.json'),
+        schema: File = File('_data/schemas/scenario.json'),
         overrides: Optional[Dict] = None,
         validator_factory: JSONValidatorFactory = Draft7ValidatorFactory()
     ):

--- a/tripleo/utils/fs.py
+++ b/tripleo/utils/fs.py
@@ -14,15 +14,28 @@
 #    under the License.
 """
 from abc import ABC, abstractmethod
-from os import PathLike
+from contextlib import contextmanager
+from os import PathLike, chdir, getcwd
 from pathlib import Path
-from typing import Union
+from typing import Generator, Union
 
 from overrides import overrides
 
 from tripleo.utils.paths import Preprocessor
 
 RawPath = Union[bytes, str, PathLike, Path]
+
+
+@contextmanager
+def cd_context_manager(path: RawPath) -> Generator:
+    """Simple context manager that changes the working directory and restores
+    the previous one on exit"""
+    old_dir = getcwd()
+    chdir(path)
+    try:
+        yield
+    finally:
+        chdir(old_dir)
 
 
 class FSPath(str, ABC):


### PR DESCRIPTION
When running a command like `cibyl --jobs periodic-tripleo-ci-centos-8-ovb-3ctlr_1comp-featureset035-internal-wallaby --pipeline check-rdo --project tripleo-downstream-trigger-nested-virt --ip-version` against a zuul source, we get an error:
```python
  File "/home/jgilaber/redhat/cibyl/tripleo/insights/interpreters.py", line 105, in __init__
    super().__init__(data, schema, overrides, validator_factory)
  File "/home/jgilaber/redhat/cibyl/tripleo/insights/interpreters.py", line 63, in __init__
    validator = validator_factory.from_file(schema)
  File "/home/jgilaber/redhat/cibyl/tripleo/utils/json.py", line 52, in from_file
    with open(file, 'r') as buffer:
FileNotFoundError: [Errno 2] No such file or directory: 'tripleo/_data/schemas/environment.json'
``
The default path to look for json schemas specified in the tripleo library 
was specified as a relative path, which if run from a random
location would not find the schema files. This was solved by changing
the paths and making them relative to the tripleo package path, so it
can be located from any working directory.

The PR includes also one integration test that reproduced the issue for each of the interpreter classes (Environment, FeatureSet, Nodes and ReleaseInterpreters).
