### PR TITLE
Use different index for ELK queries

### DIFF
--- a/cibyl/plugins/openstack/sources/elasticsearch.py
+++ b/cibyl/plugins/openstack/sources/elasticsearch.py
@@ -193,7 +193,7 @@ class ElasticSearch(SourceExtension):
 
             results = self.__query_get_hits(
                 query=query_body,
-                index='logstash_jenkins'
+                index='logstash_jenkins_jobs_cibyl'
             )
             for result in results:
                 hits_info[


### PR DESCRIPTION
The logstash_jenkins index contained multiple documents for a single job 
build. This caused some issues as some documents were missing fields 
like ip_version, topology, ...

The new logstash_jenkins_jobs_cibyl index contains one document per
job build. Using this index we make sure that each time we query
for a specific job we get all fields (ip_version, topology, ...) that
are available for a given job.