### PR TITLE
Adding query composers for Zuul source

### DIFF
--- a/cibyl/sources/zuul/managers/factory.py
+++ b/cibyl/sources/zuul/managers/factory.py
@@ -1,0 +1,33 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from cibyl.sources.zuul.apis import ZuulAPI as Zuul
+from cibyl.sources.zuul.managers import SourceManager
+from cibyl.sources.zuul.managers.verbose import VerboseManager
+
+
+class SourceManagerFactory:
+    """Factory for :class:`SourceManager`.
+    """
+
+    def from_kwargs(self, api: Zuul, **kwargs) -> SourceManager:
+        """Chooses the manager type from the undefined arguments passed to
+        this.
+
+        :param api: Interface to communicate with the Zuul host.
+        :param kwargs: Arguments coming from the CLI.
+        :return: A new manager instance.
+        """
+        return VerboseManager(api)

--- a/cibyl/sources/zuul/queries/composition/__init__.py
+++ b/cibyl/sources/zuul/queries/composition/__init__.py
@@ -14,9 +14,11 @@
 #    under the License.
 """
 from abc import ABC, abstractmethod
+from typing import NamedTuple
 
 from cibyl.sources.zuul.apis import ZuulAPI as Zuul
-from cibyl.sources.zuul.output import QueryOutput, QueryOutputBuilder
+from cibyl.sources.zuul.output import QueryOutput
+from cibyl.sources.zuul.output import QueryOutputBuilder as OutputBuilder
 
 
 class AggregatedQuery(ABC):
@@ -31,13 +33,20 @@ class AggregatedQuery(ABC):
     class.
     """
 
-    def __init__(self, api: Zuul):
+    class Tools(NamedTuple):
+        """Tools used by this to perform its task.
+        """
+        builder: OutputBuilder = OutputBuilder()
+        """Tools used to generate the output of this query."""
+
+    def __init__(self, api: Zuul, tools: Tools = Tools()):
         """Constructor.
 
         :param api: Low-Level API with which to communicate with the Zuul host.
+        :param tools: Tools used by this to perform its task.
         """
         self._api = api
-        self._result = QueryOutputBuilder()
+        self._tools = tools
 
     @property
     def api(self) -> Zuul:
