### PR TITLE
Make parsing of the plugin argument aware of subcommands

### DIFF
--- a/cibyl/cli/main.py
+++ b/cibyl/cli/main.py
@@ -29,6 +29,29 @@ from cibyl.utils.logger import configure_logging
 LOG = logging.getLogger(__name__)
 
 
+def get_plugins_from_arguments(arguments: List[str], index: int) -> List[str]:
+    """Get the list of plugins from the arguments list. This requires iterating
+    through the argument list until another argument (starting with a '-') or
+    a subcommand (query, features, spec) is found.
+
+    :param arguments: A list of strings representing the arguments and their
+                      values, defaults to None
+    :param index: Index of the arguments list to start looking at
+    :returns: List of plugin names found in argument list
+    """
+    # list of all possible subcommands, needed so a command like
+    # cibyl -p plugin1 query --jobs does not mistake the query subcommand with
+    # a plugin name
+    subcommands_list = ["query", "spec", "features"]
+    plugins = []
+    for argument in arguments[(index + 2):]:
+        if argument.startswith("-") or argument in subcommands_list:
+            break
+        plugins.append(argument)
+
+    return plugins
+
+
 def raw_parsing(arguments: List[str]) -> dict:
     """Returns config file path if one was passed with --config argument
 
@@ -55,12 +78,7 @@ def raw_parsing(arguments: List[str]) -> dict:
             # exception traceback is clearer
             args["debug"] = True
         elif item in ('-p', '--plugin'):
-            plugins = []
-            for argument in arguments[(i + 2):]:
-                if argument.startswith("-"):
-                    break
-                plugins.append(argument)
-            args["plugins"] = plugins
+            args["plugins"] = get_plugins_from_arguments(arguments, i)
         elif item in ('-o', '--output'):
             args["output_file_path"] = arguments[i + 2]
         elif item in ('-f', '--output-format'):

--- a/tests/cibyl/unit/cli/test_raw_parsing.py
+++ b/tests/cibyl/unit/cli/test_raw_parsing.py
@@ -80,3 +80,24 @@ class TestRawParsing(TestCase):
         self.assertEqual(args['logging'], logging.DEBUG)
         self.assertEqual(args['plugins'], ['plugin1', 'plugin2'])
         self.assertEqual(args['output_style'], OutputStyle.from_key('text'))
+
+    def test_parser_plugin_argument_with_query(self):
+        """Tests parser plugin argument with subcommands."""
+        parse_args = ['cibyl', '--plugin', 'openstack', 'unknown', 'query',
+                      '--jobs']
+        args = raw_parsing(parse_args)
+        self.assertEqual(args['plugins'], ['openstack', 'unknown'])
+
+    def test_parser_plugin_argument_with_features(self):
+        """Tests parser plugin argument with subcommands."""
+        parse_args = ['cibyl', '--plugin', 'openstack', 'unknown', 'features']
+
+        args = raw_parsing(parse_args)
+        self.assertEqual(args['plugins'], ['openstack', 'unknown'])
+
+    def test_parser_plugin_argument_with_spec(self):
+        """Tests parser plugin argument with subcommands."""
+        parse_args = ['cibyl', '--plugin', 'openstack', 'unknown', 'spec']
+
+        args = raw_parsing(parse_args)
+        self.assertEqual(args['plugins'], ['openstack', 'unknown'])


### PR DESCRIPTION
The parsing of app-level arguments done before the full parsing did not
take into account the subcommands. This creates a problem if plugins are
specified with the -p flag, since it would read plugins until another
argument was found, but could not distinguish between plugin names and
subcommands. This commit fixes the problem by keeping a list of all
available subcommands and using it to check which arguments are plugin
names.
