### PR TITLE
Add query and features subcommands to cibyl

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -110,6 +110,7 @@ def main() -> None:
         # Add arguments from CI & product models to the parser of the app
         for env in orchestrator.environments:
             orchestrator.extend_parser(attributes=env.API)
+        orchestrator.parser.add_subparsers()
         # We can parse user's arguments only after we have loaded the
         # configuration and extended based on it the parser with arguments
         # from the CI models

--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -66,40 +66,62 @@ class Parser:
         self.app_args = app_args
         if not app_args:
             self.app_args = {}
-        self.argument_parser = argparse.ArgumentParser()
+        # parser for model-related arguments
+        self.model_parser = argparse.ArgumentParser(add_help=False)
+        # application-wide parser that will contain all the subparsers
+        self.app_parser = argparse.ArgumentParser()
+
         self.__add_arguments()
         self.graph_queries = nx.DiGraph()
 
     def __add_arguments(self) -> None:
         """Creates argparse parser with all its sub-parsers."""
-        self.argument_parser.add_argument(
+        general_args_title = "General cibyl options"
+        app_args_group = self.app_parser.add_argument_group(general_args_title)
+        app_args_group.add_argument(
             '--debug', '-d', action='store_true',
             dest="debug", help='turn on debug')
-        self.argument_parser.add_argument(
+        app_args_group.add_argument(
             '--config', '-c', dest="config_file_path")
-        self.argument_parser.add_argument(
+        app_args_group.add_argument(
             '--log-file', dest="log_file",
             help='Path to store the output, default is cibyl_output.log')
-        self.argument_parser.add_argument(
+        app_args_group.add_argument(
             '--log-mode', dest="log_mode",
             choices=("terminal", "file", "both"),
             help='Where to write the output, default is both')
-        self.argument_parser.add_argument(
+        app_args_group.add_argument(
             '--output-format', '-f', choices=("text", "colorized", "json"),
             dest="output_style", default="colorized",
             help="Sets the output format."
         )
-        self.argument_parser.add_argument(
+        app_args_group.add_argument(
             '--plugin', '-p', dest="plugin", default="openstack")
-        self.argument_parser.add_argument(
+        app_args_group.add_argument(
             '-v', '--verbose', dest="verbosity", default=0, action="count",
             help="Causes Cibyl to print more debug messages. "
                  "Adding multiple -v will increase the verbosity.")
 
+    def add_subparsers(self) -> None:
+        """Add subparsers to the application-wide argument parser."""
+        subparsers_title = "Available subcommands"
+        subparsers = self.app_parser.add_subparsers(dest="command",
+                                                    title=subparsers_title)
+        # subparser for normal queries
+        subparsers.add_parser("query", add_help=True,
+                              parents=[self.model_parser])
+        # subparser for features
+        features_sp = subparsers.add_parser("features", add_help=True)
+        features_sp.add_argument("features", nargs="*",
+                                 help="Features to query")
+        features_sp.add_argument("--jobs", type=str, nargs=0, func='get_jobs',
+                                 help="List jobs that use the features",
+                                 action=CustomAction)
+
     def print_help(self) -> None:
         """Call argparse's print_help method to show the help message with the
         arguments that are currently added."""
-        self.argument_parser.print_help()
+        self.app_parser.print_help()
 
     def add_argument_to_tree(self, arg: Argument,
                              parent_queries: Set[str]) -> None:
@@ -127,7 +149,8 @@ class Parser:
 
         :param arguments: Arguments to parse
         """
-        arguments = vars(self.argument_parser.parse_args(arguments))
+
+        arguments = vars(self.app_parser.parse_args(arguments))
         # Keep only the used arguments
         self.ci_args = {arg_name: arg_value for arg_name, arg_value in
                         arguments.items() if isinstance(arg_value, Argument)}
@@ -146,7 +169,7 @@ class Parser:
         # pylint: disable=protected-access
         # Access the private member '_action_groups' to check
         # whether the group exists
-        for action_group in self.argument_parser._action_groups:
+        for action_group in self.model_parser._action_groups:
             if action_group.title == group_name:
                 return action_group
         return None
@@ -166,7 +189,7 @@ class Parser:
         # If the group doesn't exists, we would like to add it
         # so arguments are grouped based on the model class they belong to
         if not group:
-            group = self.argument_parser.add_argument_group(group_name)
+            group = self.model_parser.add_argument_group(group_name)
 
         try:
             for arg in arguments:

--- a/cibyl/models/ci/base/system.py
+++ b/cibyl/models/ci/base/system.py
@@ -66,11 +66,7 @@ class System(Model):
         'features': {
             'attr_type': Feature,
             'attribute_value_class': AttributeDictValue,
-            'arguments': [
-                Argument(name='--features', arg_type=str,
-                         nargs="*",
-                         description="Template to query for a given feature")
-            ]
+            'arguments': []
         },
     }
     """Defines the CLI arguments for all systems.

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -147,11 +147,11 @@ class Orchestrator:
     def load_features(self) -> list:
         """Read user-requested features and setup the right argument to query
         the information for them."""
-        user_features = self.parser.ci_args.get('features')
+        user_features = self.parser.app_args.get('features')
         if user_features is None:
             return []
         load_features()
-        if not user_features.value:
+        if not user_features:
             # throw error in case cibyl is called with --features argument but
             # without any specified feature
             features_string = get_string_all_features()
@@ -164,7 +164,7 @@ class Orchestrator:
                 msg += "plugin that provides the requested feature is added."
             raise InvalidArgument(msg)
         return [get_feature(feature_name)
-                for feature_name in user_features.value]
+                for feature_name in user_features]
 
     def run_features(self, system: System, features_to_run: list) -> None:
         """Run user-requested features, the output of each feature will be
@@ -372,9 +372,10 @@ class Orchestrator:
 
         The query is performed per system, while the results are published
         once per environment"""
+        command = self.parser.app_args.get('command')
         for env in self.environments:
             for system in env.systems:
-                if features:
+                if command == "features":
                     self.run_features(system, features)
                 else:
                     self.run_query(system)
@@ -383,5 +384,5 @@ class Orchestrator:
             self.publisher.publish(
                 environment=env,
                 style=output_style,
-                query=get_query_type(**self.parser.ci_args),
-                verbosity=self.parser.app_args.get('verbosity'))
+                query=get_query_type(**self.parser.ci_args, command=command),
+                verbosity=self.parser.app_args.get('verbosity', 0))

--- a/tests/cibyl/e2e/test_config.py
+++ b/tests/cibyl/e2e/test_config.py
@@ -27,8 +27,7 @@ class TestConfig(TestCase):
         """
         with HTTPDContainer() as httpd:
             command = [
-                'cibyl',
-                '--config', f'{httpd.url}/jenkins.yaml',
+                'cibyl', '--config', f'{httpd.url}/jenkins.yaml',
                 '-f', 'text'
             ]
 

--- a/tests/cibyl/e2e/test_elasticsearch.py
+++ b/tests/cibyl/e2e/test_elasticsearch.py
@@ -29,10 +29,10 @@ class TestElasticSearch(EndToEndTest):
         """
         with ElasticSearchContainer(index_name='logstash_jenkins_jobs'):
             sys.argv = [
-                '',
+                'cibyl',
                 '--config', 'tests/cibyl/e2e/data/configs/elasticsearch.yaml',
                 '-f', 'text',
-                '-vv',
+                '-vv', 'query',
                 '--jobs'
             ]
 

--- a/tests/cibyl/e2e/test_jenkins.py
+++ b/tests/cibyl/e2e/test_jenkins.py
@@ -34,10 +34,10 @@ class TestJenkins(EndToEndTest):
             jenkins.add_job('test_2')
 
             sys.argv = [
-                '',
+                'cibyl',
                 '--config', 'tests/cibyl/e2e/data/configs/jenkins.yaml',
                 '-f', 'text',
-                '-vv',
+                '-vv', 'query',
                 '--jobs'
             ]
 
@@ -54,9 +54,9 @@ class TestJenkins(EndToEndTest):
             jenkins.add_job('job-x')
 
             sys.argv = [
-                '',
+                'cibyl',
                 '--config', 'tests/cibyl/e2e/data/configs/jenkins.yaml',
-                '-f', 'text',
+                '-f', 'text', 'query',
                 '--jobs'
             ]
 
@@ -80,11 +80,10 @@ class TestFeatures(EndToEndTest):
         """
         with JenkinsContainer():
             sys.argv = [
-                '',
+                'cibyl',
                 '--config',
                 'tests/cibyl/e2e/data/configs/jenkins/with-openstack.yaml',
-                '-f', 'text',
-                '--features', 'IPv4'
+                '-f', 'text', 'features', 'IPv4'
             ]
 
             main()

--- a/tests/cibyl/e2e/test_zuul.py
+++ b/tests/cibyl/e2e/test_zuul.py
@@ -40,10 +40,10 @@ class TestQueryLevel(EndToEndTest):
         """Checks that tenants are retrieved with the "--tenants" flag.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
             '-f', 'text',
-            '-vv',
+            '-vv', 'query',
             '--tenants'
         ]
 
@@ -55,10 +55,10 @@ class TestQueryLevel(EndToEndTest):
         """Checks that tenants are retrieved with the "--tenants name" flag.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
             '-f', 'text',
-            '-vv',
+            '-vv', 'query',
             '--tenants', '^(example-tenant)$'
         ]
 
@@ -71,10 +71,10 @@ class TestQueryLevel(EndToEndTest):
         """Checks that projects are retrieved with the "--projects" flag.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
             '-f', 'text',
-            '-vv',
+            '-vv', 'query',
             '--tenants', '^(example-tenant)$',
             '--projects'
         ]
@@ -91,10 +91,10 @@ class TestQueryLevel(EndToEndTest):
         name2" flag.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
             '-f', 'text',
-            '-vv',
+            '-vv', 'query',
             '--tenants', '^(example-tenant)$',
             '--projects', 'test1'
         ]
@@ -115,12 +115,11 @@ class TestQueryLevel(EndToEndTest):
         """Checks that "-v" will print a project's URL.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
+            '-f', 'text', '-v', 'query',
             '--tenants', '^(example-tenant)$',
-            '--projects', 'test1',
-            '-v'
+            '--projects', 'test1'
         ]
 
         main()
@@ -139,10 +138,10 @@ class TestQueryLevel(EndToEndTest):
         """Checks that jobs are retrieved with the "--jobs" flag.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
             '-f', 'text',
-            '-vv',
+            '-vv', 'query',
             '--tenants', '^(example-tenant)$',
             '--jobs'
         ]
@@ -158,10 +157,10 @@ class TestQueryLevel(EndToEndTest):
         """Checks retrieved jobs by "--jobs name" flag.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
             '-f', 'text',
-            '-vv',
+            '-vv', 'query',
             '--tenants', '^(example-tenant)$',
             '--jobs', 'build-docker-image'
         ]
@@ -182,12 +181,11 @@ class TestQueryLevel(EndToEndTest):
         """Checks that "-v" will print a job's URL.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
+            '-v', '-f', 'text', 'query',
             '--tenants', '^(example-tenant)$',
             '--jobs', 'build-docker-image',
-            '-v'
         ]
 
         main()