@@ -45,6 +54,13 @@ class AggregatedQuery(ABC):
         :return: Low-Level API with which to communicate with the Zuul host.
         """
         return self._api
+
+    @property
+    def tools(self):
+        """
+        :return: Tools used by this to perform its task.
+        """
+        return self._tools
 
     @abstractmethod
     def with_tenants_query(self, **kwargs) -> 'AggregatedQuery':
@@ -113,4 +129,4 @@ class AggregatedQuery(ABC):
         """
         :return: Result of the complex query.
         """
-        return self._result.assemble()
+        return self.tools.builder.assemble()

--- a/cibyl/sources/zuul/queries/composition/__init__.py
+++ b/cibyl/sources/zuul/queries/composition/__init__.py
@@ -1,0 +1,60 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from abc import ABC, abstractmethod
+
+from cibyl.sources.zuul.apis import ZuulAPI as Zuul
+from cibyl.sources.zuul.output import QueryOutput, QueryOutputBuilder
+
+
+class AggregatedQuery(ABC):
+    def __init__(self, api: Zuul):
+        self._api = api
+        self._result = QueryOutputBuilder()
+
+    @property
+    def api(self):
+        return self._api
+
+    @abstractmethod
+    def with_tenants_query(self, **kwargs) -> 'AggregatedQuery':
+        raise NotImplementedError
+
+    @abstractmethod
+    def with_projects_query(self, **kwargs) -> 'AggregatedQuery':
+        raise NotImplementedError
+
+    @abstractmethod
+    def with_pipelines_query(self, **kwargs) -> 'AggregatedQuery':
+        raise NotImplementedError
+
+    @abstractmethod
+    def with_jobs_query(self, **kwargs) -> 'AggregatedQuery':
+        raise NotImplementedError
+
+    @abstractmethod
+    def with_variants_query(self, **kwargs) -> 'AggregatedQuery':
+        raise NotImplementedError
+
+    @abstractmethod
+    def with_builds_query(self, **kwargs) -> 'AggregatedQuery':
+        raise NotImplementedError
+
+    @abstractmethod
+    def with_tests_query(self, **kwargs) -> 'AggregatedQuery':
+        raise NotImplementedError
+
+    def get_result(self) -> QueryOutput:
+        return self._result.assemble()

--- a/cibyl/sources/zuul/queries/composition/__init__.py
+++ b/cibyl/sources/zuul/queries/composition/__init__.py
@@ -20,41 +20,97 @@ from cibyl.sources.zuul.output import QueryOutput, QueryOutputBuilder
 
 
 class AggregatedQuery(ABC):
+    """Represents a query whose result is composed of the result of others.
+
+    When a simple query is not enough to satisfy the demands from the user,
+    this class can be used to generate a more complex response from the
+    answer of those queries. Output produced here is done from the
+    merging of the models retrieved from all the other calls. No data is
+    duplicated, but instead each new call adds up to the output. Access to
+    each of the known atomic queries is provided in the format of a builder
+    class.
+    """
+
     def __init__(self, api: Zuul):
+        """Constructor.
+
+        :param api: Low-Level API with which to communicate with the Zuul host.
+        """
         self._api = api
         self._result = QueryOutputBuilder()
 
     @property
-    def api(self):
+    def api(self) -> Zuul:
+        """
+        :return: Low-Level API with which to communicate with the Zuul host.
+        """
         return self._api
 
     @abstractmethod
     def with_tenants_query(self, **kwargs) -> 'AggregatedQuery':
+        """Calls and adds the result of the tenants' query to this.
+
+        :param kwargs: Arguments received from the command line.
+        :return: The query's instance.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def with_projects_query(self, **kwargs) -> 'AggregatedQuery':
+        """Calls and adds the result of the projects' query to this.
+
+        :param kwargs: Arguments received from the command line.
+        :return: The query's instance.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def with_pipelines_query(self, **kwargs) -> 'AggregatedQuery':
+        """Calls and adds the result of the pipelines' query to this.
+
+        :param kwargs: Arguments received from the command line.
+        :return: The query's instance.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def with_jobs_query(self, **kwargs) -> 'AggregatedQuery':
+        """Calls and adds the result of the jobs' query to this.
+
+        :param kwargs: Arguments received from the command line.
+        :return: The query's instance.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def with_variants_query(self, **kwargs) -> 'AggregatedQuery':
+        """Calls and adds the result of the variants' query to this.
+
+        :param kwargs: Arguments received from the command line.
+        :return: The query's instance.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def with_builds_query(self, **kwargs) -> 'AggregatedQuery':
+        """Calls and adds the result of the builds' query to this.
+
+        :param kwargs: Arguments received from the command line.
+        :return: The query's instance.
+        """
         raise NotImplementedError
 
     @abstractmethod
     def with_tests_query(self, **kwargs) -> 'AggregatedQuery':
+        """Calls and adds the result of the tests' query to this.
+
+        :param kwargs: Arguments received from the command line.
+        :return: The query's instance.
+        """
         raise NotImplementedError
 
     def get_result(self) -> QueryOutput:
+        """
+        :return: Result of the complex query.
+        """
         return self._result.assemble()

--- a/cibyl/sources/zuul/queries/composition/factory.py
+++ b/cibyl/sources/zuul/queries/composition/factory.py
@@ -18,5 +18,15 @@ from cibyl.sources.zuul.queries.composition.quick import QuickQuery
 
 
 class AggregatedQueryFactory:
+    """Factory for :class:`AggregatedQuery`.
+    """
+
     def from_kwargs(self, api: Zuul, **kwargs):
+        """Infers the desired query type from the undefined arguments passed
+        here.
+
+        :param api: Low-Level API with which to interact with the Zuul host.
+        :param kwargs: Random set of arguments.
+        :return: The query instance.
+        """
         return QuickQuery(api)

