### PR TITLE
Filter topology with regex in Jenkins source

### DIFF
--- a/cibyl/plugins/openstack/sources/jenkins.py
+++ b/cibyl/plugins/openstack/sources/jenkins.py
@@ -313,7 +313,7 @@ accurate results", len(jobs_found))
                                        field_to_check=attribute,
                                        default_user_value=['True']))
                 continue
-            if attribute in ('release') and input_attr:
+            if attribute in ('release', 'topology') and input_attr:
                 for pattern_str in input_attr.value:
                     pattern = re.compile(pattern_str)
                     checks_to_apply.append(partial(satisfy_regex_match,

--- a/tests/cibyl/e2e/test_jenkins.py
+++ b/tests/cibyl/e2e/test_jenkins.py
@@ -626,6 +626,24 @@ class TestJenkinsOpenstack(EndToEndTest):
 
         self.assertIn(expected.build(), self.stdout)
 
+    def test_filter_test_topology(self):
+        """Checks that jobs are filtered with the "--topology" flag.
+        """
+        sys.argv = [
+            'cibyl',
+            '--config', 'tests/cibyl/e2e/data/configs/jenkins.yaml',
+            '-p', 'openstack',
+            '-f', 'text', 'query', '--topology', 'compute:2'
+        ]
+
+        main()
+
+        expected = IndentedTextBuilder()
+        expected.add('Job: test_1', 2)
+        expected.add('Openstack deployment: ', 3)
+        expected.add('Topology: compute:2,controller:3', 4)
+        expected.add('Total jobs found in query: 1', 2)
+
     def test_filter_ip_show_tests(self):
         """Check the jobs are filtered by ip-version and tests are correctly
         retrieved."""

--- a/tests/cibyl/unit/plugins/openstack/sources/test_jenkins.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/test_jenkins.py
@@ -690,6 +690,36 @@ tripleo_ironic_conductor.service loaded    active     running
         self.assertEqual(network.ip_version.value, "")
         self.assertEqual(deployment.topology.value, topology_value)
 
+    def test_get_deployment_filter_topology_regex(self):
+        """Test that get_deployment filters by topology."""
+        job_names = ['test_17.3_ipv4_job_2comp_1cont',
+                     'test_16_ipv6_job_1comp_2cont', 'test_job']
+        topology_value = "compute:2,controller:1"
+        response = {'jobs': [{'_class': 'folder'}]}
+        for job_name in job_names:
+            response['jobs'].append({'_class': 'org.job.WorkflowJob',
+                                     'name': job_name, 'url': 'url',
+                                     'lastBuild': None})
+
+        self.jenkins.send_request = Mock(side_effect=[response])
+        args = {
+            "topology": Argument("topology", str, "",
+                                 value=["comp", "controller:1"])
+        }
+
+        jobs = self.jenkins.get_deployment(**args)
+        self.assertEqual(len(jobs), 1)
+        job_name = 'test_17.3_ipv4_job_2comp_1cont'
+        job = jobs[job_name]
+        deployment = job.deployment.value
+        network = deployment.network.value
+        self.assertEqual(job.name.value, job_name)
+        self.assertEqual(job.url.value, "url")
+        self.assertEqual(len(job.builds.value), 0)
+        self.assertEqual(deployment.release.value, "")
+        self.assertEqual(network.ip_version.value, "")
+        self.assertEqual(deployment.topology.value, topology_value)
+
     def test_get_deployment_filter_release(self):
         """Test that get_deployment filters by release."""
         job_names = ['test_17.3_ipv4_job_2comp_1cont',


### PR DESCRIPTION
The Jenkins source for the openstack plugin was filtering the topology
using an exact match, instead of applying a regex match. This change
uses regex to filter and introduces unit and e2e test to check the
behavior.
