### PR TITLE
Allowing output to be saved into a file.

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -38,7 +38,8 @@ def raw_parsing(arguments: List[str]) -> dict:
     args = {'config_file_path': None, 'help': False,
             "log_file": "cibyl_output.log", "log_mode": "both",
             "logging": logging.INFO, "plugins": [],
-            "debug": False, "output_style": "colorized"}
+            "debug": False, "output_file_path": None,
+            "output_style": "colorized"}
     for i, item in enumerate(arguments[1:]):
         if item in ('-c', '--config'):
             args['config_file_path'] = arguments[i + 2]
@@ -60,6 +61,8 @@ def raw_parsing(arguments: List[str]) -> dict:
                     break
                 plugins.append(argument)
             args["plugins"] = plugins
+        elif item in ('-o', '--output'):
+            args["output_file_path"] = arguments[i + 2]
         elif item in ('-f', '--output-format'):
             args["output_style"] = arguments[i + 2]
 

--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -121,8 +121,11 @@ def main() -> None:
         orchestrator.parser.parse()
         orchestrator.validate_environments()
         features = orchestrator.load_features()
-        orchestrator.query_and_publish(arguments["output_style"],
-                                       features=features)
+        orchestrator.query_and_publish(
+            output_path=arguments["output_file_path"],
+            output_style=arguments["output_style"],
+            features=features
+        )
     except CibylException as ex:
         if arguments.get('help', False):
             # if the user wants to see the --help, we should show it even if

--- a/cibyl/cli/parser.py
+++ b/cibyl/cli/parser.py
@@ -91,6 +91,10 @@ class Parser:
             choices=("terminal", "file", "both"),
             help='Where to write the output, default is both')
         app_args_group.add_argument(
+            '--output', '-o', dest='output_file_path',
+            help='Write output into <OUTPUT_FILE_PATH>.'
+        )
+        app_args_group.add_argument(
             '--output-format', '-f', choices=("text", "colorized", "json"),
             dest="output_style", default="colorized",
             help="Sets the output format."

--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -75,9 +75,9 @@ class Orchestrator:
     def get_source(self, source_name: str, source_data: dict) -> Source:
         try:
             return SourceFactory.create_source(
-                source_data.get('driver'),
-                source_name,
-                **source_data)
+                    source_data.get('driver'),
+                    source_name,
+                    **source_data)
         except AttributeError as exception:
             raise conf_exc.InvalidSourceConfiguration(
                 source_name, source_data) from exception
@@ -197,7 +197,7 @@ class Orchestrator:
                         features_combination = feature_info
                     else:
                         features_combination = intersect_models(
-                            features_combination, feature_info)
+                                features_combination, feature_info)
 
         if "jobs" in self.parser.ci_args:
             # add the combined result for all features requested, e.g.
@@ -279,7 +279,7 @@ class Orchestrator:
                 continue
             for source_method, speed_score in source_methods:
                 source_info = source_information_from_method(
-                    source_method)
+                        source_method)
                 source_obj = get_source_instance_from_method(source_method)
                 try:
                     source_obj.ensure_source_setup()
@@ -299,7 +299,7 @@ class Orchestrator:
                     continue
                 end_time = time.time()
                 LOG.info("Took %.2fs to query system %s using %s",
-                         end_time - start_time, system.name.value,
+                         end_time-start_time, system.name.value,
                          source_info)
                 if query_result is None:
                     query_result = model_instances_dict
@@ -335,7 +335,7 @@ class Orchestrator:
             arguments = attr_dict.get('arguments')
             class_type = attr_dict.get('attr_type')
             has_api = class_type not in [str, list, dict, int] and \
-                      hasattr(class_type, 'API')
+                hasattr(class_type, 'API')
             if has_api:
                 # API entry is related to a model that has an API
                 new_group_name = class_type.__name__
@@ -344,7 +344,7 @@ class Orchestrator:
                     # add the arguments found in the current entry, but
                     # group them to the model they relate to
                     self.parser.extend(arguments, new_group_name,
-                                       level=level + 1,
+                                       level=level+1,
                                        parent_queries=parent_queries)
 
                     # generate a set of all query method associated with