--- a/cibyl/sources/zuul/queries/composition/factory.py
+++ b/cibyl/sources/zuul/queries/composition/factory.py
@@ -14,20 +14,9 @@
 #    under the License.
 """
 from cibyl.sources.zuul.apis import ZuulAPI as Zuul
-from cibyl.sources.zuul.managers import SourceManager
-from cibyl.sources.zuul.managers.verbose import VerboseManager
+from cibyl.sources.zuul.queries.composition.quick import QuickQuery
 
 
-class SourceManagerFactory:
-    """Factory for :class:`SourceManager`.
-    """
-
-    def from_kwargs(self, api: Zuul, **kwargs) -> SourceManager:
-        """Chooses the manager type from the undefined arguments passed to
-        this.
-
-        :param api: Interface to communicate with the Zuul host.
-        :param kwargs: Arguments coming from the CLI.
-        :return: A new manager instance.
-        """
-        return VerboseManager(api)
+class AggregatedQueryFactory:
+    def from_kwargs(self, api: Zuul, **kwargs):
+        return QuickQuery(api)

--- a/cibyl/sources/zuul/queries/composition/quick.py
+++ b/cibyl/sources/zuul/queries/composition/quick.py
@@ -23,7 +23,6 @@ from cibyl.sources.zuul.queries.projects import perform_projects_query
 from cibyl.sources.zuul.queries.tenants import perform_tenants_query
 from cibyl.sources.zuul.queries.tests import perform_tests_query
 from cibyl.sources.zuul.queries.variants import perform_variants_query
-from cibyl.sources.zuul.transactions import PipelineResponse as Pipeline
 
 
 class QuickQuery(AggregatedQuery):
@@ -33,28 +32,28 @@ class QuickQuery(AggregatedQuery):
     @overrides
     def with_tenants_query(self, **kwargs) -> 'AggregatedQuery':
         for tenant in perform_tenants_query(self.api, **kwargs):
-            self._result.with_tenant(tenant)
+            self.tools.builder.with_tenant(tenant)
 
         return self
 
     @overrides
     def with_projects_query(self, **kwargs) -> 'AggregatedQuery':
         for project in perform_projects_query(self.api, **kwargs):
-            self._result.with_project(project)
+            self.tools.builder.with_project(project)
 
         return self
 
     @overrides
     def with_pipelines_query(self, **kwargs) -> 'AggregatedQuery':
         for pipeline in perform_pipelines_query(self.api, **kwargs):
-            self._result.with_pipeline(pipeline)
+            self.tools.builder.with_pipeline(pipeline)
 
         return self
 
     @overrides
     def with_jobs_query(self, **kwargs) -> 'AggregatedQuery':
         for job in perform_jobs_query(self.api, **kwargs):
-            self._result.with_job(job)
+            self.tools.builder.with_job(job)
 
         return self
 
@@ -62,7 +61,7 @@ class QuickQuery(AggregatedQuery):
     def with_variants_query(self, **kwargs) -> 'AggregatedQuery':
         for job in perform_jobs_query(self.api, **kwargs):
             for variant in perform_variants_query(job, **kwargs):
-                self._result.with_variant(variant)
+                self.tools.builder.with_variant(variant)
 
         return self
 
@@ -70,7 +69,7 @@ class QuickQuery(AggregatedQuery):
     def with_builds_query(self, **kwargs) -> 'AggregatedQuery':
         for job in perform_jobs_query(self.api, **kwargs):
             for build in perform_builds_query(job, **kwargs):
-                self._result.with_build(build)
+                self.tools.builder.with_build(build)
 
         return self
 
@@ -79,6 +78,6 @@ class QuickQuery(AggregatedQuery):
         for job in perform_jobs_query(self.api, **kwargs):
             for build in perform_builds_query(job, **kwargs):
                 for test in perform_tests_query(build, **kwargs):
-                    self._result.with_test(test)
+                    self.tools.builder.with_test(test)
 
         return self

--- a/cibyl/sources/zuul/queries/composition/quick.py
+++ b/cibyl/sources/zuul/queries/composition/quick.py
@@ -1,0 +1,81 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from overrides import overrides
+
+from cibyl.sources.zuul.queries.builds import perform_builds_query
+from cibyl.sources.zuul.queries.composition import AggregatedQuery
+from cibyl.sources.zuul.queries.jobs import perform_jobs_query
+from cibyl.sources.zuul.queries.pipelines import perform_pipelines_query
+from cibyl.sources.zuul.queries.projects import perform_projects_query
+from cibyl.sources.zuul.queries.tenants import perform_tenants_query
+from cibyl.sources.zuul.queries.tests import perform_tests_query
+from cibyl.sources.zuul.queries.variants import perform_variants_query
+from cibyl.sources.zuul.transactions import PipelineResponse as Pipeline
+
+
+class QuickQuery(AggregatedQuery):
+    @overrides
+    def with_tenants_query(self, **kwargs) -> 'AggregatedQuery':
+        for tenant in perform_tenants_query(self.api, **kwargs):
+            self._result.with_tenant(tenant)
+
+        return self
+
+    @overrides
+    def with_projects_query(self, **kwargs) -> 'AggregatedQuery':
+        for project in perform_projects_query(self.api, **kwargs):
+            self._result.with_project(project)
+
+        return self
+
+    @overrides
+    def with_pipelines_query(self, **kwargs) -> 'AggregatedQuery':
+        for pipeline in perform_pipelines_query(self.api, **kwargs):
+            self._result.with_pipeline(pipeline)
+
+        return self
+
+    @overrides
+    def with_jobs_query(self, **kwargs) -> 'AggregatedQuery':
+        for job in perform_jobs_query(self.api, **kwargs):
+            self._result.with_job(job)
+
+        return self
+
+    @overrides
+    def with_variants_query(self, **kwargs) -> 'AggregatedQuery':
+        for job in perform_jobs_query(self.api, **kwargs):
+            for variant in perform_variants_query(job, **kwargs):
+                self._result.with_variant(variant)
+
+        return self
+
+    @overrides
+    def with_builds_query(self, **kwargs) -> 'AggregatedQuery':
+        for job in perform_jobs_query(self.api, **kwargs):
+            for build in perform_builds_query(job, **kwargs):
+                self._result.with_build(build)
+
+        return self
+
+    @overrides
+    def with_tests_query(self, **kwargs) -> 'AggregatedQuery':
+        for job in perform_jobs_query(self.api, **kwargs):
+            for build in perform_builds_query(job, **kwargs):
+                for test in perform_tests_query(build, **kwargs):
+                    self._result.with_test(test)
+
+        return self

--- a/cibyl/sources/zuul/queries/composition/quick.py
+++ b/cibyl/sources/zuul/queries/composition/quick.py
@@ -27,6 +27,9 @@ from cibyl.sources.zuul.transactions import PipelineResponse as Pipeline
 
 
 class QuickQuery(AggregatedQuery):
+    """A kind of complex query that focuses on speed over completeness.
+    """
+
     @overrides
     def with_tenants_query(self, **kwargs) -> 'AggregatedQuery':
         for tenant in perform_tenants_query(self.api, **kwargs):

--- a/cibyl/sources/zuul/queries/composition/verbose.py
+++ b/cibyl/sources/zuul/queries/composition/verbose.py
@@ -28,6 +28,9 @@ from cibyl.sources.zuul.transactions import PipelineResponse as Pipeline
 
 
 class VerboseQuery(QuickQuery):
+    """A kind of complex query that focuses on completeness over speed.
+    """
+
     @overrides
     def with_jobs_query(self, **kwargs) -> 'AggregatedQuery':
         def is_job_in(pl: Pipeline) -> bool:

--- a/cibyl/sources/zuul/queries/composition/verbose.py
+++ b/cibyl/sources/zuul/queries/composition/verbose.py
@@ -15,15 +15,10 @@
 """
 from overrides import overrides
 
