### PR TITLE
Add separate publisher for JSON output

### DIFF
--- a/cibyl/publisher.py
+++ b/cibyl/publisher.py
@@ -13,13 +13,17 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+import json
 import logging
+from abc import ABC, abstractmethod
 from enum import Enum
+from typing import Optional, Union
 
 from cibyl.cli.output import OutputStyle
 from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.environment import Environment
 from cibyl.outputs.cli.ci.env.factory import CIPrinterFactory
+from cibyl.utils.fs import File
 
 LOG = logging.getLogger(__name__)
 
@@ -29,35 +33,116 @@ class PublisherTarget(Enum):
     FILE = 1
 
 
-class Publisher:
+class Publisher(ABC):
     """Represents a publisher which is responsible for publishing the data
     collected by the application in the chosen format and to the chosen
-    location
+    location.
     """
 
-    def publish(self,
-                environment: Environment,
-                target: PublisherTarget = PublisherTarget.TERMINAL,
-                style: OutputStyle = OutputStyle.TEXT,
-                query: QueryType = QueryType.NONE,
-                verbosity: int = 0, **kwargs) -> None:
+    def __init__(self, target: PublisherTarget = PublisherTarget.TERMINAL,
+                 style: OutputStyle = OutputStyle.TEXT,
+                 query: QueryType = QueryType.NONE,
+                 verbosity: int = 0, output_file: Optional[File] = None):
+        self.target = target
+        self.style = style
+        self.query = query
+        self.verbosity = verbosity
+        self.output_file = output_file
+        self.printer = CIPrinterFactory.from_style(self.style, self.query,
+                                                   self.verbosity)
+
+    @abstractmethod
+    def publish(self, environment: Environment) -> None:
         """Publishes the data of the given environments to the
         chosen destination.
         """
-        printer = CIPrinterFactory.from_style(style, query, verbosity)
-        output = printer.print_environment(environment)
+        raise NotImplementedError
 
-        if target == PublisherTarget.TERMINAL:
+    def finish_publishing(self):
+        """Method to print all the output for output styles that must collect
+        the output for all environments, like the json one. It will do nothing
+        for the other styles, like text or colored."""
+        pass
+
+    def _generate_environment_output(self, environment: Environment) -> str:
+        """Generate a string representation of the environment in the desired
+        style (text, colored, json...)
+
+        :returns: The string representation of the environment
+        """
+        return self.printer.print_environment(environment)
+
+    def _print_output(self, output: str) -> None:
+        """Print the contents of the output string to the desired
+        destination."""
+        if self.target == PublisherTarget.TERMINAL:
             LOG.info("Writing output into console...")
             print(output)
             return
 
-        if target == PublisherTarget.FILE:
-            file = kwargs['output_path']
-            LOG.info("Writing output to: '%s'...", file)
+        if self.target == PublisherTarget.FILE:
+            LOG.info("Writing output to: '%s'...", self.output_file)
             # add newline to the end out the output that is not added by the
             # printers
-            file.append(output+'\n')
+            self.output_file.append(output+'\n')
             return
 
-        raise NotImplementedError(f"Unhandled target: '{target}'.")
+        raise NotImplementedError(f"Unhandled target: '{self.target}'.")
+
+
+class PrintPublisher(Publisher):
+    """Publisher for text output, it supports both colored and raw text. It
+    prints the output after each query finishes, either to
+    file or to stdout."""
+
+    def publish(self, environment: Environment) -> None:
+        """Publishes the data of the given environments to the
+        chosen destination.
+        """
+        output = self._generate_environment_output(environment)
+        self._print_output(output)
+
+
+class JSONPublisher(Publisher):
+    """Publisher for JSON output. It prints all the output after all queries
+    have finished in a single json object."""
+
+    def __init__(self, target: PublisherTarget = PublisherTarget.TERMINAL,
+                 style: OutputStyle = OutputStyle.JSON,
+                 query: QueryType = QueryType.NONE,
+                 verbosity: int = 0, output_file: Optional[File] = None):
+        super().__init__(target=target, style=style, query=query,
+                         verbosity=verbosity, output_file=output_file)
+        self.output = []
+
+    def publish(self, environment: Environment) -> None:
+        """Store the JSON representation of the environment for later printing.
+        """
+        self.output.append(self._generate_environment_output(environment))
+
+    def finish_publishing(self) -> None:
+        """Method to print all the output for output styles that must collect
+        the output for all environments, like the json one."""
+        envs = [json.loads(env) for env in self.output]
+        final_output = {'environments': envs}
+        self._print_output(json.dumps(final_output,
+                                      indent=self.printer.indentation))
+
+
+PUBLISHER_TYPE = Union[PrintPublisher, JSONPublisher]
+
+
+class PublisherFactory:
+    """Create the apropiate publisher according to user input."""
+    @staticmethod
+    def create_publisher(target: PublisherTarget = PublisherTarget.TERMINAL,
+                         style: OutputStyle = OutputStyle.TEXT,
+                         query: QueryType = QueryType.NONE,
+                         verbosity: int = 0,
+                         output_file: Optional[File] = None) -> PUBLISHER_TYPE:
+        if style in (OutputStyle.JSON,):
+            return JSONPublisher(target=target, style=style, query=query,
+                                 verbosity=verbosity, output_file=output_file)
+        else:
+            return PrintPublisher(target=target, style=style, query=query,
+                                  verbosity=verbosity, output_file=output_file)

--- a/tests/cibyl/unit/test_publisher.py
+++ b/tests/cibyl/unit/test_publisher.py
@@ -13,19 +13,21 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+import json
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
 from cibyl.cli.output import OutputStyle
