### PR TITLE
Adding transaction for Zuul tests

### DIFF
--- a/cibyl/sources/zuul/transactions/__init__.py
+++ b/cibyl/sources/zuul/transactions/__init__.py
@@ -23,7 +23,7 @@ License:
 from abc import ABC
 from typing import Iterable
 
-from cibyl.cli.ranged_argument import Range
+from cibyl.cli.ranged_argument import Range, RANGE_OPERATORS
 from cibyl.models.ci.zuul.test import TestKind, TestStatus
 from cibyl.sources.zuul.apis import ZuulBuildAPI
 from cibyl.sources.zuul.utils.tests.tempest.types import TempestTest
@@ -393,6 +393,19 @@ class TestsRequest(Request):
             return any(
                 response.status == patt for patt in status
             )
+
+        self._filters.append(test)
+        return self
+
+    def with_duration(self, *duration: Range) -> 'TestsRequest':
+        def test(response):
+            for condition in duration:
+                run_test = RANGE_OPERATORS[condition.operator]
+
+                if run_test(response.duration, condition.operand):
+                    return True
+
+            return False
 
         self._filters.append(test)
         return self

--- a/cibyl/sources/zuul/transactions/__init__.py
+++ b/cibyl/sources/zuul/transactions/__init__.py
@@ -23,7 +23,7 @@ License:
 from abc import ABC
 from typing import Iterable
 
-from cibyl.cli.ranged_argument import Range, RANGE_OPERATORS
+from cibyl.cli.ranged_argument import RANGE_OPERATORS, Range
 from cibyl.models.ci.zuul.test import TestKind, TestStatus
 from cibyl.sources.zuul.apis import ZuulBuildAPI
 from cibyl.sources.zuul.utils.tests.tempest.types import TempestTest
@@ -380,6 +380,12 @@ class TestsRequest(Request):
         self._build = build
 
     def with_name(self, *pattern: str) -> 'TestsRequest':
