### PR TITLE
Add tripleo library to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY $CIBYL_ROOT/setup.cfg .
 COPY $CIBYL_ROOT/requirements.txt .
 
 COPY $CIBYL_ROOT/cibyl ./cibyl
+COPY $CIBYL_ROOT/tripleo ./tripleo
 
 RUN python3 -m pip install .
 


### PR DESCRIPTION
The Dockerfile was not copying the tripleo library source to the
container, which was causing the config e2e test to fail.
