### PR TITLE
Write output to file for multiple environments

### DIFF
--- a/cibyl/orchestrator.py
+++ b/cibyl/orchestrator.py
@@ -387,24 +387,25 @@ class Orchestrator:
                     source.ensure_teardown()
 
         def publish():
-            target = PublisherTarget.TERMINAL
-            kwargs = {}
-
-            if output_path:
-                target = PublisherTarget.FILE
-                kwargs['output_path'] = output_path
-
-                # Overwrite is it already exists
-                file = File(output_path, resolve_home)
-                file.delete()
-                file.create()
-
             self.publisher.publish(
                 environment=env, target=target, style=output_style,
-                query=get_query_type(**self.parser.ci_args, command=command),
-                verbosity=self.parser.app_args.get('verbosity', 0), **kwargs)
+                query=query_type,
+                verbosity=self.parser.app_args.get('verbosity', 0),
+                **kwargs)
 
         command = self.parser.app_args.get('command')
+        query_type = get_query_type(**self.parser.ci_args, command=command)
+        kwargs = {}
+
+        target = PublisherTarget.TERMINAL
+        if output_path:
+            target = PublisherTarget.FILE
+
+            # Overwrite file if it already exists
+            file = File(output_path, resolve_home)
+            file.delete()
+            file.create()
+            kwargs['output_path'] = file
 
         for env in self.environments:
             query()

--- a/cibyl/publisher.py
+++ b/cibyl/publisher.py
@@ -20,8 +20,6 @@ from cibyl.cli.output import OutputStyle
 from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.environment import Environment
 from cibyl.outputs.cli.ci.env.factory import CIPrinterFactory
-from cibyl.utils.fs import File
-from cibyl.utils.paths import resolve_home
 
 LOG = logging.getLogger(__name__)
 
@@ -55,9 +53,11 @@ class Publisher:
             return
 
         if target == PublisherTarget.FILE:
-            file = File(kwargs['output_path'], resolve_home)
+            file = kwargs['output_path']
             LOG.info("Writing output to: '%s'...", file)
-            file.append(output)
+            # add newline to the end out the output that is not added by the
+            # printers
+            file.append(output+'\n')
             return
 
         raise NotImplementedError(f"Unhandled target: '{target}'.")


### PR DESCRIPTION
Calling cibyl with multiple environments and writing the output to file
would only write the output for the last environment. In the publish
function of the orchestrator, the output file was recreated for each
environment, deleting the output for the previous ones.