+        """Will limit request to tests whose name follows a certain pattern.
+
+        :param pattern: Regex pattern for the desired test name.
+        :return: The request's instance.
+        """
+
         def test(response):
             return any(
                 matches_regex(patt, response.name) for patt in pattern
@@ -389,6 +395,12 @@ class TestsRequest(Request):
         return self
 
     def with_status(self, *status: TestStatus) -> 'TestsRequest':
+        """Will limit request to tests on a certain status.
+
+        :param status: Desired status of the test cases.
+        :return: The request's instance.
+        """
+
         def test(response):
             return any(
                 response.status == patt for patt in status
@@ -398,6 +410,13 @@ class TestsRequest(Request):
         return self
 
     def with_duration(self, *duration: Range) -> 'TestsRequest':
+        """Will limit request to tests whose duration falls under the range.
+
+        :param duration: Desired scope of the test's duration. Keep in mind
+            that test duration is measured in seconds.
+        :return: The request's instance.
+        """
+
         def test(response):
             for condition in duration:
                 run_test = RANGE_OPERATORS[condition.operator]

--- a/cibyl/sources/zuul/transactions/__init__.py
+++ b/cibyl/sources/zuul/transactions/__init__.py
@@ -21,8 +21,14 @@ License:
 #
 """
 from abc import ABC
+from typing import Iterable
 
+from cibyl.models.ci.zuul.test import TestKind, TestStatus
+from cibyl.sources.zuul.apis import ZuulBuildAPI
+from cibyl.sources.zuul.utils.tests.tempest.types import TempestTest
+from cibyl.sources.zuul.utils.tests.types import Test, TestResult, TestSuite
 from cibyl.utils.filtering import apply_filters, matches_regex
+from cibyl.utils.urls import URL
 
 
 class Request(ABC):
@@ -358,6 +364,34 @@ class BuildsRequest(Request):
         return [BuildResponse(build) for build in builds]
 
 
+class TestsRequest(Request):
+    """High-Level petition focused on retrieval of data related to test
+    cases.
+    """
+
+    def __init__(self, build: ZuulBuildAPI):
+        """Constructor.
+
+        :param build: Low-Level API to the build to get the test cases from.
+        """
+        super().__init__()
+
+        self._build = build
+
+    def get(self) -> Iterable['TestResponse']:
+        """Performs the request.
+
+        :return: Answer from the host.
+        """
+        result = []
+
+        for suite in self._build.tests():
+            for test in suite.tests:
+                result.append(TestResponse(self._build, suite, test))
+
+        return result
+
+
 class TenantResponse:
     """Response for a :class:`TenantsRequest`.
     """
@@ -604,3 +638,92 @@ class BuildResponse:
         :rtype: dict[str, Any]
         """
         return self._build.raw
+
+    def tests(self) -> TestsRequest:
+        return TestsRequest(self._build)
+
+
+class TestResponse:
+    """Response for a :class:`TestsRequest`.
+    """
+
+    def __init__(self, build: ZuulBuildAPI, suite: TestSuite, test: Test):
+        """Constructor.
+
+        :param build: Low-Level API to access the build's data.
+        :param suite: The test suite the test belongs to.
+        :param test: Data on the test case.
+        """
+        self._build = build
+        self._suite = suite
+        self._test = test
+
+    @property
+    def build(self) -> BuildResponse:
+        """
+        :return: Response for the test's build.
+        """
+        return BuildResponse(self._build)
+
+    @property
+    def suite(self) -> TestSuite:
+        """
+        :return: Suite the test belongs to.
+        """
+        return self._suite
+
+    @property
+    def kind(self) -> TestKind:
+        """
+        :return: Type of the test case.
+        """
+        if isinstance(self.data, TempestTest):
+            return TestKind.TEMPEST
+
+        return TestKind.UNKNOWN
+
+    @property
+    def name(self) -> str:
+        """
+        :return: Name of the test case.
+        """
+        return self.data.name
+
+    @property
+    def status(self) -> TestStatus:
+        """
+        :return: Result of the test case.
+        """
+        result = self.data.result
+
+        if result == TestResult.SUCCESS:
+            return TestStatus.SUCCESS
+
+        if result == TestResult.FAILURE:
+            return TestStatus.FAILURE
+
+        if result == TestResult.SKIPPED:
+            return TestStatus.SKIPPED
+
+        return TestStatus.UNKNOWN
+
+    @property
+    def duration(self) -> float:
+        """
+        :return: How long the test case took to complete, in seconds.
+        """
+        return self.data.duration
+
+    @property
+    def url(self) -> URL:
+        """
+        :return: URL to the source of the test case data.
+        """
+        return URL(self.data.url)
+
+    @property
+    def data(self) -> Test:
+        """
+        :return: Raw data of this test.
+        """
+        return self._test

--- a/cibyl/sources/zuul/transactions/__init__.py
+++ b/cibyl/sources/zuul/transactions/__init__.py
@@ -694,6 +694,9 @@ class BuildResponse:
         return self._build.raw
 
     def tests(self) -> TestsRequest:
+        """
+        :return: A request to this build's tests.
+        """
         return TestsRequest(self._build)
 
 

--- a/tests/cibyl/unit/sources/zuul/test_transactions.py
+++ b/tests/cibyl/unit/sources/zuul/test_transactions.py
@@ -16,6 +16,7 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
+from cibyl.cli.ranged_argument import Range
 from cibyl.models.ci.zuul.test import TestKind, TestStatus
 from cibyl.sources.zuul.transactions import TestResponse, TestsRequest
 from cibyl.sources.zuul.utils.tests.tempest.types import TempestTest
@@ -79,6 +80,34 @@ class TestTestsRequest(TestCase):
 
         self.assertEqual(1, len(result))
         self.assertEqual(status, result[0].status)
+
+    def test_with_duration(self):
+        """Checks that the request can filter tests by duration.
+        """
+        test1 = Mock()
+        test1.name = 'test1'
+        test1.duration = 10
+
+        test2 = Mock()
+        test2.name = 'test2'
+        test2.duration = 2
+
+        suite = Mock()
+        suite.tests = [test1, test2]
+
+        build = Mock()
+        build.tests = Mock()
+        build.tests.return_value = [suite]
+
+        duration = Range('>', 2)
+
+        request = TestsRequest(build)
+        request.with_duration(duration)
+
+        result = list(request.get())
+
+        self.assertEqual(1, len(result))
+        self.assertEqual(test1.name, result[0].name)
 
 
 class TestTestResponse(TestCase):

--- a/tests/cibyl/unit/sources/zuul/test_transactions.py
+++ b/tests/cibyl/unit/sources/zuul/test_transactions.py
@@ -17,13 +17,42 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from cibyl.models.ci.zuul.test import TestKind, TestStatus
-from cibyl.sources.zuul.transactions import TestResponse
+from cibyl.sources.zuul.transactions import TestResponse, TestsRequest
 from cibyl.sources.zuul.utils.tests.tempest.types import TempestTest
 from cibyl.sources.zuul.utils.tests.types import Test, TestResult
 
 
 class TestTestsRequest(TestCase):
     """Tests for :class:`TestsRequest`.
+    """
+
+    def test_with_name(self):
+        """Checks that the request can filter tests by name.
+        """
+        test1 = Mock()
+        test1.name = 'test1'
+
+        test2 = Mock()
+        test2.name = 'test2'
+
+        suite = Mock()
+        suite.tests = [test1, test2]
+
+        build = Mock()
+        build.tests = Mock()
+        build.tests.return_value = [suite]
+
+        request = TestsRequest(build)
+        request.with_name(test1.name)
+
+        result = list(request.get())
+
+        self.assertEqual(1, len(result))
+        self.assertEqual(test1, result[0].data)
+
+
+class TestTestResponse(TestCase):
+    """Tests for :class:`TestResponse`.
     """
 
     def test_kind(self):

--- a/tests/cibyl/unit/sources/zuul/test_transactions.py
+++ b/tests/cibyl/unit/sources/zuul/test_transactions.py
@@ -1,0 +1,64 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.models.ci.zuul.test import TestKind, TestStatus
+from cibyl.sources.zuul.transactions import TestResponse
+from cibyl.sources.zuul.utils.tests.tempest.types import TempestTest
+from cibyl.sources.zuul.utils.tests.types import Test, TestResult
+
+
+class TestTestsRequest(TestCase):
+    """Tests for :class:`TestsRequest`.
+    """
+
+    def test_kind(self):
+        """Checks that the correct test types are returned.
+        """
+        generic_test = Mock(spec=Test)
+        tempest_test = Mock(spec=TempestTest)
+
+        response = TestResponse(Mock(), Mock(), generic_test)
+
+        self.assertEqual(TestKind.UNKNOWN, response.kind)
+
+        response = TestResponse(Mock(), Mock(), tempest_test)
+
+        self.assertEqual(TestKind.TEMPEST, response.kind)
+
+    def test_status(self):
+        """Checks that the correct result is returned.
+        """
+        test = Mock()
+
+        response = TestResponse(Mock(), Mock(), test)
+
+        test.result = TestResult.SUCCESS
+
+        self.assertEqual(TestStatus.SUCCESS, response.status)
+
+        test.result = TestResult.FAILURE
+
+        self.assertEqual(TestStatus.FAILURE, response.status)
+
+        test.result = TestResult.SKIPPED
+
+        self.assertEqual(TestStatus.SKIPPED, response.status)
+
+        test.result = TestResult.UNKNOWN
+
+        self.assertEqual(TestStatus.UNKNOWN, response.status)

--- a/tests/cibyl/unit/sources/zuul/test_transactions.py
+++ b/tests/cibyl/unit/sources/zuul/test_transactions.py
@@ -42,13 +42,43 @@ class TestTestsRequest(TestCase):
         build.tests = Mock()
         build.tests.return_value = [suite]
 
+        name = test1.name
+
         request = TestsRequest(build)
-        request.with_name(test1.name)
+        request.with_name(name)
 
         result = list(request.get())
 
         self.assertEqual(1, len(result))
         self.assertEqual(test1, result[0].data)
+
+    def test_with_status(self):
+        """Checks that the request can filter tests by status.
+        """
+        test1 = Mock()
+        test1.name = 'test1'
+        test1.result = TestResult.SUCCESS
+
+        test2 = Mock()
+        test2.name = 'test2'
+        test2.result = TestResult.FAILURE
+
+        suite = Mock()
+        suite.tests = [test1, test2]
+
+        build = Mock()
+        build.tests = Mock()
+        build.tests.return_value = [suite]
+
+        status = TestStatus.SUCCESS
+
+        request = TestsRequest(build)
+        request.with_status(status)
+
+        result = list(request.get())
+
+        self.assertEqual(1, len(result))
+        self.assertEqual(status, result[0].status)
 
 
 class TestTestResponse(TestCase):


### PR DESCRIPTION
- Adding a transaction that allows Cibyl to fetch test cases from a Zuul build.
- The transaction allows to filter tests by:
  - Name
  - Result
  - Duration, as a range.
- The test response provides access to all the data Cibyl needs to present.
- Unit testing filtering and data processing.