### PR TITLE
Filter by release using regex in Jenkins

### DIFF
--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -46,7 +46,7 @@ from cibyl.utils.filtering import (CINDER_BACKEND_PATTERN, DEPLOYMENT_PATTERN,
                                    SERVICES_PATTERN, TOPOLOGY_PATTERN,
                                    apply_filters, filter_topology,
                                    satisfy_case_insensitive_match,
-                                   satisfy_exact_match)
+                                   satisfy_exact_match, satisfy_regex_match)
 
 # shorthand for the type that will hold the job information obtained from the
 # Jenkins API response
@@ -312,6 +312,13 @@ accurate results", len(jobs_found))
                                        user_input=input_attr,
                                        field_to_check=attribute,
                                        default_user_value=['True']))
+                continue
+            if attribute in ('release') and input_attr:
+                for pattern_str in input_attr.value:
+                    pattern = re.compile(pattern_str)
+                    checks_to_apply.append(partial(satisfy_regex_match,
+                                                   pattern=pattern,
+                                                   field_to_check=attribute))
                 continue
             if attribute == 'test_setup' and input_attr:
                 checks_to_apply.append(partial(filter_test_collection,

--- a/tests/cibyl/unit/plugins/openstack/sources/test_jenkins.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/test_jenkins.py
@@ -695,7 +695,7 @@ tripleo_ironic_conductor.service loaded    active     running
         self.jenkins.send_request = Mock(side_effect=[response])
 
         args = {
-            "release": Argument("release", str, "", value=["17.3"])
+            "release": Argument("release", str, "", value=["17"])
         }
         jobs = self.jenkins.get_deployment(**args)
         self.assertEqual(len(jobs), 1)


### PR DESCRIPTION
The jenkins extension from the openstack plugin was filtering using the
release version using an exact match, instead of regex. So running
a query with '--release 16' would only return jobs using osp 16, not OSP
16.1 or 16.2.
