### PR TITLE
Add mechanism to add subcommands from plugins

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -105,12 +105,13 @@ def main() -> None:
             plugins = orchestrator.config.plugins
         # add plugins after the environments are created, since the environment
         # might modify some of the models APIs
+        plugin_parsers = []
         if plugins:
-            enable_plugins(plugins)
+            plugin_parsers = enable_plugins(plugins)
         # Add arguments from CI & product models to the parser of the app
         for env in orchestrator.environments:
             orchestrator.extend_parser(attributes=env.API)
-        orchestrator.parser.add_subparsers()
+        orchestrator.parser.add_subparsers(subparser_creators=plugin_parsers)
         # We can parse user's arguments only after we have loaded the
         # configuration and extended based on it the parser with arguments
         # from the CI models

--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -102,7 +102,7 @@ class Parser:
             help="Causes Cibyl to print more debug messages. "
                  "Adding multiple -v will increase the verbosity.")
 
-    def add_subparsers(self) -> None:
+    def add_subparsers(self, subparser_creators: List[Callable] = []) -> None:
         """Add subparsers to the application-wide argument parser."""
         subparsers_title = "Available subcommands"
         subparsers = self.app_parser.add_subparsers(dest="command",
@@ -117,11 +117,8 @@ class Parser:
         features_sp.add_argument("--jobs", type=str, nargs='*',
                                  func='get_jobs', action=CustomAction,
                                  help="List jobs that use the features")
-        # subparser for spec
-        features_sp = subparsers.add_parser("spec", add_help=True)
-        features_sp.add_argument("spec", nargs=1, metavar="job_name",
-                                 func='get_deployment', action=CustomAction,
-                                 help="Name of the job to get the spec for")
+        for function in subparser_creators:
+            function(subparsers)
 
     def print_help(self) -> None:
         """Call argparse's print_help method to show the help message with the

--- a/cibyl/plugins/openstack/__init__.py
+++ b/cibyl/plugins/openstack/__init__.py
@@ -13,10 +13,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from typing import Callable, List
+
+from cibyl.cli.parser import CustomAction
 from cibyl.cli.query import QuerySelector, QueryType
 from cibyl.features import add_feature_location
 from cibyl.models.ci.base.job import Job
 from cibyl.models.ci.zuul.job import Job as ZuulJob
+from cibyl.plugins import PluginTemplate
 from cibyl.plugins.openstack.deployment import Deployment
 from cibyl.utils.dicts import subset
 
@@ -48,13 +52,14 @@ def get_query_openstack(**kwargs) -> QueryType:
     return result
 
 
-class Plugin:
+class Plugin(PluginTemplate):
     """Extend a CI model with Openstack specific models and methods."""
     plugin_attributes_to_add = {
         'deployment': {'add_method': 'add_deployment'}
         }
 
     def extend_models(self):
+        """Extend models' API with product specific information."""
         def get_deployment_api():
             return {
                 'attr_type': Deployment,
@@ -88,3 +93,16 @@ class Plugin:
     def extend_query_types(self):
         """Register the plugin function to deduce the type of query."""
         QuerySelector.query_selector_functions.append(get_query_openstack)
+
+    def get_subparsers_creators(self) -> List[Callable]:
+        """Collect a list of functions from the plugin that will be used to
+        extend Cibyl's cli with additional subcommands. All functions returned
+        by this method must take an ArgumentParser object as an argument."""
+        def add_spec_subcommand(parser):
+            # subparser for spec
+            spec_sp = parser.add_parser("spec", add_help=True)
+            help_msg = "Name of the job to get the spec for"
+            spec_sp.add_argument("spec", nargs=1, metavar="job_name",
+                                 func='get_deployment',
+                                 action=CustomAction, help=help_msg)
+        return [add_spec_subcommand]

--- a/tests/cibyl/unit/plugins/test_plugin.py
+++ b/tests/cibyl/unit/plugins/test_plugin.py
@@ -27,7 +27,9 @@ class TestPlugin(RestoreAPIs):
 
     def test_enable_plugins(self):
         """Test enable_plugins method"""
-        self.assertIsNone(enable_plugins(["openstack"]))
+        # check that the openstack plugin returns only a list with one element,
+        # the function to create the spec subparser
+        self.assertEqual(len(enable_plugins(["openstack"])), 1)
 
     def test_missing_plugin(self):
         """Test enable_plugins method with a non-existing plugin."""


### PR DESCRIPTION
Implement a mechanism to provide product-specific subcommands from the
plugin themselves. At the moment, there is only one example of this, the
spec subcommand provided by the openstack plugin. The plugins that add
subcommands must provide a list of functions that take an ArgumentParser
object as argument and add the subpbarser there. This list is collected
when the plugins are loaded and passed to the add_subparser method of
the Parser class to form the complete cli.