-from cibyl.sources.zuul.queries.builds import perform_builds_query
 from cibyl.sources.zuul.queries.composition import AggregatedQuery
 from cibyl.sources.zuul.queries.composition.quick import QuickQuery
 from cibyl.sources.zuul.queries.jobs import perform_jobs_query
 from cibyl.sources.zuul.queries.pipelines import perform_pipelines_query
-from cibyl.sources.zuul.queries.projects import perform_projects_query
-from cibyl.sources.zuul.queries.tenants import perform_tenants_query
-from cibyl.sources.zuul.queries.tests import perform_tests_query
-from cibyl.sources.zuul.queries.variants import perform_variants_query
 from cibyl.sources.zuul.transactions import PipelineResponse as Pipeline
 
 
@@ -40,7 +35,7 @@ class VerboseQuery(QuickQuery):
         pipelines = perform_pipelines_query(self.api, **kwargs)
 
         for job in perform_jobs_query(self.api, **kwargs):
-            model = self._result.with_job(job)
+            model = self.tools.builder.with_job(job)
 
             # Include also pipelines where the job is present
             for pipeline in pipelines:
@@ -48,6 +43,6 @@ class VerboseQuery(QuickQuery):
                     continue
 
                 # Register job as a child of the pipeline
-                self._result.with_pipeline(pipeline).add_job(model)
+                self.tools.builder.with_pipeline(pipeline).add_job(model)
 
         return self