@@ -207,9 +205,9 @@ class TestQueryLevel(EndToEndTest):
         """Checks retrieved variants by "--jobs --variants" flag.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
+            '-f', 'text', 'query',
             '--tenants', '^(example-tenant)$',
             '--jobs', 'build-docker-image',
             '--variants'
@@ -254,9 +252,9 @@ class TestQueryComposing(EndToEndTest):
         """Checks that '--tenants --project projectA' gets you all tenants
         as well."""
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
+            '-f', 'text', 'query',
             '--tenants',
             '--projects', '^test2$'
         ]
@@ -278,9 +276,9 @@ class TestQueryComposing(EndToEndTest):
         """Checks that '--tenants --project projectA' gets you all tenants
         as well."""
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
+            '-f', 'text', 'query',
             '--tenants',
             '--jobs', '^build-docker-image$'
         ]
@@ -305,9 +303,9 @@ class TestQueryComposing(EndToEndTest):
         """Checks that '--tenants --project projectA' gets you all tenants
         as well."""
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
+            '-f', 'text', 'query',
             '--projects', '^test2$',
             '--jobs', '^build-docker-image$'
         ]
@@ -349,10 +347,9 @@ class TestOutputFormatting(EndToEndTest):
         '--tenants' query.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
-            '-vv',
+            '-vv', '-f', 'text', 'query',
             '--tenants', '^(example-tenant)$'
         ]
 
@@ -368,10 +365,9 @@ class TestOutputFormatting(EndToEndTest):
         '--projects' query.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
-            '-vv',
+            '-f', 'text', '-vv', 'query',
             '--tenants', '^(example-tenant)$',
             '--projects'
         ]
@@ -388,9 +384,9 @@ class TestOutputFormatting(EndToEndTest):
         query did not find any tenant.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
+            '-f', 'text', 'query',
             '--tenants', '^(some-unknown-tenant)$',
         ]
 
@@ -406,9 +402,9 @@ class TestOutputFormatting(EndToEndTest):
         query did not find any project.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
+            '-f', 'text', 'query',
             '--tenants',
             '--project', '^(some-unknown-project)$'
         ]
@@ -425,9 +421,9 @@ class TestOutputFormatting(EndToEndTest):
         query did not find any jobs.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
+            '-f', 'text', 'query',
             '--tenants',
             '--jobs', '^(some-unknown-job)$'
         ]
@@ -459,11 +455,9 @@ class TestDefaults(EndToEndTest):
         to be consulted.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul/with-tenants.yaml',
-            '-f', 'text',
-            '-vv',
-            '--jobs'
+            '-f', 'text', '-vv', 'query', '--jobs'
         ]
 
         main()
@@ -477,11 +471,9 @@ class TestDefaults(EndToEndTest):
         tenants define in the configuration file.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul/with-tenants.yaml',
-            '-f', 'text',
-            '-vv',
-            '--tenants'
+            '-f', 'text', '-vv', 'query', '--tenants'
         ]
 
         main()
@@ -508,9 +500,9 @@ class TestOthers(EndToEndTest):
         """Checks that when printed, jobs are alphabetically ordered.
         """
         sys.argv = [
-            '',
+            'cibyl',
             '--config', 'tests/cibyl/e2e/data/configs/zuul.yaml',
-            '-f', 'text',
+            '-f', 'text', 'query',
             '--jobs', '^nodejs-.*'
         ]
 

--- a/tests/cibyl/intr/cli/test_config.py
+++ b/tests/cibyl/intr/cli/test_config.py
@@ -62,12 +62,12 @@ class TestConfigHelp(TestCase):
         """
         with NamedTemporaryFile() as config_file:
             sys.argv = [
-                'cibyl',
+                'cibyl', 'query',
                 '--config', config_file.name,
                 '--help'
             ]
             self.assertRaises(SystemExit, main)
