### PR TITLE
Enable e2e tests in github actions

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -13,7 +13,8 @@ jobs:
       matrix:
         python-version: ['3.6', '3.9']
     steps:
-      - uses: actions/checkout@v1
+      - name: "Checkout repo"
+        uses: actions/checkout@v1
       - name: "Setup Python"
         uses: actions/setup-python@v2
         with:

--- a/tests/cibyl/e2e/containers/zuul.py
+++ b/tests/cibyl/e2e/containers/zuul.py
@@ -42,7 +42,7 @@ class OpenDevZuulContainer(ComposedContainer):
 
     @property
     def origin(self):
-        return 'git@github.com:rhos-infra/cibyl-e2e-zuul.git'
+        return 'https://github.com/rhos-infra/cibyl-e2e-zuul.git'
 
     @property
     def workspace(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.8.0
-envlist = linters,unit,intr,coverage,docs
+envlist = linters,unit,intr,coverage,docs,e2e
 skipsdist = True
 ignore_basepython_conflict = True
 skip_missing_interpreters = False


### PR DESCRIPTION
Re-enable e2e tests in github actions without any ssh key, as the helper
repo that required is public now.