--- a/cibyl/sources/zuul/queries/composition/verbose.py
+++ b/cibyl/sources/zuul/queries/composition/verbose.py
@@ -1,0 +1,50 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from overrides import overrides
+
+from cibyl.sources.zuul.queries.builds import perform_builds_query
+from cibyl.sources.zuul.queries.composition import AggregatedQuery
+from cibyl.sources.zuul.queries.composition.quick import QuickQuery
+from cibyl.sources.zuul.queries.jobs import perform_jobs_query
+from cibyl.sources.zuul.queries.pipelines import perform_pipelines_query
+from cibyl.sources.zuul.queries.projects import perform_projects_query
+from cibyl.sources.zuul.queries.tenants import perform_tenants_query
+from cibyl.sources.zuul.queries.tests import perform_tests_query
+from cibyl.sources.zuul.queries.variants import perform_variants_query
+from cibyl.sources.zuul.transactions import PipelineResponse as Pipeline
+
+
+class VerboseQuery(QuickQuery):
+    @overrides
+    def with_jobs_query(self, **kwargs) -> 'AggregatedQuery':
+        def is_job_in(pl: Pipeline) -> bool:
+            return job.name in [jb.name for jb in pl.jobs().get()]
+
+        # Cache pipelines for later use
+        pipelines = perform_pipelines_query(self.api, **kwargs)
+
+        for job in perform_jobs_query(self.api, **kwargs):
+            model = self._result.with_job(job)
+
+            # Include also pipelines where the job is present
+            for pipeline in pipelines:
+                if not is_job_in(pipeline):
+                    continue
+
+                # Register job as a child of the pipeline
+                self._result.with_pipeline(pipeline).add_job(model)
+
+        return self

--- a/tests/cibyl/unit/sources/zuul/queries/composition/__init__.py
+++ b/tests/cibyl/unit/sources/zuul/queries/composition/__init__.py
@@ -1,0 +1,15 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""

--- a/tests/cibyl/unit/sources/zuul/queries/composition/test_quick.py
+++ b/tests/cibyl/unit/sources/zuul/queries/composition/test_quick.py
@@ -188,7 +188,7 @@ class TestQuickQuery(TestCase):
     @patch(f'{pkg}.perform_tests_query')
     @patch(f'{pkg}.perform_builds_query')
     @patch(f'{pkg}.perform_jobs_query')
-    def test_gets_builds(self, jobs: Mock, builds: Mock, tests: Mock):
+    def test_gets_tests(self, jobs: Mock, builds: Mock, tests: Mock):
         """Checks that the simple queries are made in order to aggregate
         builds.
         """