-        self.assertIn("usage: cibyl [-h]", self.stdout)
+        self.assertIn("usage: cibyl query [-h]", self.stdout)
 
     def test_valid_config_help(self):
         """Test that the help message is printed when calling cibyl with an
@@ -85,9 +85,10 @@ class TestConfigHelp(TestCase):
             config_file.seek(0)
             sys.argv = [
                 'cibyl',
+                'query',
                 '--config', config_file.name,
                 '--jobs',
                 '--help'
             ]
             self.assertRaises(SystemExit, main)
-        self.assertIn("usage: cibyl [-h]", self.stdout)
+        self.assertIn("usage: cibyl query [-h]", self.stdout)

--- a/tests/cibyl/intr/cli/test_openstack_plugin.py
+++ b/tests/cibyl/intr/cli/test_openstack_plugin.py
@@ -62,9 +62,11 @@ class TestOpenstackCLI(RestoreAPIs):
             config_file.write(b"      system_type: zuul\n")
             config_file.write(b"      sources: {}\n")
             config_file.seek(0)
-            sys.argv = ['-h', '-p', 'openstack', '--config', config_file.name]
+            sys.argv = ['query', '-h', '-p', 'openstack', '--config',
+                        config_file.name]
 
-            main()
+            with self.assertRaises(SystemExit):
+                main()
         self.assertIn('deployment', ZuulJob.Variant.API)
 
     def test_openstack_cli_jenkins_system(self):
@@ -78,9 +80,11 @@ class TestOpenstackCLI(RestoreAPIs):
             config_file.write(b"      system_type: jenkins\n")
             config_file.write(b"      sources: {}\n")
             config_file.seek(0)
-            sys.argv = ['-h', '-p', 'openstack', '--config', config_file.name]
+            sys.argv = ['query', '-h', '-p', 'openstack', '--config',
+                        config_file.name]
 
-            main()
+            with self.assertRaises(SystemExit):
+                main()
         self.assertIn('deployment', BaseJob.API)
 
     def test_openstack_cli_zuul_jenkins_system(self):
@@ -97,9 +101,11 @@ class TestOpenstackCLI(RestoreAPIs):
             config_file.write(b"      system_type: jenkins\n")
             config_file.write(b"      sources: {}\n")
             config_file.seek(0)
-            sys.argv = ['-h', '-p', 'openstack', '--config', config_file.name]
+            sys.argv = ['query', '-h', '-p', 'openstack', '--config',
+                        config_file.name]
 
-            main()
+            with self.assertRaises(SystemExit):
+                main()
         self.assertIn('deployment', ZuulJob.Variant.API)
 
     def test_openstack_cli_jenkins_zuul_system(self):
@@ -116,9 +122,11 @@ class TestOpenstackCLI(RestoreAPIs):
             config_file.write(b"      system_type: zuul\n")
             config_file.write(b"      sources: {}\n")
             config_file.seek(0)
-            sys.argv = ['-h', '-p', 'openstack', '--config', config_file.name]
+            sys.argv = ['query', '-h', '-p', 'openstack', '--config',
+                        config_file.name]
 
-            main()
+            with self.assertRaises(SystemExit):
+                main()
         self.assertIn('deployment', BaseJob.API)
 
     def test_openstack_cli_zuul_system_plugin_configuration(self):
@@ -135,7 +143,8 @@ class TestOpenstackCLI(RestoreAPIs):
             config_file.write(b"plugins:\n")
             config_file.write(b"  - openstack\n")
             config_file.seek(0)
-            sys.argv = ['-h', '--config', config_file.name]
+            sys.argv = ['cibyl', 'query', '-h', '--config', config_file.name]
 
-            main()
+            with self.assertRaises(SystemExit):
+                main()
         self.assertIn('deployment', ZuulJob.Variant.API)

--- a/tests/cibyl/intr/test_orchestrator.py
+++ b/tests/cibyl/intr/test_orchestrator.py
@@ -81,8 +81,9 @@ class TestOrchestrator(TestCase):
             config_file.write(b"          driver: jenkins\n")
             config_file.write(b"          url: url\n")
             config_file.seek(0)
-            sys.argv = ['', '-p', 'openstack', '--config', config_file.name,
-                        '--jobs', 'DFG-compute', '--spec']
+            sys.argv = ['cibyl', '-p', 'openstack', '--config',
+                        config_file.name, 'query', '--jobs', 'DFG-compute',
+                        '--spec']
 
             main()
         jenkins_deployment.assert_called_once()
@@ -124,8 +125,9 @@ class TestOrchestrator(TestCase):
             config_file.write(b"          driver: jenkins\n")
             config_file.write(b"          url: url\n")
             config_file.seek(0)
-            sys.argv = ['', '-p', 'openstack', '--config', config_file.name,
-                        '--last-build', '--spec', '4', '-f', 'text']
+            sys.argv = ['cibyl', '-p', 'openstack', '-f', 'text', '--config',
+                        config_file.name, 'query', '--last-build', '--spec',
+                        '4']
 
             main()
 
@@ -162,8 +164,9 @@ class TestOrchestrator(TestCase):
             config_file.write(b"          driver: jenkins\n")
             config_file.write(b"          url: url\n")
             config_file.seek(0)
-            sys.argv = ['', '-p', 'openstack', '--config', config_file.name,
-                        '--jobs', 'DFG-compute', '--spec', '--tests']
+            sys.argv = ['cibyl', '-p', 'openstack', '--config',
+                        config_file.name, 'query', '--jobs', 'DFG-compute',
+                        '--spec', '--tests']
 
             main()
         jenkins_deployment.assert_called_once()
@@ -195,8 +198,9 @@ class TestOrchestrator(TestCase):
             config_file.write(b"          driver: jenkins\n")
             config_file.write(b"          url: url\n")
             config_file.seek(0)
-            sys.argv = ['', '-p', 'openstack', '--config', config_file.name,
-                        '--jobs', 'DFG-compute', '--spec', '--builds']
+            sys.argv = ['cibyl', '-p', 'openstack', '--config',
+                        config_file.name, 'query', '--jobs', 'DFG-compute',
+                        '--spec', '--builds']
 
             main()
         jenkins_deployment.assert_called_once()
@@ -228,7 +232,8 @@ class TestOrchestrator(TestCase):
             config_file.write(b"          driver: jenkins\n")
             config_file.write(b"          url: url\n")
             config_file.seek(0)
-            sys.argv = ['', '-p', 'openstack', '--config', config_file.name,
+            sys.argv = ['cibyl', '-p', 'openstack', '--config',
+                        config_file.name, 'query',
                         '--jobs', 'DFG-compute', '--spec', '--tests',
                         '--builds']
 
@@ -264,7 +269,8 @@ class TestOrchestrator(TestCase):
             config_file.write(b"          driver: zuul\n")
             config_file.write(b"          url: url\n")
             config_file.seek(0)
-            sys.argv = ['', '-p', 'openstack', '--config', config_file.name,
+            sys.argv = ['cibyl', '-p', 'openstack', '--config',
+                        config_file.name, 'query',
                         '--jobs', 'DFG-compute', '--spec', '--tests']
 
             main()
@@ -298,7 +304,8 @@ class TestOrchestrator(TestCase):
             config_file.write(b"          driver: zuul\n")
             config_file.write(b"          url: url\n")
             config_file.seek(0)
-            sys.argv = ['', '-p', 'openstack', '--config', config_file.name,
+            sys.argv = ['cibyl', '-p', 'openstack', '--config',
+                        config_file.name, 'query',
                         '--jobs', 'DFG-compute', '--spec', '--builds']
 
             main()
@@ -335,8 +342,8 @@ class TestOrchestrator(TestCase):
             config_file.write(b"          driver: elasticsearch\n")
             config_file.write(b"          url: url\n")
             config_file.seek(0)
-            sys.argv = ['', '--config', config_file.name,
-                        '--builds', 'DFG-compute']
+            sys.argv = ['cibyl', '--config', config_file.name,
+                        'query', '--builds', 'DFG-compute']
 
             main()
         elasticsearch_setup.assert_called_once()

--- a/tests/cibyl/unit/cli/test_parser.py
+++ b/tests/cibyl/unit/cli/test_parser.py
@@ -35,36 +35,32 @@ class TestParser(TestCase):
 
     def test_parser_plugin_argument(self):
         """Tests parser plugin argument"""
-        parsed_args = self.parser.argument_parser.parse_args(
+        parsed_args = self.parser.app_parser.parse_args(
             ['--plugin', 'openstack'])
         self.assertEqual(parsed_args.plugin, 'openstack')
 
     def test_parser_debug_argument(self):
         """Tests parser debug argument"""
-        parsed_args = self.parser.argument_parser.parse_args(
+        parsed_args = self.parser.app_parser.parse_args(
             ['--debug'])
         self.assertTrue(parsed_args.debug)
 
     def test_parser_config_argument(self):
         """Tests parser config argument"""
-        parsed_args = self.parser.argument_parser.parse_args(
+        parsed_args = self.parser.app_parser.parse_args(
             ['--config', '/some/path'])
         self.assertEqual(parsed_args.config_file_path, '/some/path')
 
     def test_parser_parse_args(self):
         """Testing parser extend method"""
-        self.parser.parse({})
-        self.assertEqual(self.parser.app_args, {'debug': False,
-                                                'plugin': 'openstack',
-                                                'output_style': 'colorized',
-                                                'verbosity': 0})
-        self.assertEqual(self.parser.ci_args, {})
 
         self.parser.extend(self.environment.arguments, 'Environment')
-        self.parser.parse(['--envs', 'env1', '--plugin', 'openshift'])
+        self.parser.add_subparsers()
+        self.parser.parse(['--plugin', 'openshift', 'query', '--envs', 'env1'])
         self.assertEqual(self.parser.app_args, {'plugin': 'openshift',
                                                 'verbosity': 0,
                                                 'output_style': 'colorized',
+                                                'command': 'query',
                                                 'debug': False})
         self.assertEqual(self.parser.ci_args,
                          {'envs': Argument(

--- a/tests/cibyl/unit/cli/test_query.py
+++ b/tests/cibyl/unit/cli/test_query.py
@@ -144,21 +144,36 @@ class TestGetQueryType(TestCase):
 
     def test_get_feature(self):
         """Checks that "FEATURES" is returned for "--feature"."""
-        args = {
-            'features': None
-        }
+        args = {}
 
-        self.assertEqual(QueryType.FEATURES, get_query_type(**args))
+        self.assertEqual(QueryType.FEATURES,
+                         get_query_type(command="features", **args))
+
+    def test_get_feature_no_command(self):
+        """Checks that "FEATURES" is returned for "--feature" without the
+        command argument."""
+        args = {}
+
+        self.assertEqual(QueryType.NONE, get_query_type(**args))
 
     def test_get_feature_jobs(self):
         """Checks that "FEATURES_JOBS" is returned for "--feature" and
         "--jobs"."""
         args = {
-            'features': None,
             'jobs': None
         }
 
-        self.assertEqual(QueryType.FEATURES_JOBS, get_query_type(**args))
+        self.assertEqual(QueryType.FEATURES_JOBS,
+                         get_query_type(command="features", **args))
+
+    def test_get_feature_jobs_no_command(self):
+        """Checks that "JOBS" is returned for "--feature" and
+        "--jobs" without the command argument."""
+        args = {
+            'jobs': None
+        }
+
+        self.assertEqual(QueryType.JOBS, get_query_type(**args))
 
     def test_get_tests_builds(self):
         """Checks that "Tests" is returned for "--tests" and "--last-build".

