### PR TITLE
Add missing value to some features

### DIFF
--- a/cibyl/plugins/openstack/features/ironic.py
+++ b/cibyl/plugins/openstack/features/ironic.py
@@ -35,5 +35,5 @@ class Inspector(OpenstackFeatureTemplate, FeatureDefinition):
         the feature."""
         inspector_arg = Argument("ironic_inspector", arg_type=str,
                                  description="Ironic Inspector",
-                                 func="get_deployment")
+                                 func="get_deployment", value="True")
         return {'ironic_inspector': inspector_arg}

--- a/cibyl/plugins/openstack/features/network.py
+++ b/cibyl/plugins/openstack/features/network.py
@@ -89,5 +89,5 @@ class DVR(OpenstackFeatureTemplate, FeatureDefinition):
         the feature."""
         dvr_arg = Argument("dvr", arg_type=str,
                            description="DVR enabled",
-                           func="get_deployment")
+                           func="get_deployment", value="True")
         return {'dvr': dvr_arg}

--- a/cibyl/plugins/openstack/features/security.py
+++ b/cibyl/plugins/openstack/features/security.py
@@ -36,5 +36,5 @@ class TLSEverywhere(OpenstackFeatureTemplate, FeatureDefinition):
         the feature."""
         tls_everywhere_arg = Argument("tls_everywhere", arg_type=str,
                                       description="TLS Everywhere",
-                                      func="get_deployment")
+                                      func="get_deployment", value="True")
         return {'tls_everywhere': tls_everywhere_arg}

--- a/tox.ini
+++ b/tox.ini
@@ -45,8 +45,8 @@ commands =
 passenv =
     DOCKER_HOST
 setenv=
-    # set timeout for e2e testing to 5 minutes
-    TC_MAX_TRIES = 300
+    # set timeout for e2e testing to 10 minutes
+    TC_MAX_TRIES = 600
 deps =
     -r {toxinidir}/requirements.txt
     -r {toxinidir}/test-requirements.txt


### PR DESCRIPTION
Some features missed the value paremeter in the argument passed to
get_deployment, which caused them not to properly filter jobs and report
inaccurate results.
