### PR TITLE
Return ML2 driver as part of the deployment summary on TripleO library

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
@@ -130,28 +130,28 @@ class VariantDeployment:
         :return: Number of the IP version used by the cloud. 'None' if it is
             not defined.
         """
-        return self._summary.ip_version
+        return self._summary.components.neutron.ip_version
 
     def get_neutron_backend(self) -> Optional[str]:
         """
         :return: Name of the backend that supports the Neutron component.
             'None' if it is not defined.
         """
-        return self._summary.neutron_backend
+        return self._summary.components.neutron.backend
 
     def get_tls_everywhere(self) -> Optional[str]:
         """
         :return: State of TLS-Everywhere on the deployment. 'None' if it is
             not defined.
         """
-        return self._summary.tls_everywhere
+        return self._summary.components.neutron.tls_everywhere
 
     def get_cinder_backend(self) -> Optional[str]:
         """
         :return: Name of the backend that supports the Cinder component.
             'None' if it is not defined.
         """
-        return self._summary.cinder_backend
+        return self._summary.components.cinder.backend
 
 
 class VariantDeploymentFactory:

--- a/tripleo/insights/interpreters.py
+++ b/tripleo/insights/interpreters.py
@@ -388,7 +388,9 @@ class ScenarioInterpreter(FileInterpreter):
             """Defines all the fields related to the neutron component.
             """
             backend: str = 'NeutronNetworkType'
-            """Keys pointing to the tenant network type."""
+            """Key pointing to the tenant network type."""
+            ml2_driver: str = 'NeutronMechanismDrivers'
+            """Key pointing to the mechanism drivers for the tenant network."""
 
         parameters: str = 'parameter_defaults'
         """Level at which the parameters are defined."""
@@ -450,6 +452,8 @@ class ScenarioInterpreter(FileInterpreter):
         """Default backend supporting cinder."""
         neutron_backend: str = 'geneve'
         """Default backend supporting neutron."""
+        ml2_driver: str = 'ovn'
+        """Default ml2 driver."""
 
     def __init__(
         self,
@@ -546,6 +550,21 @@ class ScenarioInterpreter(FileInterpreter):
 
         if key not in self._parameters:
             # The backend is not defined on the file
+            return default
+
+        return self._parameters[key]
+
+    def get_ml2_driver(self) -> str:
+        """
+        :return: Comma delimited list with the names of the ml2 drivers
+            configured for Neutron. If none are defined, then this will fall
+            back to OVN.
+        """
+        key = self.keys.neutron.ml2_driver
+        default = self.defaults.ml2_driver
+
+        if key not in self._parameters:
+            # The drivers are not defined on the file
             return default
 
         return self._parameters[key]

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -62,17 +62,46 @@ class DeploymentSummary:
     Every field left as 'None' indicates that no information related to it
     could be found. Interpret it as missing content.
     """
+
+    @dataclass
+    class Components:
+        """Holds information on each of the deployed components.
+        """
+
+        @dataclass
+        class Cinder:
+            """Information on the Cinder component.
+            """
+            backend: Optional[str] = None
+            """Name of the backend supporting cinder."""
+
+        @dataclass
+        class Neutron:
+            """Information on the Neutron component.
+            """
+            ip_version: Optional[str] = None
+            """TCP/IP protocol in use."""
+            backend: Optional[str] = None
+            """Name of the backend supporting neutron."""
+            tls_everywhere: Optional[str] = None
+            """State (On / Off) of TLS-Everywhere."""
+
+        cinder: Cinder = field(
+            default_factory=lambda *_: DeploymentSummary.Components.Cinder()
+        )
+        """Section for the Cinder component."""
+        neutron: Neutron = field(
+            default_factory=lambda *_: DeploymentSummary.Components.Neutron()
+        )
+        """Section for the Neutron component."""
+
     release: Optional[str] = None
     """Name of the OpenStack release deployed."""
-    ip_version: Optional[str] = None
-    """Name of the IP protocol used on the deployment."""
     infra_type: Optional[str] = None
     """Infrastructure type of the cloud."""
     topology: Optional[Topology] = None
-    """Nodes on the deployment."""
-    cinder_backend: Optional[str] = None
-    """Backend supporting the cinder component."""
-    neutron_backend: Optional[str] = None
-    """Backend supporting the neutron component."""
-    tls_everywhere: Optional[str] = None
-    """State (On / Off) of TLS-Everywhere on the deployment."""
+    """Definition of the deployed network."""
+    components: Components = field(
+        default_factory=lambda *_: DeploymentSummary.Components()
+    )
+    """Section dedicated to each of the components that form the deployment."""

--- a/tripleo/insights/io.py
+++ b/tripleo/insights/io.py
@@ -83,6 +83,8 @@ class DeploymentSummary:
             """TCP/IP protocol in use."""
             backend: Optional[str] = None
             """Name of the backend supporting neutron."""
+            ml2_driver: Optional[str] = None
+            """Comma delimited list with the name of the mechanism drivers."""
             tls_everywhere: Optional[str] = None
             """State (On / Off) of TLS-Everywhere."""
 

--- a/tripleo/insights/lookup.py
+++ b/tripleo/insights/lookup.py
@@ -189,14 +189,15 @@ class DeploymentLookUp:
         result.infra_type = environment.get_intra_type()
         result.topology = nodes.get_topology()
 
-        result.ip_version = '4'
-        result.tls_everywhere = 'Off'
+        # Giving default values
+        result.components.neutron.ip_version = '4'
+        result.components.neutron.tls_everywhere = 'Off'
 
         if featureset.is_ipv6():
-            result.ip_version = '6'
+            result.components.neutron.ip_version = '6'
 
         if featureset.is_tls_everywhere_enabled():
-            result.tls_everywhere = 'On'
+            result.components.neutron.tls_everywhere = 'On'
 
         # Take care of the scenario file too
         if featureset.get_scenario():
@@ -204,7 +205,7 @@ class DeploymentLookUp:
                 outline, featureset, release
             )
 
-            result.cinder_backend = scenario.get_cinder_backend()
-            result.neutron_backend = scenario.get_neutron_backend()
+            result.components.cinder.backend = scenario.get_cinder_backend()
+            result.components.neutron.backend = scenario.get_neutron_backend()
 
         return result

--- a/tripleo/insights/lookup.py
+++ b/tripleo/insights/lookup.py
@@ -207,5 +207,6 @@ class DeploymentLookUp:
 
             result.components.cinder.backend = scenario.get_cinder_backend()
             result.components.neutron.backend = scenario.get_neutron_backend()
+            result.components.neutron.ml2_driver = scenario.get_ml2_driver()
 
         return result


### PR DESCRIPTION
Reading the 'NeutronMechanismDrivers' field of a scenario file and returning it as the ML2 driver. In case the field does not exist, 'ovn' is returned instead.