### PR TITLE
Sort templates and tests in spec for consistency

### DIFF
--- a/cibyl/plugins/openstack/printers/colored.py
+++ b/cibyl/plugins/openstack/printers/colored.py
@@ -197,7 +197,8 @@ class OSColoredPrinter(OSPrinter):
                 if isinstance(deployment.overcloud_templates.value, str):
                     printer[-1].append(deployment.overcloud_templates.value)
                 else:
-                    for template in deployment.overcloud_templates.value:
+                    templates = deployment.overcloud_templates.value
+                    for template in sorted(templates):
                         printer.add(self.palette.blue('- '), 2)
                         printer[-1].append(template)
 
@@ -213,6 +214,12 @@ class OSColoredPrinter(OSPrinter):
                             deployment.test_collection.value)
                     if testing_string:
                         printer.add(testing_string, 1)
+                    elif self.verbosity > 0:
+                        # if testing collection was empty but verbose output
+                        # was request, we still want to print the field
+                        printer.add(self.palette.blue('Testing information: '),
+                                    1)
+                        printer[-1].append('N/A')
 
         is_empty_deployment &= (is_empty_network and is_empty_storage and
                                 is_empty_ironic)
@@ -252,7 +259,7 @@ class OSColoredPrinter(OSPrinter):
         if test_collection.tests.value:
             has_testing_info = True
             printer.add(self.palette.blue('Test suites: '), 1)
-            for test in test_collection.tests.value:
+            for test in sorted(test_collection.tests.value):
                 printer.add(self.palette.blue('- '), 2)
                 printer[-1].append(test)
 


### PR DESCRIPTION
Since overcloud templates and test suites are stored in sets, the
ordering might change between runs, sorting them ensures a consistent
output. This commit also prints a 'N/A' in cases where the testing
collection for the spec is empty, but verbose output is requested.