--- a/tests/cibyl/unit/sources/zuul/queries/composition/test_quick.py
+++ b/tests/cibyl/unit/sources/zuul/queries/composition/test_quick.py
@@ -1,0 +1,220 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from cibyl.sources.zuul.queries.composition.quick import QuickQuery
+
+pkg = 'cibyl.sources.zuul.queries.composition.quick'
+
+
+class TestQuickQuery(TestCase):
+    """Tests for :class:`QuickQuery`.
+    """
+
+    @patch(f'{pkg}.perform_tenants_query')
+    def test_gets_tenants(self, tenants: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        tenants.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        tenant = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_tenant = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        tenants.return_value = [tenant]
+
+        query = QuickQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_tenants_query(**kwargs))
+
+        tenants.assert_called_once_with(api, **kwargs)
+        builder.with_tenant.assert_called_once_with(tenant)
+
+    @patch(f'{pkg}.perform_projects_query')
+    def test_gets_projects(self, projects: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        projects.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        tenant = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_project = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        projects.return_value = [tenant]
+
+        query = QuickQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_projects_query(**kwargs))
+
+        projects.assert_called_once_with(api, **kwargs)
+        builder.with_project.assert_called_once_with(tenant)
+
+    @patch(f'{pkg}.perform_pipelines_query')
+    def test_gets_pipelines(self, pipelines: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        pipelines.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        pipeline = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_pipeline = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        pipelines.return_value = [pipeline]
+
+        query = QuickQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_pipelines_query(**kwargs))
+
+        pipelines.assert_called_once_with(api, **kwargs)
+        builder.with_pipeline.assert_called_once_with(pipeline)
+
+    @patch(f'{pkg}.perform_jobs_query')
+    def test_gets_jobs(self, jobs: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        jobs.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        job = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_job = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        jobs.return_value = [job]
+
+        query = QuickQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_jobs_query(**kwargs))
+
+        jobs.assert_called_once_with(api, **kwargs)
+        builder.with_job.assert_called_once_with(job)
+
+    @patch(f'{pkg}.perform_variants_query')
+    @patch(f'{pkg}.perform_jobs_query')
+    def test_gets_variants(self, jobs: Mock, variants: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        variants.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        job = Mock()
+        variant = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_variant = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        jobs.return_value = [job]
+        variants.return_value = [variant]
+
+        query = QuickQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_variants_query(**kwargs))
+
+        jobs.assert_called_once_with(api, **kwargs)
+        variants.assert_called_once_with(job, **kwargs)
+
+        builder.with_variant.assert_called_once_with(variant)
+
+    @patch(f'{pkg}.perform_builds_query')
+    @patch(f'{pkg}.perform_jobs_query')
+    def test_gets_builds(self, jobs: Mock, builds: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        builds.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        job = Mock()
+        build = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_build = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        jobs.return_value = [job]
+        builds.return_value = [build]
+
+        query = QuickQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_builds_query(**kwargs))
+
+        jobs.assert_called_once_with(api, **kwargs)
+        builds.assert_called_once_with(job, **kwargs)
+
+        builder.with_build.assert_called_once_with(build)
+
+    @patch(f'{pkg}.perform_tests_query')
+    @patch(f'{pkg}.perform_builds_query')
+    @patch(f'{pkg}.perform_jobs_query')
+    def test_gets_builds(self, jobs: Mock, builds: Mock, tests: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        builds.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        job = Mock()
+        build = Mock()
+        test = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_test = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        jobs.return_value = [job]
+        builds.return_value = [build]
+        tests.return_value = [test]
+
+        query = QuickQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_tests_query(**kwargs))
+
+        jobs.assert_called_once_with(api, **kwargs)
+        builds.assert_called_once_with(job, **kwargs)
+        tests.assert_called_once_with(build, **kwargs)
+
+        builder.with_test.assert_called_once_with(test)

