### PR TITLE
Adding support for --ml2-driver at a Zuul-CI source

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
@@ -89,6 +89,11 @@ class ArgumentReview:
         return any(arg in kwargs for arg in ('spec',))
 
     def is_ml2_driver_requested(self, **kwargs: Any) -> bool:
+        """
+        :param kwargs: Arguments coming from the CLI.
+        :return: True if the user requested ml2 driver to be part of the
+            deployment, False if not.
+        """
         return any(arg in kwargs for arg in ('spec', 'ml2_driver'))
 
 

--- a/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
@@ -88,6 +88,9 @@ class ArgumentReview:
         """
         return any(arg in kwargs for arg in ('spec',))
 
+    def is_ml2_driver_requested(self, **kwargs: Any) -> bool:
+        return any(arg in kwargs for arg in ('spec', 'ml2_driver'))
+
 
 class SpecArgumentHandler:
     """Figures out which argument holds the jobs to be fetched from the host.

--- a/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/filtering.py
@@ -87,6 +87,7 @@ class DeploymentFiltering:
         network_args = (
             'network_backend',
             'ip_version',
+            'ml2_driver'
         )
 
         for arg in network_args:

--- a/cibyl/plugins/openstack/sources/zuul/deployments/generator.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/generator.py
@@ -74,7 +74,8 @@ class DeploymentGenerator:
             network=Network(
                 ip_version=self._get_ip_version(summary, **kwargs),
                 network_backend=self._get_neutron_backend(summary, **kwargs),
-                tls_everywhere=self._get_tls_everywhere(summary, **kwargs)
+                tls_everywhere=self._get_tls_everywhere(summary, **kwargs),
+                ml2_driver=self._get_ml2_driver(summary, **kwargs)
             ),
             storage=Storage(
                 cinder_backend=self._get_cinder_backend(summary, **kwargs)
@@ -174,6 +175,18 @@ class DeploymentGenerator:
             return None
 
         return summary.get_tls_everywhere()
+
+    def _get_ml2_driver(
+        self,
+        summary: VariantDeployment,
+        **kwargs: Any
+    ) -> Optional[str]:
+        arguments = self.tools.argument_review
+
+        if not arguments.is_ml2_driver_requested(**kwargs):
+            return None
+
+        return summary.get_ml2_driver()
 
     def _get_cinder_backend(
         self,

--- a/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
@@ -147,6 +147,9 @@ class VariantDeployment:
         """
         return self._summary.components.neutron.tls_everywhere
 
+    def get_ml2_driver(self) -> Optional[str]:
+        return self._summary.components.neutron.ml2_driver
+
     def get_cinder_backend(self) -> Optional[str]:
         """
         :return: Name of the backend that supports the Cinder component.

--- a/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/summary.py
@@ -148,6 +148,10 @@ class VariantDeployment:
         return self._summary.components.neutron.tls_everywhere
 
     def get_ml2_driver(self) -> Optional[str]:
+        """
+        :return: Comma delimited list with all the ml2 drivers in use.
+            'None' if it not defined.
+        """
         return self._summary.components.neutron.ml2_driver
 
     def get_cinder_backend(self) -> Optional[str]:

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_arguments.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_arguments.py
@@ -120,6 +120,16 @@ class TestArgumentReview(TestCase):
 
         self.assertTrue(review.is_tls_everywhere_requested(**{'spec': None}))
 
+    def test_is_ml2_driver_requested(self):
+        """Checks the conditions required for ml2 driver to be requested.
+        """
+        review = ArgumentReview()
+
+        self.assertFalse(review.is_ml2_driver_requested(**{}))
+
+        self.assertTrue(review.is_ml2_driver_requested(**{'spec': None}))
+        self.assertTrue(review.is_ml2_driver_requested(**{'ml2_driver': None}))
+
 
 class TestSpecArgumentHandler(TestCase):
     """Tests for :class:`SpecArgumentHandler`.

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_filtering.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_filtering.py
@@ -217,7 +217,32 @@ class TestDeploymentFiltering(TestCase):
         self.assertTrue(filtering.is_valid_deployment(deployment1))
         self.assertFalse(filtering.is_valid_deployment(deployment2))
 
-    def test_applied_cinder_backend_filter(self):
+    def test_applies_ml2_driver_filter(self):
+        """Checks that the filter for ml2 driver is generated and applied.
+        """
+        ml2_driver1 = 'ipv4'
+        ml2_driver2 = 'ipv6'
+
+        ml2_driver_arg = Mock()
+        ml2_driver_arg.value = [ml2_driver1]
+
+        kwargs = {
+            'ml2_driver': ml2_driver_arg
+        }
+
+        deployment1 = Mock()
+        deployment1.network.value.ml2_driver.value = ml2_driver1
+
+        deployment2 = Mock()
+        deployment2.network.value.ml2_driver.value = ml2_driver2
+
+        filtering = DeploymentFiltering()
+        filtering.add_filters_from(**kwargs)
+
+        self.assertTrue(filtering.is_valid_deployment(deployment1))
+        self.assertFalse(filtering.is_valid_deployment(deployment2))
+
+    def test_applies_cinder_backend_filter(self):
         """Checks that the filter for cinder backend is generated and
         applied.
         """


### PR DESCRIPTION
- Making ML2 driver part of the outputted deployment.
- Make it only be shown under --ml2-driver and --spec.
- Allow filtering by regex pattern.