### PR TITLE
Move source setup inside try/except in orchestrator

### DIFF
--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -278,12 +278,12 @@ class Orchestrator:
                 source_info = source_information_from_method(
                         source_method)
                 source_obj = get_source_instance_from_method(source_method)
-                source_obj.ensure_source_setup()
-                start_time = time.time()
-                LOG.info("Performing query on system %s", system.name)
-                LOG.debug("Running %s and speed index %d",
-                          source_info, speed_score)
                 try:
+                    source_obj.ensure_source_setup()
+                    start_time = time.time()
+                    LOG.info("Performing query on system %s", system.name)
+                    LOG.debug("Running %s and speed index %d",
+                              source_info, speed_score)
                     with StatusBar(f"Performing query ({system.name})"):
                         model_instances_dict = source_method(
                             **ci_args, **self.parser.app_args,
@@ -294,15 +294,15 @@ class Orchestrator:
                               source_info, system.name.value,
                               exception, exc_info=debug)
                     continue
+                end_time = time.time()
+                LOG.info("Took %.2fs to query system %s using %s",
+                         end_time-start_time, system.name.value,
+                         source_info)
                 if query_result is None:
                     query_result = model_instances_dict
                 else:
                     query_result = intersect_models(query_result,
                                                     model_instances_dict)
-                end_time = time.time()
-                LOG.info("Took %.2fs to query system %s using %s",
-                         end_time-start_time, system.name.value,
-                         source_info)
                 system.register_query()
                 # if one source has provided the information, there is
                 # no need to query the rest


### PR DESCRIPTION
The sources setup method was called outside a try/except block,
which would cause to skip the rest of the sources if an error ocurred
during the execution of the setup. This changes moves the call to the
setup inside the same try/except block where the call to the query
method occurss, so any SourceException raised during the setup will be
caught and the next source (if available) will be called.
