### PR TITLE
Fix bug query for ip_version in Jenkins

### DIFF
--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -473,7 +473,7 @@ accurate results", len(jobs_found))
             if "network_backend" in kwargs or spec:
                 job["network_backend"] = network.get("backend", "")
             ip_string = network.get("protocol", "")
-            if "network_backend" in kwargs or spec:
+            if "ip_version" in kwargs or spec:
                 job["ip_version"] = detect_job_info_regex(ip_string,
                                                           IP_PATTERN,
                                                           group_index=1,


### PR DESCRIPTION
Jenkins source was using the 'network_backend' to choose whether to show
ip_version. This bug slipped because it reads the job name as fallback
and most jobs have the ip version in the name.
