### PR TITLE
Adding OpenStack deployment as part of the JSON output

### DIFF
--- a/cibyl/models/model.py
+++ b/cibyl/models/model.py
@@ -32,7 +32,10 @@ class ModelMeta(type):
 
 
 class Model(metaclass=ModelMeta):
-    """Represents a base class inherited by CI and product models."""
+    """Represents a base class inherited by CI and product models.
+
+    @DynamicAttrs: Contains attributes added on runtime.
+    """
 
     def __init__(self, attributes):
         for attribute_name, attribute_dict in self.API.items():

--- a/cibyl/outputs/cli/ci/env/factory.py
+++ b/cibyl/outputs/cli/ci/env/factory.py
@@ -16,7 +16,7 @@
 from cibyl.cli.output import OutputStyle
 from cibyl.cli.query import QueryType
 from cibyl.outputs.cli.ci.env.impl.colored import CIColoredPrinter
-from cibyl.outputs.cli.ci.env.impl.serialized import JSONPrinter
+from cibyl.outputs.cli.ci.env.impl.serialized import CIJSONPrinter
 from cibyl.outputs.cli.ci.env.printer import CIPrinter
 from cibyl.utils.colors import ClearText
 
@@ -51,7 +51,7 @@ class CIPrinterFactory:
             )
 
         if style == OutputStyle.JSON:
-            return JSONPrinter(
+            return CIJSONPrinter(
                 query=query,
                 verbosity=verbosity
             )

--- a/cibyl/outputs/cli/ci/env/impl/serialized.py
+++ b/cibyl/outputs/cli/ci/env/impl/serialized.py
@@ -16,7 +16,7 @@
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Callable, Union
+from typing import Callable, Union, NamedTuple
 
 from overrides import overrides
 
@@ -87,6 +87,10 @@ class JSONPrinter(SerializedDataPrinter):
     """Serializer that prints a CI hierarchy in JSON format.
     """
 
+    class Config(NamedTuple):
+        indentation: int
+        verbosity: int
+
     def __init__(self,
                  query: QueryType = QueryType.NONE,
                  verbosity: int = 0,
@@ -104,6 +108,13 @@ class JSONPrinter(SerializedDataPrinter):
         )
 
         self._indentation = indentation
+
+    @property
+    def config(self) -> Config:
+        return JSONPrinter.Config(
+            indentation=self.indentation,
+            verbosity=self.verbosity
+        )
 
     @property
     def indentation(self) -> int:

--- a/cibyl/outputs/cli/ci/env/impl/serialized.py
+++ b/cibyl/outputs/cli/ci/env/impl/serialized.py
@@ -66,7 +66,7 @@ class CISerializedPrinter(SerializedPrinter, CIPrinter, ABC):
         raise NotImplementedError
 
 
-class JSONPrinter(CISerializedPrinter):
+class CIJSONPrinter(CISerializedPrinter):
     """Serializer that prints a CI hierarchy in JSON format.
     """
 
@@ -94,7 +94,7 @@ class JSONPrinter(CISerializedPrinter):
 
     @property
     def config(self) -> Config:
-        return JSONPrinter.Config(
+        return CIJSONPrinter.Config(
             indentation=self.indentation,
             verbosity=self.verbosity
         )

--- a/cibyl/outputs/cli/ci/env/impl/serialized.py
+++ b/cibyl/outputs/cli/ci/env/impl/serialized.py
@@ -72,7 +72,9 @@ class CIJSONPrinter(JSONPrinter, CISerializedPrinter):
             # Check specialized printers
             if isinstance(system, JobsSystem):
                 return JSONJobsSystemPrinter(
-                    self.query, self.verbosity, self.indentation
+                    query=self.query,
+                    verbosity=self.verbosity,
+                    indentation=self.indentation
                 )
 
             LOG.warning(
@@ -82,7 +84,9 @@ class CIJSONPrinter(JSONPrinter, CISerializedPrinter):
             )
 
             return JSONBaseSystemPrinter(
-                self.query, self.verbosity, self.indentation
+                query=self.query,
+                verbosity=self.verbosity,
+                indentation=self.indentation
             )
 
         return get_printer().print_system(system)

--- a/cibyl/outputs/cli/ci/env/impl/serialized.py
+++ b/cibyl/outputs/cli/ci/env/impl/serialized.py
@@ -16,7 +16,8 @@
 import json
 import logging
 from abc import ABC, abstractmethod
-from typing import Callable, Union, NamedTuple
+from dataclasses import dataclass
+from typing import Union
 
 from overrides import overrides
 
@@ -28,33 +29,15 @@ from cibyl.outputs.cli.ci.system.impls.base.serialized import \
     JSONBaseSystemPrinter
 from cibyl.outputs.cli.ci.system.impls.jobs.serialized import \
     JSONJobsSystemPrinter
+from cibyl.outputs.cli.printer import SerializedPrinter
 
 LOG = logging.getLogger(__name__)
 
 
-class SerializedDataPrinter(CIPrinter, ABC):
+class CISerializedPrinter(SerializedPrinter, CIPrinter, ABC):
     """Base class for printers that print a CI hierarchy in a format
     readable for machines, like JSON or YAML.
     """
-
-    def __init__(self,
-                 load_function: Callable[[str], dict],
-                 dump_function: Callable[[dict], str],
-                 query: QueryType = QueryType.NONE,
-                 verbosity: int = 0):
-        """Constructor. See parent for more information.
-
-        :param load_function: Function that transforms machine-readable text
-            into a Python structure. Used to unmarshall output of sub-parts
-            of the module.
-        :param dump_function: Function that transforms a Python structure into
-            machine-readable text. Used to marshall the data from the
-            hierarchy.
-        """
-        super().__init__(query, verbosity)
-
-        self._load = load_function
-        self._dump = dump_function
 
     @overrides
     def print_environment(self, env: Environment) -> str:
@@ -83,13 +66,13 @@ class SerializedDataPrinter(CIPrinter, ABC):
         raise NotImplementedError
 
 
-class JSONPrinter(SerializedDataPrinter):
+class JSONPrinter(CISerializedPrinter):
     """Serializer that prints a CI hierarchy in JSON format.
     """
 
-    class Config(NamedTuple):
+    @dataclass
+    class Config(SerializedPrinter.Config):
         indentation: int
-        verbosity: int
 
     def __init__(self,
                  query: QueryType = QueryType.NONE,

--- a/cibyl/outputs/cli/ci/env/impl/serialized.py
+++ b/cibyl/outputs/cli/ci/env/impl/serialized.py
@@ -42,7 +42,7 @@ class CISerializedPrinter(CIPrinter, SerializedPrinter, ABC):
 
             for system in env.systems:
                 key = system.name.value
-                systems[key] = self._load(self.print_system(system))
+                systems[key] = self.provider.load(self.print_system(system))
 
             return systems
 
@@ -51,7 +51,7 @@ class CISerializedPrinter(CIPrinter, SerializedPrinter, ABC):
             'systems': get_systems()
         }
 
-        return self._dump(result)
+        return self.provider.dump(result)
 
     @abstractmethod
     def print_system(self, system: System) -> str:

--- a/cibyl/outputs/cli/ci/env/impl/serialized.py
+++ b/cibyl/outputs/cli/ci/env/impl/serialized.py
@@ -25,7 +25,7 @@ from cibyl.outputs.cli.ci.system.impls.base.serialized import \
     JSONBaseSystemPrinter
 from cibyl.outputs.cli.ci.system.impls.jobs.serialized import \
     JSONJobsSystemPrinter
-from cibyl.outputs.cli.printer import SerializedPrinter, JSONPrinter
+from cibyl.outputs.cli.printer import JSONPrinter, SerializedPrinter
 
 LOG = logging.getLogger(__name__)
 

--- a/cibyl/outputs/cli/ci/system/common/models.py
+++ b/cibyl/outputs/cli/ci/system/common/models.py
@@ -20,7 +20,7 @@ from cibyl.cli.output import OutputStyle
 from cibyl.models.attribute import (AttributeDictValue, AttributeListValue,
                                     AttributeValue)
 from cibyl.models.model import Model
-from cibyl.outputs.cli.printer import ColoredPrinter, SerializedPrinter
+from cibyl.outputs.cli.printer import ColoredPrinter, JSONPrinter
 from cibyl.utils.strings import IndentedTextBuilder
 
 LOG = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ def has_plugin_section(model: Model) -> bool:
 def get_plugin_section(
     style: OutputStyle,
     model: Model,
-    reference: Union[ColoredPrinter, SerializedPrinter]
+    reference: Union[ColoredPrinter, JSONPrinter]
 ) -> str:
     """Gets the text describing the plugins that affect a model.
 

--- a/cibyl/outputs/cli/ci/system/common/models.py
+++ b/cibyl/outputs/cli/ci/system/common/models.py
@@ -97,8 +97,7 @@ def get_plugin_section(
             for value in values:
                 data = printer.as_text(value, config=reference.config)
 
-                result.add(reference.palette.blue(f"{plugin['name']}: "), 0)
-                result.add(f"{data}", 1)
+                result.add(f"{data}", 0)
 
             return result.build()
 

--- a/cibyl/outputs/cli/ci/system/impls/base/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/serialized.py
@@ -13,9 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-import json
 from abc import ABC
-from typing import Callable, Union
+from typing import Callable
 
 from overrides import overrides
 
@@ -23,9 +22,10 @@ from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.system import System
 from cibyl.models.product.feature import Feature
 from cibyl.outputs.cli.ci.system.printer import CISystemPrinter
+from cibyl.outputs.cli.printer import SerializedPrinter, JSONPrinter
 
 
-class SerializedBaseSystemPrinter(CISystemPrinter, ABC):
+class SerializedBaseSystemPrinter(CISystemPrinter, SerializedPrinter, ABC):
     """Default system printer for all serializer implementations.
     """
 
@@ -81,37 +81,6 @@ class SerializedBaseSystemPrinter(CISystemPrinter, ABC):
         return self._dump(result)
 
 
-class JSONBaseSystemPrinter(SerializedBaseSystemPrinter):
+class JSONBaseSystemPrinter(JSONPrinter, SerializedBaseSystemPrinter):
     """Basic system printer that will output a system's data in JSON format.
     """
-
-    def __init__(self,
-                 query: QueryType = QueryType.NONE,
-                 verbosity: int = 0,
-                 indentation: int = 4):
-        """Constructor. See parent for more information.
-
-        :param indentation: Number of spaces indenting each level of the
-            JSON output.
-        """
-        super().__init__(
-            load_function=self._from_json,
-            dump_function=self._to_json,
-            query=query,
-            verbosity=verbosity
-        )
-
-        self._indentation = indentation
-
-    @property
-    def indentation(self) -> int:
-        """
-        :return: Number of spaces preceding every level of the JSON output.
-        """
-        return self._indentation
-
-    def _from_json(self, obj: Union[str, bytes, bytearray]) -> dict:
-        return json.loads(obj)
-
-    def _to_json(self, obj: object) -> str:
-        return json.dumps(obj, indent=self._indentation)

--- a/cibyl/outputs/cli/ci/system/impls/base/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/serialized.py
@@ -21,7 +21,7 @@ from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.system import System
 from cibyl.models.product.feature import Feature
 from cibyl.outputs.cli.ci.system.printer import CISystemPrinter
-from cibyl.outputs.cli.printer import SerializedPrinter, JSONPrinter
+from cibyl.outputs.cli.printer import JSONPrinter, SerializedPrinter
 
 
 class SerializedBaseSystemPrinter(CISystemPrinter, SerializedPrinter, ABC):

--- a/cibyl/outputs/cli/ci/system/impls/base/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/serialized.py
@@ -14,7 +14,6 @@
 #    under the License.
 """
 from abc import ABC
-from typing import Callable
 
 from overrides import overrides
 
@@ -41,12 +40,12 @@ class SerializedBaseSystemPrinter(CISystemPrinter, SerializedPrinter, ABC):
 
             for feature in system.features.values():
                 result['features'].append(
-                    self._load(
+                    self.provider.load(
                         self.print_feature(feature)
                     )
                 )
 
-        return self._dump(result)
+        return self.provider.dump(result)
 
     def print_feature(self, feature: Feature) -> str:
         """Print a feature present in a system.
@@ -59,7 +58,7 @@ class SerializedBaseSystemPrinter(CISystemPrinter, SerializedPrinter, ABC):
             'present': feature.present.value
         }
 
-        return self._dump(result)
+        return self.provider.dump(result)
 
 
 class JSONBaseSystemPrinter(JSONPrinter, SerializedBaseSystemPrinter):

--- a/cibyl/outputs/cli/ci/system/impls/base/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/serialized.py
@@ -29,25 +29,6 @@ class SerializedBaseSystemPrinter(CISystemPrinter, SerializedPrinter, ABC):
     """Default system printer for all serializer implementations.
     """
 
-    def __init__(self,
-                 load_function: Callable[[str], dict],
-                 dump_function: Callable[[dict], str],
-                 query: QueryType = QueryType.NONE,
-                 verbosity: int = 0):
-        """Constructor. See parent for more information.
-
-        :param load_function: Function that transforms machine-readable text
-            into a Python structure. Used to unmarshall output of sub-parts
-            of the module.
-        :param dump_function: Function that transforms a Python structure into
-            machine-readable text. Used to marshall the data from the
-            hierarchy.
-        """
-        super().__init__(query, verbosity)
-
-        self._load = load_function
-        self._dump = dump_function
-
     @overrides
     def print_system(self, system: System) -> str:
         result = {

--- a/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
@@ -15,6 +15,7 @@
 """
 from overrides import overrides
 
+from cibyl.cli.output import OutputStyle
 from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.build import Build
 from cibyl.models.ci.base.job import Job
@@ -86,7 +87,7 @@ class ColoredJobsSystemPrinter(ColoredBaseSystemPrinter):
                 printer.add(self.palette.red(msg), 1)
 
         if has_plugin_section(job):
-            printer.add(get_plugin_section(self, job), 1)
+            printer.add(get_plugin_section(OutputStyle.TEXT, job, self), 1)
 
         return printer.build()
 

--- a/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
@@ -13,9 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-import json
 from abc import ABC
-from typing import Union
 
 from overrides import overrides
 
@@ -26,6 +24,7 @@ from cibyl.models.ci.base.stage import Stage
 from cibyl.models.ci.base.system import System
 from cibyl.outputs.cli.ci.system.impls.base.serialized import \
     SerializedBaseSystemPrinter
+from cibyl.outputs.cli.printer import JSONPrinter
 
 
 class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
@@ -115,37 +114,6 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
         return self._dump(result)
 
 
-class JSONJobsSystemPrinter(SerializedJobsSystemPrinter):
+class JSONJobsSystemPrinter(JSONPrinter, SerializedJobsSystemPrinter):
     """Printer that will output Jenkins systems in JSON format.
     """
-
-    def __init__(self,
-                 query: QueryType = QueryType.NONE,
-                 verbosity: int = 0,
-                 indentation: int = 4):
-        """Constructor. See parent for more information.
-
-        :param indentation: Number of spaces indenting each level of the
-            JSON output.
-        """
-        super().__init__(
-            load_function=self._from_json,
-            dump_function=self._to_json,
-            query=query,
-            verbosity=verbosity
-        )
-
-        self._indentation = indentation
-
-    @property
-    def indentation(self) -> int:
-        """
-        :return: Number of spaces preceding every level of the JSON output.
-        """
-        return self._indentation
-
-    def _from_json(self, obj: Union[str, bytes, bytearray]) -> dict:
-        return json.loads(obj)
-
-    def _to_json(self, obj: object) -> str:
-        return json.dumps(obj, indent=self._indentation)

--- a/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
@@ -38,15 +38,19 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
     @overrides
     def print_system(self, system: System) -> str:
         # Build on top of the base answer
-        result = self._load(super().print_system(system))
+        result = self.provider.load(super().print_system(system))
 
         if self.query != QueryType.NONE:
             result['jobs'] = []
 
             for job in system.jobs.values():
-                result['jobs'].append(self._load(self.print_job(job)))
+                result['jobs'].append(
+                    self.provider.load(
+                        self.print_job(job)
+                    )
+                )
 
-        return self._dump(result)
+        return self.provider.dump(result)
 
     def print_job(self, job: Job) -> str:
         """
@@ -58,15 +62,19 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
         }
 
         if self.query in (QueryType.FEATURES_JOBS, QueryType.FEATURES):
-            return self._dump(result)
+            return self.provider.dump(result)
 
         if self.query >= QueryType.BUILDS:
             result['builds'] = []
 
             for build in job.builds.values():
-                result['builds'].append(self._load(self.print_build(build)))
+                result['builds'].append(
+                    self.provider.load(
+                        self.print_build(build)
+                    )
+                )
 
-        return self._dump(result)
+        return self.provider.dump(result)
 
     def print_build(self, build: Build) -> str:
         """
@@ -82,12 +90,20 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
         }
 
         for test in build.tests.values():
-            result['tests'].append(self._load(self.print_test(test)))
+            result['tests'].append(
+                self.provider.load(
+                    self.print_test(test)
+                )
+            )
 
         for stage in build.stages:
-            result['stages'].append(self._load(self.print_stage(stage)))
+            result['stages'].append(
+                self.provider.load(
+                    self.print_stage(stage)
+                )
+            )
 
-        return self._dump(result)
+        return self.provider.dump(result)
 
     def print_test(self, test: Test) -> str:
         """
@@ -101,7 +117,7 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
             'duration': test.duration.value
         }
 
-        return self._dump(result)
+        return self.provider.dump(result)
 
     def print_stage(self, stage: Stage) -> str:
         """
@@ -114,7 +130,7 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
             'duration': stage.duration.value
         }
 
-        return self._dump(result)
+        return self.provider.dump(result)
 
 
 class JSONJobsSystemPrinter(JSONPrinter, SerializedJobsSystemPrinter):
@@ -123,10 +139,10 @@ class JSONJobsSystemPrinter(JSONPrinter, SerializedJobsSystemPrinter):
 
     @overrides
     def print_job(self, job: Job) -> str:
-        result = self._load(super().print_job(job))
+        result = self.provider.load(super().print_job(job))
 
         if has_plugin_section(job):
-            section = self._load(
+            section = self.provider.load(
                 get_plugin_section(
                     style=OutputStyle.JSON,
                     model=job,
@@ -136,4 +152,4 @@ class JSONJobsSystemPrinter(JSONPrinter, SerializedJobsSystemPrinter):
 
             result['plugins'] = section
 
-        return self._dump(result)
+        return self.provider.dump(result)

--- a/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
@@ -23,8 +23,8 @@ from cibyl.models.ci.base.build import Build, Test
 from cibyl.models.ci.base.job import Job
 from cibyl.models.ci.base.stage import Stage
 from cibyl.models.ci.base.system import System
-from cibyl.outputs.cli.ci.system.common.models import has_plugin_section, \
-    get_plugin_section
+from cibyl.outputs.cli.ci.system.common.models import (get_plugin_section,
+                                                       has_plugin_section)
 from cibyl.outputs.cli.ci.system.impls.base.serialized import \
     SerializedBaseSystemPrinter
 from cibyl.outputs.cli.printer import JSONPrinter

--- a/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
@@ -17,11 +17,14 @@ from abc import ABC
 
 from overrides import overrides
 
+from cibyl.cli.output import OutputStyle
 from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.build import Build, Test
 from cibyl.models.ci.base.job import Job
 from cibyl.models.ci.base.stage import Stage
 from cibyl.models.ci.base.system import System
+from cibyl.outputs.cli.ci.system.common.models import has_plugin_section, \
+    get_plugin_section
 from cibyl.outputs.cli.ci.system.impls.base.serialized import \
     SerializedBaseSystemPrinter
 from cibyl.outputs.cli.printer import JSONPrinter
@@ -117,3 +120,20 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter, ABC):
 class JSONJobsSystemPrinter(JSONPrinter, SerializedJobsSystemPrinter):
     """Printer that will output Jenkins systems in JSON format.
     """
+
+    @overrides
+    def print_job(self, job: Job) -> str:
+        result = self._load(super().print_job(job))
+
+        if has_plugin_section(job):
+            section = self._load(
+                get_plugin_section(
+                    style=OutputStyle.JSON,
+                    model=job,
+                    reference=self
+                )
+            )
+
+            result['plugins'] = section
+
+        return self._dump(result)

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -17,6 +17,7 @@ import logging
 
 from overrides import overrides
 
+from cibyl.cli.output import OutputStyle
 from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.build import Build
 from cibyl.models.ci.base.system import System
@@ -191,7 +192,10 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
                 result[-1].append(value)
 
             if has_plugin_section(variant):
-                result.add(get_plugin_section(self, variant), 1)
+                result.add(
+                    text=get_plugin_section(OutputStyle.TEXT, variant, self),
+                    level=1
+                )
 
             return result.build()
 

--- a/cibyl/outputs/cli/printer.py
+++ b/cibyl/outputs/cli/printer.py
@@ -16,7 +16,7 @@
 import json
 from abc import ABC
 from dataclasses import dataclass
-from typing import Callable, NamedTuple, Union
+from typing import Callable, NamedTuple
 
 from cibyl.cli.query import QueryType
 from cibyl.utils.colors import ColorPalette, DefaultPalette

--- a/cibyl/outputs/cli/printer.py
+++ b/cibyl/outputs/cli/printer.py
@@ -60,9 +60,14 @@ class ColoredPrinter(Printer, ABC):
     """
 
     class Config(NamedTuple):
+        """Parameters that define the behaviour of the printer.
+        """
         query: QueryType
+        """The type of query is gets to print."""
         palette: ColorPalette
+        """Colors this will paint the output with."""
         verbosity: int
+        """Verbosity level of the output."""
 
     def __init__(self,
                  query: QueryType = QueryType.NONE,
@@ -80,6 +85,9 @@ class ColoredPrinter(Printer, ABC):
 
     @property
     def config(self) -> Config:
+        """
+        :return: Configuration for this printer.
+        """
         return ColoredPrinter.Config(
             query=self.query,
             palette=self.palette,

--- a/cibyl/outputs/cli/printer.py
+++ b/cibyl/outputs/cli/printer.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 from abc import ABC
+from typing import NamedTuple
 
 from cibyl.cli.query import QueryType
 from cibyl.utils.colors import ColorPalette, DefaultPalette
@@ -56,6 +57,10 @@ class ColoredPrinter(Printer, ABC):
     """Base class for output styles based around coloring.
     """
 
+    class Config(NamedTuple):
+        palette: ColorPalette
+        verbosity: int
+
     def __init__(self,
                  query: QueryType = QueryType.NONE,
                  verbosity: int = 0,
@@ -69,6 +74,13 @@ class ColoredPrinter(Printer, ABC):
         super().__init__(query, verbosity)
 
         self._palette = palette
+
+    @property
+    def config(self) -> Config:
+        return ColoredPrinter.Config(
+            palette=self.palette,
+            verbosity=self.verbosity
+        )
 
     @property
     def palette(self) -> ColorPalette:

--- a/cibyl/outputs/cli/printer.py
+++ b/cibyl/outputs/cli/printer.py
@@ -14,7 +14,8 @@
 #    under the License.
 """
 from abc import ABC
-from typing import NamedTuple
+from dataclasses import dataclass
+from typing import Callable, NamedTuple
 
 from cibyl.cli.query import QueryType
 from cibyl.utils.colors import ColorPalette, DefaultPalette
@@ -88,3 +89,34 @@ class ColoredPrinter(Printer, ABC):
         :return: The palette currently in use.
         """
         return self._palette
+
+
+class SerializedPrinter(Printer, ABC):
+    @dataclass
+    class Config:
+        verbosity: int
+
+    def __init__(self,
+                 load_function: Callable[[str], dict],
+                 dump_function: Callable[[dict], str],
+                 query: QueryType = QueryType.NONE,
+                 verbosity: int = 0):
+        """Constructor. See parent for more information.
+
+        :param load_function: Function that transforms machine-readable text
+            into a Python structure. Used to unmarshall output of sub-parts
+            of the module.
+        :param dump_function: Function that transforms a Python structure into
+            machine-readable text. Used to marshall the data from the
+            hierarchy.
+        """
+        super().__init__(query, verbosity)
+
+        self._load = load_function
+        self._dump = dump_function
+
+    @property
+    def config(self):
+        return SerializedPrinter.Config(
+            verbosity=self.verbosity
+        )

--- a/cibyl/outputs/cli/printer.py
+++ b/cibyl/outputs/cli/printer.py
@@ -59,6 +59,7 @@ class ColoredPrinter(Printer, ABC):
     """
 
     class Config(NamedTuple):
+        query: QueryType
         palette: ColorPalette
         verbosity: int
 
@@ -79,6 +80,7 @@ class ColoredPrinter(Printer, ABC):
     @property
     def config(self) -> Config:
         return ColoredPrinter.Config(
+            query=self.query,
             palette=self.palette,
             verbosity=self.verbosity
         )
@@ -94,6 +96,7 @@ class ColoredPrinter(Printer, ABC):
 class SerializedPrinter(Printer, ABC):
     @dataclass
     class Config:
+        query: QueryType
         verbosity: int
 
     def __init__(self,
@@ -118,5 +121,6 @@ class SerializedPrinter(Printer, ABC):
     @property
     def config(self):
         return SerializedPrinter.Config(
+            query=self.query,
             verbosity=self.verbosity
         )

--- a/cibyl/outputs/cli/printer.py
+++ b/cibyl/outputs/cli/printer.py
@@ -95,10 +95,17 @@ class ColoredPrinter(Printer, ABC):
 
 
 class SerializedPrinter(Printer, ABC):
+    """Base class for output styles based around serializing data.
+    """
+
     @dataclass
     class Config:
+        """Parameters that define the behaviour of the printer.
+        """
         query: QueryType
+        """The type of query is gets to print."""
         verbosity: int
+        """Verbosity level of the output."""
 
     def __init__(self,
                  load_function: Callable[[str], dict],
@@ -108,11 +115,10 @@ class SerializedPrinter(Printer, ABC):
         """Constructor. See parent for more information.
 
         :param load_function: Function that transforms machine-readable text
-            into a Python structure. Used to unmarshall output of sub-parts
-            of the module.
+            into a Python structure. Used to unmarshall pieces of the output
+            text back into models.
         :param dump_function: Function that transforms a Python structure into
-            machine-readable text. Used to marshall the data from the
-            hierarchy.
+            machine-readable text. Used to marshall models into text.
         """
         super().__init__(query, verbosity)
 
@@ -120,7 +126,10 @@ class SerializedPrinter(Printer, ABC):
         self._dump = dump_function
 
     @property
-    def config(self):
+    def config(self) -> Config:
+        """
+        :return: Configuration for this printer.
+        """
         return SerializedPrinter.Config(
             query=self.query,
             verbosity=self.verbosity
@@ -128,9 +137,15 @@ class SerializedPrinter(Printer, ABC):
 
 
 class JSONPrinter(SerializedPrinter):
+    """Base class for printers that serialize data into JSON format.
+    """
+
     @dataclass
     class Config(SerializedPrinter.Config):
+        """Parameters that define the behaviour of the printer.
+        """
         indentation: int
+        """Number of spaces that indent each level of the JSON text."""
 
     def __init__(self,
                  query: QueryType = QueryType.NONE,
@@ -138,7 +153,7 @@ class JSONPrinter(SerializedPrinter):
                  indentation: int = 4):
         """Constructor. See parent for more information.
 
-        :param indentation: Number of spaces indenting each level of the
+        :param indentation: Number of spaces that indent each level of the
             JSON output.
         """
         super().__init__(
@@ -152,6 +167,9 @@ class JSONPrinter(SerializedPrinter):
 
     @property
     def config(self) -> Config:
+        """
+        :return: Configuration for this printer.
+        """
         return JSONPrinter.Config(
             query=self.query,
             indentation=self.indentation,
@@ -165,8 +183,8 @@ class JSONPrinter(SerializedPrinter):
         """
         return self._indentation
 
-    def _from_json(self, obj: Union[str, bytes, bytearray]) -> dict:
+    def _from_json(self, obj: str) -> dict:
         return json.loads(obj)
 
-    def _to_json(self, obj: object) -> str:
+    def _to_json(self, obj: dict) -> str:
         return json.dumps(obj, indent=self._indentation)

--- a/cibyl/plugins/__init__.py
+++ b/cibyl/plugins/__init__.py
@@ -20,7 +20,7 @@ from typing import Callable, List
 
 from cibyl.exceptions.plugin import MissingPlugin
 from cibyl.models.model import Model
-from cibyl.outputs.cli.ci.env.impl.serialized import JSONPrinter
+from cibyl.outputs.cli.ci.env.impl.serialized import CIJSONPrinter
 from cibyl.outputs.cli.printer import ColoredPrinter
 from cibyl.sources.plugins import SourceExtension
 from cibyl.sources.source_factory import SourceFactory
@@ -119,5 +119,5 @@ class PluginPrinterTemplate(ABC):
     def as_text(self, model: Model, config: ColoredPrinter.Config) -> str:
         raise NotImplementedError
 
-    def as_json(self, model: Model, config: JSONPrinter.Config) -> str:
+    def as_json(self, model: Model, config: CIJSONPrinter.Config) -> str:
         raise NotImplementedError

--- a/cibyl/plugins/__init__.py
+++ b/cibyl/plugins/__init__.py
@@ -20,8 +20,7 @@ from typing import Callable, List
 
 from cibyl.exceptions.plugin import MissingPlugin
 from cibyl.models.model import Model
-from cibyl.outputs.cli.ci.env.impl.serialized import CIJSONPrinter
-from cibyl.outputs.cli.printer import ColoredPrinter
+from cibyl.outputs.cli.printer import ColoredPrinter, JSONPrinter
 from cibyl.sources.plugins import SourceExtension
 from cibyl.sources.source_factory import SourceFactory
 from cibyl.utils.files import FileSearch
@@ -116,8 +115,28 @@ class PluginTemplate(ABC):
 
 
 class PluginPrinterTemplate(ABC):
+    """Abstract class to define the output formats a plugin should support."""
+
     def as_text(self, model: Model, config: ColoredPrinter.Config) -> str:
+        """Makes the plugin give a plain/custom textual representation on
+        the provided model. It is up to the plugin to check the model's type
+        and decide on more specific actions from it.
+
+        :param model: The model to print.
+        :param config: Configuration to follow.
+        :return: Textural representation of the model.
+        :raises NotImplementedError: If the model type is not supported.
+        """
         raise NotImplementedError
 
-    def as_json(self, model: Model, config: CIJSONPrinter.Config) -> str:
+    def as_json(self, model: Model, config: JSONPrinter.Config) -> str:
+        """Makes the plugin give a json representation on the provided model.
+        It is up to the plugin to check the model's type and decide on more
+        specific actions from it.
+
+        :param model: The model to print.
+        :param config: Configuration to follow.
+        :return: JSON representation of the model.
+        :raises NotImplementedError: If the model type is not supported.
+        """
         raise NotImplementedError

--- a/cibyl/plugins/__init__.py
+++ b/cibyl/plugins/__init__.py
@@ -19,6 +19,9 @@ from abc import ABC, abstractmethod
 from typing import Callable, List
 
 from cibyl.exceptions.plugin import MissingPlugin
+from cibyl.models.model import Model
+from cibyl.outputs.cli.ci.env.impl.serialized import JSONPrinter
+from cibyl.outputs.cli.printer import ColoredPrinter
 from cibyl.sources.plugins import SourceExtension
 from cibyl.sources.source_factory import SourceFactory
 from cibyl.utils.files import FileSearch
@@ -109,4 +112,12 @@ class PluginTemplate(ABC):
     @abstractmethod
     def extend_query_types(self) -> None:
         """Register the plugin function to deduce the type of query."""
+        raise NotImplementedError
+
+
+class PluginPrinterTemplate(ABC):
+    def as_text(self, model: Model, config: ColoredPrinter.Config) -> str:
+        raise NotImplementedError
+
+    def as_json(self, model: Model, config: JSONPrinter.Config) -> str:
         raise NotImplementedError

--- a/cibyl/plugins/openstack/__init__.py
+++ b/cibyl/plugins/openstack/__init__.py
@@ -57,8 +57,9 @@ class Plugin(PluginTemplate):
     """Extend a CI model with Openstack specific models and methods."""
     plugin_attributes_to_add = {
         'deployment': {
-            'add_method': 'add_deployment',
-            'printer': PrinterRouter()
+            'name': 'OpenStack',
+            'printer': PrinterRouter(),
+            'add_method': 'add_deployment'
         }
     }
 

--- a/cibyl/plugins/openstack/__init__.py
+++ b/cibyl/plugins/openstack/__init__.py
@@ -22,6 +22,7 @@ from cibyl.models.ci.base.job import Job
 from cibyl.models.ci.zuul.job import Job as ZuulJob
 from cibyl.plugins import PluginTemplate
 from cibyl.plugins.openstack.deployment import Deployment
+from cibyl.plugins.openstack.printers.router import PrinterRouter
 from cibyl.utils.dicts import subset
 
 PLUGIN_ARGUMENTS = ('release', 'spec', 'infra_type', 'nodes', 'controllers',
@@ -55,11 +56,15 @@ def get_query_openstack(**kwargs) -> QueryType:
 class Plugin(PluginTemplate):
     """Extend a CI model with Openstack specific models and methods."""
     plugin_attributes_to_add = {
-        'deployment': {'add_method': 'add_deployment'}
+        'deployment': {
+            'add_method': 'add_deployment',
+            'printer': PrinterRouter()
         }
+    }
 
     def extend_models(self):
         """Extend models' API with product specific information."""
+
         def get_deployment_api():
             return {
                 'attr_type': Deployment,
@@ -98,6 +103,7 @@ class Plugin(PluginTemplate):
         """Collect a list of functions from the plugin that will be used to
         extend Cibyl's cli with additional subcommands. All functions returned
         by this method must take an ArgumentParser object as an argument."""
+
         def add_spec_subcommand(parser):
             # subparser for spec
             spec_sp = parser.add_parser("spec", add_help=True)
@@ -105,4 +111,5 @@ class Plugin(PluginTemplate):
             spec_sp.add_argument("spec", nargs=1, metavar="job_name",
                                  func='get_deployment',
                                  action=CustomAction, help=help_msg)
+
         return [add_spec_subcommand]

--- a/cibyl/plugins/openstack/printers/__init__.py
+++ b/cibyl/plugins/openstack/printers/__init__.py
@@ -36,6 +36,14 @@ class OSPrinter(Printer, ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def print_test_collection(self, collection) -> str:
+        """
+        :param collection: The collection.
+        :return: Textual representation of the provided model.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def print_node(self, node: Node) -> str:
         """
         :param node: The node.

--- a/cibyl/plugins/openstack/printers/__init__.py
+++ b/cibyl/plugins/openstack/printers/__init__.py
@@ -16,6 +16,11 @@
 from abc import ABC, abstractmethod
 
 from cibyl.outputs.cli.printer import Printer
+from cibyl.plugins.openstack import Deployment
+from cibyl.plugins.openstack.container import Container
+from cibyl.plugins.openstack.node import Node
+from cibyl.plugins.openstack.package import Package
+from cibyl.plugins.openstack.service import Service
 
 
 class OSPrinter(Printer, ABC):
@@ -23,46 +28,41 @@ class OSPrinter(Printer, ABC):
     """
 
     @abstractmethod
-    def print_container(self, container):
-        """
-        :param container: The container.
-        :return: Textual representation of the provided model.
-        :rtype: str
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def print_deployment(self, deployment):
+    def print_deployment(self, deployment: Deployment) -> str:
         """
         :param deployment: The deployment.
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         raise NotImplementedError
 
     @abstractmethod
-    def print_node(self, node):
+    def print_node(self, node: Node) -> str:
         """
         :param node: The node.
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         raise NotImplementedError
 
     @abstractmethod
-    def print_package(self, package):
+    def print_container(self, container: Container) -> str:
+        """
+        :param container: The container.
+        :return: Textual representation of the provided model.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def print_package(self, package: Package) -> str:
         """
         :param package: The package.
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         raise NotImplementedError
 
     @abstractmethod
-    def print_service(self, service):
+    def print_service(self, service: Service) -> str:
         """
         :param service: The service.
         :return: Textual representation of the provided model.
-        :rtype: str
         """
         raise NotImplementedError

--- a/cibyl/plugins/openstack/printers/__init__.py
+++ b/cibyl/plugins/openstack/printers/__init__.py
@@ -21,6 +21,7 @@ from cibyl.plugins.openstack.container import Container
 from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.package import Package
 from cibyl.plugins.openstack.service import Service
+from cibyl.plugins.openstack.test_collection import TestCollection
 
 
 class OSPrinter(Printer, ABC):
@@ -36,7 +37,7 @@ class OSPrinter(Printer, ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def print_test_collection(self, collection) -> str:
+    def print_test_collection(self, collection: TestCollection) -> str:
         """
         :param collection: The collection.
         :return: Textual representation of the provided model.

--- a/cibyl/plugins/openstack/printers/router.py
+++ b/cibyl/plugins/openstack/printers/router.py
@@ -13,6 +13,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from overrides import overrides
+
 from cibyl.models.model import Model
 from cibyl.outputs.cli.ci.env.impl.serialized import CIJSONPrinter
 from cibyl.outputs.cli.printer import ColoredPrinter
@@ -23,6 +25,11 @@ from cibyl.plugins.openstack.printers.serialized import OSJSONPrinter
 
 
 class PrinterRouter(PluginPrinterTemplate):
+    """Takes care of redirecting the printing petition to the appropriate
+    printer on this plugin.
+    """
+
+    @overrides
     def as_text(self, model: Model, config: ColoredPrinter.Config) -> str:
         if isinstance(model, Deployment):
             printer = OSColoredPrinter(
@@ -35,6 +42,7 @@ class PrinterRouter(PluginPrinterTemplate):
 
         raise NotImplementedError(f"Unknown model: '{type(model).__name__}'.")
 
+    @overrides
     def as_json(self, model: Model, config: CIJSONPrinter.Config) -> str:
         if isinstance(model, Deployment):
             printer = OSJSONPrinter(

--- a/cibyl/plugins/openstack/printers/router.py
+++ b/cibyl/plugins/openstack/printers/router.py
@@ -14,7 +14,7 @@
 #    under the License.
 """
 from cibyl.models.model import Model
-from cibyl.outputs.cli.ci.env.impl.serialized import JSONPrinter
+from cibyl.outputs.cli.ci.env.impl.serialized import CIJSONPrinter
 from cibyl.outputs.cli.printer import ColoredPrinter
 from cibyl.plugins import PluginPrinterTemplate
 from cibyl.plugins.openstack import Deployment
@@ -35,7 +35,7 @@ class PrinterRouter(PluginPrinterTemplate):
 
         raise NotImplementedError(f"Unknown model: '{type(model).__name__}'.")
 
-    def as_json(self, model: Model, config: JSONPrinter.Config) -> str:
+    def as_json(self, model: Model, config: CIJSONPrinter.Config) -> str:
         if isinstance(model, Deployment):
             printer = OSJSONPrinter(
                 query=config.query,

--- a/cibyl/plugins/openstack/printers/router.py
+++ b/cibyl/plugins/openstack/printers/router.py
@@ -1,0 +1,48 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from cibyl.models.model import Model
+from cibyl.outputs.cli.ci.env.impl.serialized import JSONPrinter
+from cibyl.outputs.cli.printer import ColoredPrinter
+from cibyl.plugins import PluginPrinterTemplate
+from cibyl.plugins.openstack import Deployment
+from cibyl.plugins.openstack.printers.colored import OSColoredPrinter
+from cibyl.plugins.openstack.printers.serialized import OSJSONPrinter
+
+
+class PrinterRouter(PluginPrinterTemplate):
+    def as_text(self, model: Model, config: ColoredPrinter.Config) -> str:
+        if isinstance(model, Deployment):
+            printer = OSColoredPrinter(
+                query=config.query,
+                verbosity=config.verbosity,
+                palette=config.palette
+            )
+
+            return printer.print_deployment(model)
+
+        raise NotImplementedError(f"Unknown model: '{type(model).__name__}'.")
+
+    def as_json(self, model: Model, config: JSONPrinter.Config) -> str:
+        if isinstance(model, Deployment):
+            printer = OSJSONPrinter(
+                query=config.query,
+                verbosity=config.verbosity,
+                indentation=config.indentation
+            )
+
+            return printer.print_deployment(model)
+
+        raise NotImplementedError(f"Unknown model: '{type(model).__name__}'.")

--- a/cibyl/plugins/openstack/printers/serialized.py
+++ b/cibyl/plugins/openstack/printers/serialized.py
@@ -1,0 +1,103 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+import json
+from abc import ABC
+from typing import Callable, Union
+
+from overrides import overrides
+
+from cibyl.cli.query import QueryType
+from cibyl.plugins.openstack import Deployment
+from cibyl.plugins.openstack.container import Container
+from cibyl.plugins.openstack.node import Node
+from cibyl.plugins.openstack.package import Package
+from cibyl.plugins.openstack.printers import OSPrinter
+from cibyl.plugins.openstack.service import Service
+
+
+class OSSerializedPrinter(OSPrinter, ABC):
+    def __init__(
+        self,
+        load_function: Callable[[str], dict],
+        dump_function: Callable[[dict], str],
+        query: QueryType = QueryType.NONE,
+        verbosity: int = 0
+    ):
+        super().__init__(query, verbosity)
+
+        self._load = load_function
+        self._dump = dump_function
+
+    @overrides
+    def print_deployment(self, deployment: Deployment) -> str:
+        result = {
+            'release': deployment.release.value,
+            'infra_type': deployment.infra_type.value,
+            'topology': deployment.topology.value
+        }
+
+        return self._dump(result)
+
+    @overrides
+    def print_node(self, node: Node) -> str:
+        pass
+
+    @overrides
+    def print_container(self, container: Container) -> str:
+        pass
+
+    @overrides
+    def print_package(self, package: Package) -> str:
+        pass
+
+    @overrides
+    def print_service(self, service: Service) -> str:
+        pass
+
+
+class OSJSONPrinter(OSSerializedPrinter):
+    def __init__(
+        self,
+        query: QueryType = QueryType.NONE,
+        verbosity: int = 0,
+        indentation: int = 4
+    ):
+        """Constructor. See parent for more information.
+
+        :param indentation: Number of spaces indenting each level of the
+            JSON output.
+        """
+        super().__init__(
+            load_function=self._from_json,
+            dump_function=self._to_json,
+            query=query,
+            verbosity=verbosity
+        )
+
+        self._indentation = indentation
+
+    @property
+    def indentation(self) -> int:
+        """
+        :return: Number of spaces preceding every level of the JSON output.
+        """
+        return self._indentation
+
+    def _from_json(self, obj: Union[str, bytes, bytearray]) -> dict:
+        return json.loads(obj)
+
+    def _to_json(self, obj: object) -> str:
+        return json.dumps(obj, indent=self._indentation)

--- a/cibyl/plugins/openstack/printers/serialized.py
+++ b/cibyl/plugins/openstack/printers/serialized.py
@@ -24,6 +24,7 @@ from cibyl.plugins.openstack.node import Node
 from cibyl.plugins.openstack.package import Package
 from cibyl.plugins.openstack.printers import OSPrinter
 from cibyl.plugins.openstack.service import Service
+from cibyl.plugins.openstack.test_collection import TestCollection
 
 
 class OSSerializedPrinter(OSPrinter, SerializedPrinter, ABC):
@@ -56,12 +57,16 @@ class OSSerializedPrinter(OSPrinter, SerializedPrinter, ABC):
                 'ironic_inspector': ironic.ironic_inspector.value,
                 'cleaning_network': ironic.cleaning_network.value
             },
-            'overcloud_templates': list(deployment.overcloud_templates.value),
-            'test_collection': self.provider.load(
-                self.print_test_collection(
-                    deployment.test_collection.value
+            'overcloud_templates':
+                list(deployment.overcloud_templates.value)
+                if deployment.overcloud_templates.value else [],
+            'test_collection':
+                self.provider.load(
+                    self.print_test_collection(
+                        deployment.test_collection.value
+                    )
                 )
-            ),
+                if deployment.test_collection.value else {},
             'nodes': [
                 self.provider.load(self.print_node(node))
                 for node in deployment.nodes.values()
@@ -83,9 +88,11 @@ class OSSerializedPrinter(OSPrinter, SerializedPrinter, ABC):
         return self.provider.dump(result)
 
     @overrides
-    def print_test_collection(self, collection) -> str:
+    def print_test_collection(self, collection: TestCollection) -> str:
         result = {
-            'tests': list(collection.tests.value),
+            'tests':
+                list(collection.tests.value)
+                if collection.tests.value else [],
             'setup': collection.setup.value
         }
 

--- a/tests/cibyl/unit/outputs/cli/ci/env/impls/test_serialized.py
+++ b/tests/cibyl/unit/outputs/cli/ci/env/impls/test_serialized.py
@@ -17,11 +17,11 @@ import json
 from unittest import TestCase
 from unittest.mock import Mock
 
-from cibyl.outputs.cli.ci.env.impl.serialized import JSONPrinter
+from cibyl.outputs.cli.ci.env.impl.serialized import CIJSONPrinter
 
 
-class TestJSONPrinter(TestCase):
-    """Tests for :class:`JSONPrinter`.
+class TestCIJSONPrinter(TestCase):
+    """Tests for :class:`CIJSONPrinter`.
     """
 
     def test_simple_environment(self):
@@ -33,7 +33,7 @@ class TestJSONPrinter(TestCase):
         env.name.value = name
         env.systems = []
 
-        printer = JSONPrinter()
+        printer = CIJSONPrinter()
 
         result = json.loads(printer.print_environment(env))
 

--- a/tests/cibyl/unit/outputs/cli/ci/system/common/test_models.py
+++ b/tests/cibyl/unit/outputs/cli/ci/system/common/test_models.py
@@ -16,6 +16,7 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
+from cibyl.cli.output import OutputStyle
 from cibyl.outputs.cli.ci.system.common.models import (get_plugin_section,
                                                        has_plugin_section)
 
@@ -68,4 +69,4 @@ class TestGetPluginSection(TestCase):
         model = Mock()
 
         with self.assertRaises(ValueError):
-            get_plugin_section(printer, model)
+            get_plugin_section(OutputStyle.COLORIZED, model, printer)


### PR DESCRIPTION
- Extracted 'SerializedPrinter' and 'JSONPrinter' to be their own independent thing. On both, added the 'Config' class so that it is possible to reuse the arguments on other printers.
- Extracted serializing functions into 'SerializedPrinter.SerializationProvider'. Implementing this class is enough to have new output formats. See 'JSONPrinter' for an example.
- Reorganized inheritance of classes below 'SerializedPrinter' and 'JSONPrinter'. Prefixed them with 'CI' to avoid naming conflicts.
- Reworked how retrieval of plugin section is made. Cibyl no longer needs to know about the plugin's inners, instead, it expects the plugin to provide a 'PluginPrinterTemplate'. Cibyl will just call the correct output style and go on with what the plugin returns. The printer instance is installed in the model much like the functions are.
- Implemented 'OSJSONPrinter' to print the deployment as JSON.