--- a/tests/cibyl/unit/test_orchestrator.py
+++ b/tests/cibyl/unit/test_orchestrator.py
@@ -170,7 +170,8 @@ class TestOrchestrator(TestOrchestratorSetup):
         self.orchestrator.create_ci_environments()
         for env in self.orchestrator.environments:
             self.orchestrator.extend_parser(attributes=env.API)
-        self.orchestrator.parser.parse(["--jobs", "--builds"])
+        self.orchestrator.parser.add_subparsers()
+        self.orchestrator.parser.parse(["query", "--jobs", "--builds"])
         self.assertTrue("jobs" in self.orchestrator.parser.ci_args)
         self.assertTrue("builds" in self.orchestrator.parser.ci_args)
         self.assertEqual(self.orchestrator.parser.ci_args["jobs"].level, 2)
@@ -184,9 +185,10 @@ class TestOrchestrator(TestOrchestratorSetup):
         self.orchestrator.create_ci_environments()
         for env in self.orchestrator.environments:
             self.orchestrator.extend_parser(attributes=env.API)
-        self.orchestrator.parser.parse([
-            "--jobs", "--builds", "--tenants", "--projects", "--pipelines"
-        ])
+        self.orchestrator.parser.add_subparsers()
+        self.orchestrator.parser.parse(["query", "--jobs", "--builds",
+                                        "--tenants", "--projects",
+                                        "--pipelines"])
         self.assertTrue("tenants" in self.orchestrator.parser.ci_args)
         self.assertTrue("jobs" in self.orchestrator.parser.ci_args)
         self.assertTrue("builds" in self.orchestrator.parser.ci_args)