+from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.environment import Environment
-from cibyl.publisher import Publisher, PublisherTarget
+from cibyl.publisher import (JSONPublisher, PrintPublisher, PublisherFactory,
+                             PublisherTarget)
 
 
-class TestOrchestrator(TestCase):
-    """Testing publisher component"""
+class TestPrintPublisher(TestCase):
+    """Testing print publisher component"""
 
     def setUp(self):
-        self.publisher = Publisher()
         self.env_name = "env1"
         self.environment = Environment(self.env_name)
 
@@ -33,7 +35,7 @@ class TestOrchestrator(TestCase):
     @patch('builtins.print')
     def test_publisher_publish(self, mock_print, mock_printer_factory):
         """Testing Publisher publish method"""
-        style = OutputStyle.TEXT
+
         text = 'output-text'
 
         printer = Mock()
@@ -41,13 +43,97 @@ class TestOrchestrator(TestCase):
         printer.print_environment.return_value = text
 
         mock_printer_factory.return_value = printer
-
-        self.publisher.publish(
-            environment=self.environment,
-            target=PublisherTarget.TERMINAL,
-            style=style
-        )
+        publisher = PrintPublisher()
+        publisher.publish(environment=self.environment)
 
         printer.print_environment.assert_called_once_with(self.environment)
 
         mock_print.assert_called_once_with(text)
+
+
+@patch('builtins.print')
+class TestJSONPublisher(TestCase):
+    """Testing json publisher component"""
+
+    def setUp(self):
+        self.text = '{"output": "output-text"}'
+        self.publisher = JSONPublisher()
+        self.env_name = "env1"
+        self.printer = Mock()
+        self.publisher.printer = self.printer
+        self.publisher.printer.print_environment = Mock()
+        self.publisher.printer.indentation = 0
+        self.publisher.printer.print_environment.return_value = self.text
+        self.environment = Environment(self.env_name)
+
+    def test_publisher_publish(self, mock_print):
+        """Testing JSONPublisher publish method"""
+
+        self.publisher.publish(environment=self.environment)
+
+        self.printer.print_environment.assert_called_once()
+        self.printer.print_environment.assert_called_with(self.environment)
+
+        mock_print.assert_not_called()
+
+    def test_publish_multiple_environments(self, mock_print):
+        """Testing JSONPublisher publish method with multiple environments"""
+
+        self.publisher.publish(environment=self.environment)
+        self.publisher.publish(environment=self.environment)
+
+        self.assertEqual(self.printer.print_environment.call_count, 2)
+        mock_print.assert_not_called()
+
+    def test_publish_multiple_environments_print(self, mock_print):
+        """Testing JSONPublisher publish method with multiple environments and
+        printing the output"""
+
+        self.publisher.publish(environment=self.environment)
+        self.publisher.publish(environment=self.environment)
+        self.publisher.finish_publishing()
+
+        self.assertEqual(self.printer.print_environment.call_count, 2)
+        self.printer.print_environment.assert_called_with(self.environment)
+        env = json.loads(self.text)
+        expected = json.dumps({'environments': [env, env]}, indent=0)
+        mock_print.assert_called_once_with(expected)
+
+
+class TestPublisherFactory(TestCase):
+    """Testing PublisherFactory component"""
+
+    def test_json_style(self):
+        """Test the creation of a Publisher for JSON output."""
+
+        publisher = PublisherFactory.create_publisher(style=OutputStyle.JSON)
+        self.assertIsInstance(publisher, JSONPublisher)
+        self.assertEqual(publisher.style, OutputStyle.JSON)
+        self.assertEqual(publisher.target, PublisherTarget.TERMINAL)
+        self.assertEqual(publisher.query, QueryType.NONE)
+        self.assertEqual(publisher.verbosity, 0)
+        self.assertEqual(publisher.output, [])
+        self.assertIsNone(publisher.output_file)
+
+    def test_defaults(self):
+        """Test the creation of a Publisher with default arguments."""
+
+        publisher = PublisherFactory.create_publisher()
+        self.assertIsInstance(publisher, PrintPublisher)
+        self.assertEqual(publisher.style, OutputStyle.TEXT)
+        self.assertEqual(publisher.target, PublisherTarget.TERMINAL)
+        self.assertEqual(publisher.query, QueryType.NONE)
+        self.assertEqual(publisher.verbosity, 0)
+        self.assertIsNone(publisher.output_file)
+
+    def test_colorized_style(self):
+        """Test the creation of a Publisher with colorized style."""
+
+        publisher = PublisherFactory.create_publisher(
+                style=OutputStyle.COLORIZED)
+        self.assertIsInstance(publisher, PrintPublisher)
+        self.assertEqual(publisher.style, OutputStyle.COLORIZED)
+        self.assertEqual(publisher.target, PublisherTarget.TERMINAL)
+        self.assertEqual(publisher.query, QueryType.NONE)
+        self.assertEqual(publisher.verbosity, 0)
+        self.assertIsNone(publisher.output_file)

--- a/tox.ini
+++ b/tox.ini
@@ -45,8 +45,8 @@ commands =
 passenv =
     DOCKER_HOST
 setenv=
-    # set timeout for e2e testing to 3 minutes
-    TC_MAX_TRIES = 180
+    # set timeout for e2e testing to 5 minutes
+    TC_MAX_TRIES = 300
 deps =
     -r {toxinidir}/requirements.txt
     -r {toxinidir}/test-requirements.txt


### PR DESCRIPTION
Producing JSON output for multiple environments requires accumulating
the environments string representation and print it all at once, after
all queries have finished. On the other hand, when printing to screen,
we want to show the output as soon as each environment is queried,
so this change introduces two Publisher classes, one for each use
case.