--- a/tests/cibyl/unit/sources/zuul/queries/composition/test_verbose.py
+++ b/tests/cibyl/unit/sources/zuul/queries/composition/test_verbose.py
@@ -1,0 +1,243 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from cibyl.sources.zuul.queries.composition.verbose import VerboseQuery
+
+pkg = 'cibyl.sources.zuul.queries.composition'
+
+
+class TestVerboseQuery(TestCase):
+    """Tests for :class:`VerboseQuery`.
+    """
+
+    @patch(f'{pkg}.quick.perform_tenants_query')
+    def test_gets_tenants(self, tenants: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        tenants.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        tenant = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_tenant = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        tenants.return_value = [tenant]
+
+        query = VerboseQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_tenants_query(**kwargs))
+
+        tenants.assert_called_once_with(api, **kwargs)
+        builder.with_tenant.assert_called_once_with(tenant)
+
+    @patch(f'{pkg}.quick.perform_projects_query')
+    def test_gets_projects(self, projects: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        projects.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        tenant = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_project = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        projects.return_value = [tenant]
+
+        query = VerboseQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_projects_query(**kwargs))
+
+        projects.assert_called_once_with(api, **kwargs)
+        builder.with_project.assert_called_once_with(tenant)
+
+    @patch(f'{pkg}.quick.perform_pipelines_query')
+    def test_gets_pipelines(self, pipelines: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        pipelines.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        pipeline = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_pipeline = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        pipelines.return_value = [pipeline]
+
+        query = VerboseQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_pipelines_query(**kwargs))
+
+        pipelines.assert_called_once_with(api, **kwargs)
+        builder.with_pipeline.assert_called_once_with(pipeline)
+
+    @patch(f'{pkg}.verbose.perform_jobs_query')
+    @patch(f'{pkg}.verbose.perform_pipelines_query')
+    def test_gets_jobs(self, pipelines: Mock, jobs: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        jobs.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        name = 'job'
+
+        job = Mock()
+        job.name = name
+
+        pipeline = Mock()
+        pipeline.jobs = Mock()
+        pipeline.jobs.return_value = Mock()
+        pipeline.jobs.return_value.get = Mock()
+        pipeline.jobs.return_value.get.return_value = [job]
+
+        pl_model = Mock()
+        pl_model.add_job = Mock()
+        job_model = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_pipeline = Mock()
+        builder.with_pipeline.return_value = pl_model
+        builder.with_job = Mock()
+        builder.with_job.return_value = job_model
+
+        tools = Mock()
+        tools.builder = builder
+
+        pipelines.return_value = [pipeline]
+        jobs.return_value = [job]
+
+        query = VerboseQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_jobs_query(**kwargs))
+
+        pipelines.assert_called_once_with(api, **kwargs)
+        jobs.assert_called_once_with(api, **kwargs)
+
+        builder.with_pipeline.assert_called_once_with(pipeline)
+        builder.with_job.assert_called_once_with(job)
+
+        pl_model.add_job.assert_called_once_with(job_model)
+
+    @patch(f'{pkg}.quick.perform_variants_query')
+    @patch(f'{pkg}.quick.perform_jobs_query')
+    def test_gets_variants(self, jobs: Mock, variants: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        variants.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        job = Mock()
+        variant = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_variant = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        jobs.return_value = [job]
+        variants.return_value = [variant]
+
+        query = VerboseQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_variants_query(**kwargs))
+
+        jobs.assert_called_once_with(api, **kwargs)
+        variants.assert_called_once_with(job, **kwargs)
+
+        builder.with_variant.assert_called_once_with(variant)
+
+    @patch(f'{pkg}.quick.perform_builds_query')
+    @patch(f'{pkg}.quick.perform_jobs_query')
+    def test_gets_builds(self, jobs: Mock, builds: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        builds.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        job = Mock()
+        build = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_build = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        jobs.return_value = [job]
+        builds.return_value = [build]
+
+        query = VerboseQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_builds_query(**kwargs))
+
+        jobs.assert_called_once_with(api, **kwargs)
+        builds.assert_called_once_with(job, **kwargs)
+
+        builder.with_build.assert_called_once_with(build)
+
+    @patch(f'{pkg}.quick.perform_tests_query')
+    @patch(f'{pkg}.quick.perform_builds_query')
+    @patch(f'{pkg}.quick.perform_jobs_query')
+    def test_gets_builds(self, jobs: Mock, builds: Mock, tests: Mock):
+        """Checks that the simple queries are made in order to aggregate
+        builds.
+        """
+        kwargs = {'arg1': 'val1'}
+
+        job = Mock()
+        build = Mock()
+        test = Mock()
+
+        api = Mock()
+        builder = Mock()
+        builder.with_test = Mock()
+
+        tools = Mock()
+        tools.builder = builder
+
+        jobs.return_value = [job]
+        builds.return_value = [build]
+        tests.return_value = [test]
+
+        query = VerboseQuery(api=api, tools=tools)
+
+        self.assertEqual(query, query.with_tests_query(**kwargs))
+
+        jobs.assert_called_once_with(api, **kwargs)
+        builds.assert_called_once_with(job, **kwargs)
+        tests.assert_called_once_with(build, **kwargs)
+
+        builder.with_test.assert_called_once_with(test)

--- a/tests/cibyl/unit/sources/zuul/queries/composition/test_verbose.py
+++ b/tests/cibyl/unit/sources/zuul/queries/composition/test_verbose.py
@@ -211,7 +211,7 @@ class TestVerboseQuery(TestCase):
     @patch(f'{pkg}.quick.perform_tests_query')
     @patch(f'{pkg}.quick.perform_builds_query')
     @patch(f'{pkg}.quick.perform_jobs_query')
-    def test_gets_builds(self, jobs: Mock, builds: Mock, tests: Mock):
+    def test_gets_tests(self, jobs: Mock, builds: Mock, tests: Mock):
         """Checks that the simple queries are made in order to aggregate
         builds.
         """


### PR DESCRIPTION
Query composers allow to generate more complex outputs from simple queries. For examples: --tenants --jobs will result in the aggregation of two atomic queries: --tenants and --jobs.

This PR adds the skeleton for these composers and two implementations: Quick and Verbose. Quick is meant cut to the chase and reduce queries to maximum while verbose will take its time and make all it needs to get as much data on the elements as possible.