@@ -265,11 +267,12 @@ class TestOrchestratorArgumentsFiltering(TestOrchestratorSetup):
         self.orchestrator.create_ci_environments()
         for env in self.orchestrator.environments:
             self.orchestrator.extend_parser(attributes=env.API)
+        self.orchestrator.parser.add_subparsers()
 
     def test_jobs_builds(self):
         """Test that sort_and_filter_args handles properly the case with two
         arguments with different func attributes."""
-        self.orchestrator.parser.parse(["--jobs", "--builds"])
+        self.orchestrator.parser.parse(["query", "--jobs", "--builds"])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(len(args), 1)
         self.assertEqual(args[0].name, "builds")
@@ -277,14 +280,15 @@ class TestOrchestratorArgumentsFiltering(TestOrchestratorSetup):
     def test_filter_args_with_no_func(self):
         """Test that sort_and_filter_args handles properly the case with two
         arguments with different func attributes."""
-        self.orchestrator.parser.parse(["--systems", "", "--envs", ""])
+        self.orchestrator.parser.parse(["query", "--systems", "", "--envs",
+                                        ""])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(len(args), 0)
 
     def test_multiple_builds_arguments(self):
         """Test that sort_and_filter_args handles properly the case with two
         arguments that should query get_builds."""
-        self.orchestrator.parser.parse(["--jobs", "--builds",
+        self.orchestrator.parser.parse(["query", "--jobs", "--builds",
                                         "--build-status"])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(len(args), 1)
@@ -294,7 +298,7 @@ class TestOrchestratorArgumentsFiltering(TestOrchestratorSetup):
         """Test that sort_and_filter_args handles properly the case with two
         arguments that should query get_builds and two that should query
         get_tests."""
-        self.orchestrator.parser.parse(["--jobs", "--builds",
+        self.orchestrator.parser.parse(["query", "--jobs", "--builds",
                                         "--build-status", "--tests",
                                         "--test-result"])
         args = self.orchestrator.sort_and_filter_args()
@@ -309,7 +313,7 @@ class TestArgumentsFilteringOpenstack(OpenstackPluginWithJobSystem,
     def test_multiple_deployment_arguments_different_level(self):
         """Test that sort_and_filter_args handles properly the case with many
         arguments that should query get_deployment with different levels."""
-        self.orchestrator.parser.parse(["--builds", "--ip-version",
+        self.orchestrator.parser.parse(["query", "--builds", "--ip-version",
                                         "--packages", '--release'])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(len(args), 2)
@@ -319,7 +323,7 @@ class TestArgumentsFilteringOpenstack(OpenstackPluginWithJobSystem,
     def test_multiple_deployment_arguments_different_level_builds_tests(self):
         """Test that sort_and_filter_args handles properly the case with many
         arguments that should query get_deployment with different levels."""
-        self.orchestrator.parser.parse(["--builds", "--ip-version",
+        self.orchestrator.parser.parse(["query", "--builds", "--ip-version",
                                         "--packages", '--release', '--tests'])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(len(args), 2)
@@ -335,7 +339,7 @@ class TestArgumentsParsingOpenstack(OpenstackPluginWithJobSystem,
         a non-existing option."""
         with redirect_stderr(StringIO()):
             with self.assertRaises(SystemExit):
-                self.orchestrator.parser.parse(["--test-setup",
+                self.orchestrator.parser.parse(["query", "--test-setup",
                                                 "non-existing"])
 
 
@@ -378,12 +382,13 @@ class TestOrchestratorArgsFilter(TestCase):
         self.orchestrator.create_ci_environments()
         for env in self.orchestrator.environments:
             self.orchestrator.extend_parser(attributes=env.API)
+        self.orchestrator.parser.add_subparsers()
 
     def test_sort_and_filter_args_jobs_system(self):
         """Test that the sort_and_filter_args filters multiple arguments with
         the same func attribute."""
         self.prepare_tests(self.valid_single_jenkins_env_config_data)
-        self.orchestrator.parser.parse(["--jobs", "--builds",
+        self.orchestrator.parser.parse(["query", "--jobs", "--builds",
                                         "--build-status"])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(1, len(args))
@@ -393,7 +398,7 @@ class TestOrchestratorArgsFilter(TestCase):
         """Test that the sort_and_filter_args returns the only argument with a
         func attribute."""
         self.prepare_tests(self.valid_single_jenkins_env_config_data)
-        self.orchestrator.parser.parse(["--jobs"])
+        self.orchestrator.parser.parse(["query", "--jobs"])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(1, len(args))
         self.assertEqual("get_jobs", args[0].func)
@@ -402,7 +407,8 @@ class TestOrchestratorArgsFilter(TestCase):
         """Test that the sort_and_filter_args filters multiple arguments with
         the same func attribute."""
         self.prepare_tests(self.valid_single_jenkins_env_config_data)
-        self.orchestrator.parser.parse(["--jobs", "--builds", "--build-status",
+        self.orchestrator.parser.parse(["query", "--jobs", "--builds",
+                                        "--build-status",
                                         "--tests", "--test-result"])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(1, len(args))
@@ -412,7 +418,7 @@ class TestOrchestratorArgsFilter(TestCase):
         """Test that the sort_and_filter_args filters multiple arguments with
         the same func attribute."""
         self.prepare_tests(self.valid_single_zuul_env_config_data)
-        self.orchestrator.parser.parse(["--jobs", "--builds",
+        self.orchestrator.parser.parse(["query", "--jobs", "--builds",
                                         "--build-status"])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(1, len(args))
@@ -422,7 +428,8 @@ class TestOrchestratorArgsFilter(TestCase):
         """Test that the sort_and_filter_args filters multiple arguments with
         the same func attribute."""
         self.prepare_tests(self.valid_single_zuul_env_config_data)
-        self.orchestrator.parser.parse(["--jobs", "--builds", "--build-status",
+        self.orchestrator.parser.parse(["query", "--jobs", "--builds",
+                                        "--build-status",
                                         "--tests", "--test-result"])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(1, len(args))
@@ -432,7 +439,8 @@ class TestOrchestratorArgsFilter(TestCase):
         """Test that the sort_and_filter_args filters handles correctly
         argument that connect through multiple paths."""
         self.prepare_tests(self.valid_single_zuul_env_config_data)
-        self.orchestrator.parser.parse(["--jobs", "--tenants", "--pipelines"])
+        self.orchestrator.parser.parse(["query", "--jobs", "--tenants",
+                                        "--pipelines"])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(1, len(args))
         self.assertEqual("get_jobs", args[0].func)
@@ -447,7 +455,7 @@ class TestOrchestratorArgsFilterOpenstackPlugin(TestOrchestratorArgsFilter,
         """Test that the sort_and_filter_args filters multiple arguments with
         the same func attribute."""
         self.prepare_tests(self.valid_single_jenkins_env_config_data)
-        self.orchestrator.parser.parse(["--ip-version", "--packages",
+        self.orchestrator.parser.parse(["query", "--ip-version", "--packages",
                                         "--build-status"])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(2, len(args))
@@ -458,7 +466,7 @@ class TestOrchestratorArgsFilterOpenstackPlugin(TestOrchestratorArgsFilter,
         """Test that the sort_and_filter_args filters multiple arguments with
         the same func attribute."""
         self.prepare_tests(self.valid_single_jenkins_env_config_data)
-        self.orchestrator.parser.parse(["--ip-version", "--packages",
+        self.orchestrator.parser.parse(["query", "--ip-version", "--packages",
                                         "--build-status", "--tests"])
         args = self.orchestrator.sort_and_filter_args()
         self.assertEqual(2, len(args))


### PR DESCRIPTION
This change introduces two subcommands to cibyl: query and features. The
first corresponds to normal queries, for --jobs, --builds, etc. The
second corresponds to feature queries. This change should mantain most
of the funcionality. For example, runnning cibyl without arguments will
still print the configuration envs. It also leaves the sources
untouched. The cibyl parser will contain two subparsers and a block of
general, application level options (--verbose, --debug, --config, ...).
The query subparser will contain all the arguments that it had until
now, while the features one will have only the application-level
arguments and --jobs (it can be easily expanded in the future if
needed).
