### PR TITLE
Separate e2e step in CI

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -25,3 +25,5 @@ jobs:
           pip install tox
       - name: "Run tox"
         run: tox
+      - name: "Run e2e tests"
+        run: tox -e e2e

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.8.0
-envlist = linters,unit,intr,coverage,docs,e2e
+envlist = linters,unit,intr,coverage,docs
 skipsdist = True
 ignore_basepython_conflict = True
 skip_missing_interpreters = False


### PR DESCRIPTION
Move e2e tests to another step in CI to have more organized logs. This
should allow to see the reason for failures in other CI checks (linters,
unit test) due to the biggere amount of output in e2e tests.
