### PR TITLE
Add spec subcommand and update documentation

### DIFF
--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -117,6 +117,11 @@ class Parser:
         features_sp.add_argument("--jobs", type=str, nargs='*',
                                  func='get_jobs', action=CustomAction,
                                  help="List jobs that use the features")
+        # subparser for spec
+        features_sp = subparsers.add_parser("spec", add_help=True)
+        features_sp.add_argument("spec", nargs=1, metavar="job_name",
+                                 func='get_deployment', action=CustomAction,
+                                 help="Name of the job to get the spec for")
 
     def print_help(self) -> None:
         """Call argparse's print_help method to show the help message with the

--- a/cibyl/plugins/openstack/__init__.py
+++ b/cibyl/plugins/openstack/__init__.py
@@ -13,7 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from cibyl.cli.argument import Argument
 from cibyl.cli.query import QuerySelector, QueryType
 from cibyl.features import add_feature_location
 from cibyl.models.ci.base.job import Job
@@ -59,10 +58,7 @@ class Plugin:
         def get_deployment_api():
             return {
                 'attr_type': Deployment,
-                'arguments': [Argument(name='--spec', arg_type=str,
-                              func='get_deployment', nargs='*',
-                              description="Print complete openstack"
-                              " deployment")]
+                'arguments': []
             }
 
         def extend_job_model():

--- a/docs/source/plugins/openstack.rst
+++ b/docs/source/plugins/openstack.rst
@@ -33,13 +33,13 @@ Spec
 .. note:: | This feature is only fully implemented with the Jenkins automation system.
           | It is partially supported with Zuul (The option will work but will not provide the complete specification)
 
-`cibyl query --spec JOB_NAME` allows you to easily get the full OpenStack specification of a single job.
+`cibyl spec JOB_NAME` allows you to easily get the full OpenStack specification of a single job.
 
 The idea behind it is to allow the user to quickly get information on which OpenStack services and features
 are covered by a single job so the user doesn't have to go and deep dive into the job configuration and build
 artifacts to figure it out by himself.
 
-An example of an output from running `cibyl query --spec JOB_NAME`::
+An example of an output from running `cibyl spec JOB_NAME`::
 
     Openstack deployment:
       Release: 17.0

--- a/docs/source/usage/cli.rst
+++ b/docs/source/usage/cli.rst
@@ -43,9 +43,11 @@ Cibyl supports the following subcommands:
 
   * query
   * features
+  * spec
 
 This page will cover many uses of the ``query`` subcommand, for examples of the
-``features`` one see the `features section <../features.html>`_.
+``features`` one see the `features section <../features.html>`_ and for
+examples of the ``spec`` subcommand see the `spec section <../plugins/openstack.html#spec>`_.
 
 General parameters
 ------------------
@@ -241,14 +243,8 @@ used ipv6::
 
     cibyl query --ip-version 6 --network-backend
 
-Other examples of relevant openstack arguments include the spec, which provides
-the full Openstack specification of a job (note that the spec argument only accepts
-one value, more details in the `spec section <../plugins/openstack.html#spec>`_ of
-the openstack plugin documentation)::
-
-    cibyl query --spec job_name
-
-checking which jobs setup the tests from git, instead of rpm packages::
+Other examples of relevant openstack arguments include checking which jobs
+setup the tests from git, instead of rpm packages::
 
     cibyl query --test-setup git
 

--- a/tests/tripleo/intr/utils/git/test_gitpython.py
+++ b/tests/tripleo/intr/utils/git/test_gitpython.py
@@ -14,7 +14,7 @@
 #    under the License.
 """
 from tempfile import TemporaryDirectory
-from unittest import TestCase, skip
+from unittest import TestCase
 
 from tripleo.utils.fs import Dir
 from tripleo.utils.git.gitpython import GitPython
@@ -44,7 +44,6 @@ class TestGitPython(TestCase):
 
                 self.assertEqual(branch, repo.branch)
 
-    @skip("changed README in this commit, so it will differ from main")
     def test_get_as_text(self):
         """Checks that it is possible to get the contents of a file in the
         repository as text.

--- a/tests/tripleo/intr/utils/github/test_pygithub.py
+++ b/tests/tripleo/intr/utils/github/test_pygithub.py
@@ -13,7 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from unittest import TestCase, skip
+from unittest import TestCase
 
 from tripleo.utils.github import GitHubError
 from tripleo.utils.github.pygithub import PyGitHub
@@ -42,7 +42,6 @@ class TestPyGitHub(TestCase):
         with self.assertRaises(GitHubError):
             repo.download_as_text('some_file')
 
-    @skip("changed README in this commit, so it will differ from main")
     def test_downloads_file_as_text(self):
         """Checks that it is possible to download a file through the API."""
         github = PyGitHub.from_no_login()


### PR DESCRIPTION
Add a new spec subcommand that should replace a call like cibyl query
--spec job-name. The same command would be now cibyl spec job-name.
Functionality stays the same, that is, calling cibyl spec without
a job-name will fail, and calling it with multiple job-names will also
fail. This change also removes the --spec argument, updates the
mentions to it in the documentation to new subcommand and reactivates
a couple of tests that were skipped in the past.

This PR creates the new subparser in the core parser, but a future PR will try
to move the spec subparser to the openstack plugin and introduce a mechanism so
that plugins can provide subcommands to the application parser.
