### PR TITLE
Retrieving implicit branches for untrusted projects on the Zuul source

### DIFF
--- a/cibyl/models/ci/zuul/job.py
+++ b/cibyl/models/ci/zuul/job.py
@@ -88,26 +88,6 @@ class Job(BaseJob):
                 }
             )
 
-        @staticmethod
-        def from_data(data):
-            """Builds a variant from the data fetched from the input.
-
-            ..  seealso::
-                :meth:`Job.Variant.__init__` for expected data.
-
-            :param data: Random set of data.
-            :type data: dict[str, Any]
-            :return: The variant instance.
-            :rtype: :class:`Job.Variant`
-            """
-            return Job.Variant(
-                parent=data.get('parent', 'Unknown'),
-                name=data.get('name', 'Unknown'),
-                description=data.get('description'),
-                branches=data.get('branches'),
-                variables=data.get('variables')
-            )
-
         def __eq__(self, other):
             if not isinstance(other, Job.Variant):
                 return False

--- a/cibyl/sources/zuul/apis/__init__.py
+++ b/cibyl/sources/zuul/apis/__init__.py
@@ -190,6 +190,14 @@ class ZuulVariantAPI(Closeable, ABC):
         return self._job
 
     @property
+    def parent(self):
+        """
+        :return: Name of the parent job for this variant.
+        :rtype: str
+        """
+        return self.raw['parent']
+
+    @property
     def name(self):
         """
         :return: The name of the variant.
@@ -198,12 +206,24 @@ class ZuulVariantAPI(Closeable, ABC):
         return self.raw['name']
 
     @property
-    def parent(self):
+    def description(self):
         """
-        :return: Name of the parent job of this variant.
+        :return: Explains what makes this variant special.
         :rtype: str
         """
-        return self.raw['parent']
+        return self.raw['description']
+
+    @property
+    def branches(self):
+        """
+        :return: Regular expressions which describe the branches the job
+            runs on. For untrusted jobs, this collection being empty means
+            that the job will trigger on the branch from its definition. On
+            config jobs, it being empty means that the job will trigger on
+            all branches.
+        :rtype: list[str]
+        """
+        return self.raw['branches']
 
     @property
     def context(self):

--- a/cibyl/sources/zuul/apis/__init__.py
+++ b/cibyl/sources/zuul/apis/__init__.py
@@ -229,9 +229,13 @@ class ZuulVariantAPI(Closeable, ABC):
     def context(self):
         """
         :return: The source context of the variant.