@@ -360,7 +360,7 @@ class Orchestrator:
                 # explore the API of the model found, even if there are no
                 # arguments
                 self.extend_parser(class_type.API, new_group_name,
-                                   level=level + 1,
+                                   level=level+1,
                                    parent_queries=next_parent_queries)
             elif arguments:
                 # if the API entry has arguments but is not related to any

--- a/cibyl/utils/fs.py
+++ b/cibyl/utils/fs.py
@@ -129,17 +129,37 @@ class File(FSPath):
         return self.as_path().is_file()
 
     def create(self) -> None:
+        """Creates the file at this path.
+        """
         self.write('')
 
     def delete(self) -> None:
+        """Deletes the file at this path. Will do nothing if the file does
+        not exist.
+        """
         self.as_path().unlink(missing_ok=True)
 
     def append(self, text: str) -> None:
+        """Appends some text at the end of the file.
+
+        :param text: Text to append.
+        """
         self._write(text, 'a')
 
     def write(self, text: str) -> None:
+        """Overwrites contents of the file with the given text.
+
+        :param text: Text to write.
+        """
         self._write(text, 'w')
 
     def _write(self, text: str, mode: str) -> None:
+        """Writes some text into the file. This makes no checks to verify
+        that the file exists and is accessible beforehand, it is up to the
+        caller to ensure this.
+
+        :param text: Text to write.
+        :param mode: Mode to write on, just like in builtin 'open'.
+        """
         with open(self, mode) as buffer:
             buffer.write(text)

--- a/cibyl/utils/fs.py
+++ b/cibyl/utils/fs.py
@@ -127,3 +127,19 @@ class File(FSPath):
     @overrides
     def exists(self) -> bool:
         return self.as_path().is_file()
+
+    def create(self) -> None:
+        self.write('')
+
+    def delete(self) -> None:
+        self.as_path().unlink(missing_ok=True)
+
+    def append(self, text: str) -> None:
+        self._write(text, 'a')
+
+    def write(self, text: str) -> None:
+        self._write(text, 'w')
+
+    def _write(self, text: str, mode: str) -> None:
+        with open(self, mode) as buffer:
+            buffer.write(text)

--- a/cibyl/utils/paths.py
+++ b/cibyl/utils/paths.py
@@ -1,0 +1,42 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from pathlib import Path
+from typing import Callable
+
+Preprocessor = Callable[[Path], Path]
+
+
+def resolve_home(path: Path) -> Path:
+    """Resolves the '~' shortcut used to indicate that a path starts from
+    the home directory.
+
+    The symbol will only be treated if it is the first character of the path,
+    anywhere else will be ignored.
+
+    If the symbol does not appear, then everything is returned as is.
+
+    The original path is not modified. A copy of it is returned instead.
+
+    :param path: The path to resolve.
+    :return: The same path, with the '~' replaced to the absolute path of the
+        home directory.
+    """
+    raw = str(path)
+
+    if raw.startswith('~'):
+        raw = raw.replace('~', str(path.home()))
+
+    return Path(raw)

--- a/tests/cibyl/unit/test_publisher.py
+++ b/tests/cibyl/unit/test_publisher.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock, patch
 
 from cibyl.cli.output import OutputStyle
 from cibyl.models.ci.base.environment import Environment
-from cibyl.publisher import Publisher
+from cibyl.publisher import Publisher, PublisherTarget
 
 
 class TestOrchestrator(TestCase):
@@ -44,7 +44,7 @@ class TestOrchestrator(TestCase):
 
         self.publisher.publish(
             environment=self.environment,
-            target="terminal",
+            target=PublisherTarget.TERMINAL,
             style=style
         )
 


### PR DESCRIPTION
Added the '-o' or '--output' that allows the user to store Cibyl's output into a file. For example: 'cibyl -o ~/my_file.txt query '--jobs'.