### PR TITLE
Small fixes for openstack jenkins source

### DIFF
--- a/cibyl/plugins/openstack/printers/colored.py
+++ b/cibyl/plugins/openstack/printers/colored.py
@@ -66,9 +66,10 @@ class OSColoredPrinter(OSPrinter):
             printer[-1].append(network.ip_version)
 
         if network.network_backend.value:
-            is_empty_network = False
-            printer.add(self.palette.blue('Network backend: '), 2)
-            printer[-1].append(network.network_backend)
+            if network.network_backend.value != "N/A" or self.verbosity > 0:
+                is_empty_network = False
+                printer.add(self.palette.blue('Network backend: '), 2)
+                printer[-1].append(network.network_backend)
 
         if network.ml2_driver.value:
             if network.ml2_driver.value != "N/A" or self.verbosity > 0:
@@ -156,19 +157,22 @@ class OSColoredPrinter(OSPrinter):
         is_empty_deployment = True
 
         if deployment.release.value:
-            is_empty_deployment = False
-            printer.add(self.palette.blue('Release: '), 1)
-            printer[-1].append(deployment.release.value)
+            if self.verbosity > 0 or deployment.release.value != "N/A":
+                is_empty_deployment = False
+                printer.add(self.palette.blue('Release: '), 1)
+                printer[-1].append(deployment.release.value)
 
         if deployment.infra_type.value:
-            is_empty_deployment = False
-            printer.add(self.palette.blue('Infra type: '), 1)
-            printer[-1].append(deployment.infra_type)
+            if self.verbosity > 0 or deployment.infra_type.value != "N/A":
+                is_empty_deployment = False
+                printer.add(self.palette.blue('Infra type: '), 1)
+                printer[-1].append(deployment.infra_type)
 
         if deployment.topology.value:
-            is_empty_deployment = False
-            printer.add(self.palette.blue('Topology: '), 1)
-            printer[-1].append(deployment.topology)
+            if self.verbosity > 0 or deployment.topology.value != "N/A":
+                is_empty_deployment = False
+                printer.add(self.palette.blue('Topology: '), 1)
+                printer[-1].append(deployment.topology)
 
         is_empty_network = True
         if deployment.network.value:
@@ -205,8 +209,10 @@ class OSColoredPrinter(OSPrinter):
                     printer.add(self.palette.blue('Testing information: '), 1)
                     printer[-1].append(deployment.test_collection.value)
                 else:
-                    printer.add(self.print_test_collection(
-                                    deployment.test_collection.value), 1)
+                    testing_string = self.print_test_collection(
+                            deployment.test_collection.value)
+                    if testing_string:
+                        printer.add(testing_string, 1)
 
         is_empty_deployment &= (is_empty_network and is_empty_storage and
                                 is_empty_ironic)
@@ -240,17 +246,23 @@ class OSColoredPrinter(OSPrinter):
         :param test_collection: The test collection used in the deployment
         :type test_collection: :class:`TestCollection`
         """
+        has_testing_info = False
         printer = IndentedTextBuilder()
         printer.add(self.palette.blue('Testing information: '), 0)
         if test_collection.tests.value:
+            has_testing_info = True
             printer.add(self.palette.blue('Test suites: '), 1)
             for test in test_collection.tests.value:
                 printer.add(self.palette.blue('- '), 2)
                 printer[-1].append(test)
 
         if test_collection.setup.value:
+            has_testing_info = True
             printer.add(self.palette.blue('Setup: '), 1)
             printer[-1].append(test_collection.setup.value)
+        if not has_testing_info:
+            # if the test_collection object had nothing, remove the header
+            printer.pop()
         return printer.build()
 
     def print_node(self, node):

--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -162,7 +162,7 @@ class Jenkins(SourceExtension):
     # deployment properties that have no cli argument and will not be used to
     # filter jobs, just for the spec
     spec_params = ["cleaning_network", "security_group", "overcloud_templates",
-                   "test_collection"]
+                   "test_collection", "tls_everywhere"]
     possible_attributes = deployment_attr+spec_params
 
     def add_job_info_from_name(self, job: JenkinsJob, **kwargs) -> None:
@@ -471,7 +471,9 @@ accurate results", len(jobs_found))
                 job["release"] = overcloud.get("version", "")
             deployment = overcloud.get('deployment', {})
             if "infra_type" in kwargs or spec:
-                infra = os.path.split(deployment.get('files', ""))[1]
+                infra = deployment.get('files', "")
+                if infra is not None:
+                    infra = os.path.split(infra)[1]
                 job["infra_type"] = infra
             storage = overcloud.get("storage", {})
             if "cinder_backend" in kwargs or spec:
@@ -489,7 +491,11 @@ accurate results", len(jobs_found))
                 job["dvr"] = str(network.get("dvr", ""))
             if "tls_everywhere" in kwargs or spec:
                 tls = overcloud.get("tls", {})
-                job["tls_everywhere"] = str(tls.get("everywhere", ""))
+                tls_value = tls.get("everywhere", "")
+                if tls_value is not None:
+                    # tls everywhere is encoded a a bool in the artifacts, we
+                    # want to store it as a string
+                    job["tls_everywhere"] = str(tls_value)
             if "ml2_driver" in kwargs or spec:
                 job["ml2_driver"] = "ovn"
                 if network.get("ovs"):

--- a/tests/cibyl/unit/plugins/openstack/sources/test_jenkins.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/test_jenkins.py
@@ -1635,8 +1635,9 @@ tripleo_ironic_conductor.service loaded    active     running
         artifacts = [
                 get_yaml_from_topology_string(topology),
                 get_yaml_overcloud(ip_version, release,
-                                   "ceph", "geneve", False,
-                                   False, "path/to/ovb",
+                                   "ceph", "geneve", dvr=False,
+                                   tls_everywhere=False,
+                                   infra_type="path/to/ovb",
                                    ironic_inspector=False, ml2_driver="ovs",
                                    cleaning_network=True,
                                    security_group="openvswitch",

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,9 @@ commands =
 [testenv:e2e]
 passenv =
     DOCKER_HOST
+setenv=
+    # set timeout for e2e testing to 3 minutes
+    TC_MAX_TRIES = 180
 deps =
     -r {toxinidir}/requirements.txt
     -r {toxinidir}/test-requirements.txt


### PR DESCRIPTION
During e2e testing, some corner cases related to the how some spec
fields are printed have come up. They are mostly related to handling
edge cases (fields missing in artifacts or having a null value) and this
change makes some of the reading and printing more robust aroung null
values.