-        :rtype: :class:`ZuulVariantAPI.Context`
+        :rtype: :class:`ZuulVariantAPI.Context` or None
         """
         context = self.raw['source_context']
+
+        # Very unlikely, but some jobs may not have a definition
+        if not context:
+            return None
 
         return ZuulVariantAPI.Context(
             project=context['project'],

--- a/cibyl/sources/zuul/output.py
+++ b/cibyl/sources/zuul/output.py
@@ -147,7 +147,13 @@ class QueryOutputBuilder:
         job = self.with_job(variant.job)
 
         # Generate the variant's model
-        model = Job.Variant.from_data(variant.data)
+        model = Job.Variant(
+            parent=variant.parent,
+            name=variant.name,
+            description=variant.description,
+            branches=variant.branches,
+            variables=variant.variables(recursive=True)
+        )
 
         # Register the variant
         job.add_variant(model)

--- a/cibyl/sources/zuul/transactions/__init__.py
+++ b/cibyl/sources/zuul/transactions/__init__.py
@@ -642,12 +642,42 @@ class VariantResponse:
         return JobResponse(self._variant.job)
 
     @property
+    def parent(self):
+        """
+        :return: Name of the variant's parent job.
+        :rtype str
+        """
+        return self._variant.parent
+
+    @property
     def name(self):
         """
         :return: The variants name. Most likely, it will match its job's name.
         :rtype: str
         """
         return self._variant.name
+
+    @property
+    def description(self):
+        """
+        :return: Deeper information on this variant's purpose.
+        :rtype: str
+        """
+        return self._variant.description
+
+    @property
+    def branches(self):
+        """
+        :return: Collection of branch names / regex patterns that indicate the
+            branches the variant triggers on.
+        :rtype: list[str]
+        """
+        result = self._variant.branches
+
+        if not result:
+            result = [self._variant.context.branch]
+
+        return result
 
     @property
     def data(self):

--- a/tests/cibyl/intr/plugins/openstack/sources/zuul/test_actions.py
+++ b/tests/cibyl/intr/plugins/openstack/sources/zuul/test_actions.py
@@ -54,18 +54,14 @@ class TestDeploymentQuery(TestCase):
 
         variant1 = Mock()
         variant1.job = job
-        variant1.data = {
-            'name': 'variant1'
-        }
+        variant1.name = 'variant1'
         variant1.variables.return_value = {
             'rhos_release_version': '1.2'
         }
 
         variant2 = Mock()
         variant2.job = job
-        variant2.data = {
-            'name': 'variant2'
-        }
+        variant2.name = 'variant2'
         variant2.variables.return_value = {
             'rhos_release_version': '2.0'
         }
@@ -88,4 +84,4 @@ class TestDeploymentQuery(TestCase):
 
         # Check the that variant in the first release is the one returned
         self.assertEqual(1, len(result_variants))
-        self.assertEqual(variant1.data['name'], result_variants[0].name.value)
+        self.assertEqual(variant1.name, result_variants[0].name.value)

--- a/tests/cibyl/intr/sources/zuul/queries/composition/test_quick.py
+++ b/tests/cibyl/intr/sources/zuul/queries/composition/test_quick.py
@@ -278,11 +278,12 @@ class TestQuickQuery(TestCase):
         job.variants.return_value = [variant]
 
         variant.job = job
-        variant.raw = {
-            'parent': 'job',
-            'name': 'variant',
-            'description': 'desc'
-        }
+        variant.parent = 'job'
+        variant.name = 'variant'
+        variant.description = 'desc'
+        variant.branches = ['branch']
+        variant.variables = Mock()
+        variant.variables.return_value = {}
 
         api = Mock()
         api.tenants = Mock()
@@ -324,9 +325,11 @@ class TestQuickQuery(TestCase):
                         url=job.url,
                         variants=[
                             Job.Variant(
-                                parent=variant.raw['parent'],
-                                name=variant.raw['name'],
-                                description=variant.raw['description']
+                                parent=variant.parent,
+                                name=variant.name,
+                                description=variant.description,
+                                branches=variant.branches,
+                                variables=variant.variables.return_value
                             )
                         ]
                     )

--- a/tests/cibyl/unit/sources/zuul/apis/test_rest.py
+++ b/tests/cibyl/unit/sources/zuul/apis/test_rest.py
@@ -204,6 +204,49 @@ class TestZuulVariantRESTClient(TestCase):
             variant.variables(recursive=True)
         )
 
+    def test_context(self):
+        """Checks that the API fetches the source context for the variant.
+        """
+        session = Mock()
+        job = Mock()
+        variant = {
+            'source_context': {
+                'project': 'project',
+                'branch': 'master',
+                'path': 'some/path'
+            }
+        }
+
+        client = ZuulVariantRESTClient(
+            session=session,
+            job=job,
+            variant=variant
+        )
+
+        result = client.context
+
+        self.assertEqual(variant['source_context']['project'], result.project)
+        self.assertEqual(variant['source_context']['branch'], result.branch)
+        self.assertEqual(variant['source_context']['path'], result.path)
+
+    def test_null_context(self):
+        """Checks that 'None' is returned if the variant has no source
+        context.
+        """
+        session = Mock()
+        job = Mock()
+        variant = {
+            'source_context': None
+        }
+
+        client = ZuulVariantRESTClient(
+            session=session,
+            job=job,
+            variant=variant
+        )
+
+        self.assertIsNone(client.context)
+
     class TestZuulJobRESTClient(TestCase):
         """Tests for :class:`ZuulJobRESTClient`.
         """

--- a/tests/cibyl/unit/sources/zuul/test_transactions.py
+++ b/tests/cibyl/unit/sources/zuul/test_transactions.py
@@ -20,8 +20,8 @@ from parameterized import parameterized
 
 from cibyl.cli.ranged_argument import Range
 from cibyl.models.ci.zuul.test import TestKind, TestStatus
-from cibyl.sources.zuul.transactions import TestResponse, TestsRequest, \
-    VariantResponse
+from cibyl.sources.zuul.transactions import (TestResponse, TestsRequest,
+                                             VariantResponse)
 from cibyl.sources.zuul.utils.tests.tempest.types import TempestTest
 from cibyl.sources.zuul.utils.tests.types import Test, TestResult
 

--- a/tests/cibyl/unit/sources/zuul/test_transactions.py
+++ b/tests/cibyl/unit/sources/zuul/test_transactions.py
@@ -20,7 +20,8 @@ from parameterized import parameterized
 
 from cibyl.cli.ranged_argument import Range
 from cibyl.models.ci.zuul.test import TestKind, TestStatus
-from cibyl.sources.zuul.transactions import TestResponse, TestsRequest
+from cibyl.sources.zuul.transactions import TestResponse, TestsRequest, \
+    VariantResponse
 from cibyl.sources.zuul.utils.tests.tempest.types import TempestTest
 from cibyl.sources.zuul.utils.tests.types import Test, TestResult
 
@@ -109,6 +110,37 @@ class TestTestsRequest(TestCase):
 
         self.assertEqual(1, len(result))
         self.assertEqual(test1.name, result[0].name)
+
+
+class TestVariantResponse(TestCase):
+    """Tests for :class:`VariantResponse`.
+    """
+
+    def test_explicit_branches(self):
+        """Checks that when the variant has explicit branches assigned to
+        it, those are the ones returned.
+        """
+        api = Mock()
+        api.branches = ['explicit']
+
+        variant = VariantResponse(variant=api)
+
+        self.assertEqual(api.branches, variant.branches)
+
+    def test_implicit_branches(self):
+        """Checks that when the variant has no explicit branches assigned to
+        it, the branch is implicitly extracted from its definition then.
+        """
+        context = Mock()
+        context.branch = 'implicit'
+
+        api = Mock()
+        api.branches = []
+        api.context = context
+
+        variant = VariantResponse(variant=api)
+
+        self.assertEqual([context.branch], variant.branches)
 
 
 class TestTestResponse(TestCase):


### PR DESCRIPTION
As described here: https://zuul-ci.org/docs/zuul/latest/config/job.html#attr-job.branches, when the branches of a variant are not explicitly defined, they take the branch from their definition file. This PR makes Cibyl display that same behavior, matching with it what it shown on Zuul's UI.

There are another two conditions I have to do without:
- If the variant's repo has a single branch, then that is the one used. It is so likely to match its definition's branch, that I do not think is necessary to query the repo for the name. I am not sure even Zuul's UI does it.
- If the job is on a configuration project, the job is assigned to all branches instead. Figuring this out is a very taxing operation that again Zuul's UI does not bother doing. It is hard to tell the projects a job is assigned to starting from it. 