### PR TITLE
Letting the user choose query mode on Zuul source

### DIFF
--- a/cibyl/models/ci/zuul/system.py
+++ b/cibyl/models/ci/zuul/system.py
@@ -27,14 +27,27 @@ class ZuulSystem(System):
     API = deepcopy(System.API)
     API.update(
         {
+            'modes': {
+                'attr_type': str,
+                'arguments': [
+                    Argument(
+                        name='--mode', arg_type=str, nargs=1,
+                        choices=('normal', 'verbose'),
+                        default='normal',
+                        description='Decides on contents of output'
+                    )
+                ]
+            },
             'tenants': {
                 'attr_type': Tenant,
                 'attribute_value_class': AttributeDictValue,
                 'arguments': [
-                    Argument(name='--tenants', arg_type=str,
-                             nargs='*',
-                             description='System tenants',
-                             func='get_tenants')
+                    Argument(
+                        name='--tenants', arg_type=str,
+                        nargs='*',
+                        description='System tenants',
+                        func='get_tenants'
+                    )
                 ]
             }
         }

--- a/cibyl/sources/zuul/output.py
+++ b/cibyl/sources/zuul/output.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Dict, Optional
 
 from cibyl.models.ci.zuul.build import Build
@@ -30,6 +31,42 @@ from cibyl.sources.zuul.utils.variants.hierarchy import \
 class QueryOutput(Dict[str, Tenant]):
     """The hierarchy of models that form a response for a Zuul query.
     """
+
+
+class QueryOutputMode(Enum):
+    """Decides the style on which the query's output should be generated.
+    """
+    NORMAL = 0
+    """Chooses speed over completeness. This mode will focus on getting the
+    bare minimum information to satisfy the query. Each element is treated
+    independently and listed on its own.
+    """
+    VERBOSE = 1
+    """Chooses completeness over speed. This mode will focus on getting as
+    much information from the host as it can, no matter how long that can
+    take. Elements are related to each other and listed as dependencies.
+    For example, this mode will join pipelines and jobs together to
+    indicate which of them each pipeline triggers."""
+
+    @staticmethod
+    def from_key(key: str) -> "QueryOutputMode":
+        """Parses a key into a :class:`QueryOutputMode`.
+
+        Map of known keys:
+            * 'normal' -> QueryOutputMode.NORMAL
+            * 'verbose' -> QueryOutputMode.VERBOSE
+
+        :param: key: The key to get the mode for.
+        :return: The correspondent mode.
+        :raise NotImplementedError: If no mode is found for the given key.
+        """
+        if key == 'normal':
+            return QueryOutputMode.NORMAL
+
+        if key == 'verbose':
+            return QueryOutputMode.VERBOSE
+
+        raise NotImplementedError(f"Unknown key: '{key}'.")
 
 
 class QueryOutputBuilder:

--- a/cibyl/sources/zuul/queries/composition/factory.py
+++ b/cibyl/sources/zuul/queries/composition/factory.py
@@ -13,8 +13,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+import logging
+
 from cibyl.sources.zuul.apis import ZuulAPI as Zuul
+from cibyl.sources.zuul.output import QueryOutputMode
+from cibyl.sources.zuul.queries.composition.quick import QuickQuery
 from cibyl.sources.zuul.queries.composition.verbose import VerboseQuery
+
+LOG = logging.getLogger(__name__)
 
 
 class AggregatedQueryFactory:
@@ -29,4 +35,21 @@ class AggregatedQueryFactory:
         :param kwargs: Random set of arguments.
         :return: The query instance.
         """
-        return VerboseQuery(api)
+        arg = kwargs.get('mode')
+
+        if not arg:
+            msg = "'mode' argument is missing. Defaulting to quick query..."
+            LOG.warning(msg)
+            return QuickQuery(api)
+
+        mode = QueryOutputMode.from_key(arg)
+
+        if mode == QueryOutputMode.NORMAL:
+            return QuickQuery(api)
+
+        if mode == QueryOutputMode.VERBOSE:
+            return VerboseQuery(api)
+
+        msg = "Unknown query mode: '%s'. Defaulting to quick query..."
+        LOG.warning(msg, arg)
+        return QuickQuery(api)

--- a/tests/cibyl/unit/sources/zuul/queries/composition/test_factory.py
+++ b/tests/cibyl/unit/sources/zuul/queries/composition/test_factory.py
@@ -1,0 +1,94 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from cibyl.sources.zuul.output import QueryOutputMode
+from cibyl.sources.zuul.queries.composition.factory import \
+    AggregatedQueryFactory
+from cibyl.sources.zuul.queries.composition.quick import QuickQuery
+from cibyl.sources.zuul.queries.composition.verbose import VerboseQuery
+
+pkg = 'cibyl.sources.zuul.queries.composition.factory'
+
+
+class TestAggregatedQueryFactory(TestCase):
+    """Tests for :class:`AggregatedQueryFactory`.
+    """
+
+    def test_defaults_to_quick_if_no_arg(self):
+        """Checks that if the mode is not specified then the quick query is
+        returned.
+        """
+        api = Mock()
+
+        query = AggregatedQueryFactory()
+
+        result = query.from_kwargs(api)
+
+        self.assertIsInstance(result, QuickQuery)
+
+    @patch(f'{pkg}.QueryOutputMode.from_key')
+    def test_defaults_to_quick_if_unknown(self, parser: Mock):
+        """Checks that if the mode is unknown then the quick query is
+        returned.
+        """
+        api = Mock()
+        arg = 'unknown'
+
+        parser.return_value = 10
+
+        query = AggregatedQueryFactory()
+
+        result = query.from_kwargs(api, **{'mode': arg})
+
+        self.assertIsInstance(result, QuickQuery)
+
+        parser.assert_called_once_with(arg)
+
+    @patch(f'{pkg}.QueryOutputMode.from_key')
+    def test_quick_mode(self, parser: Mock):
+        """Checks that quick mode is returned if the argument specifies so.
+        """
+        api = Mock()
+        arg = 'normal'
+
+        parser.return_value = QueryOutputMode.NORMAL
+
+        query = AggregatedQueryFactory()
+
+        result = query.from_kwargs(api, **{'mode': arg})
+
+        self.assertIsInstance(result, QuickQuery)
+
+        parser.assert_called_once_with(arg)
+
+    @patch(f'{pkg}.QueryOutputMode.from_key')
+    def test_verbose_mode(self, parser: Mock):
+        """Checks that verbose mode is returned if the argument specifies so.
+        """
+        api = Mock()
+        arg = 'verbose'
+
+        parser.return_value = QueryOutputMode.VERBOSE
+
+        query = AggregatedQueryFactory()
+
+        result = query.from_kwargs(api, **{'mode': arg})
+
+        self.assertIsInstance(result, VerboseQuery)
+
+        parser.assert_called_once_with(arg)

--- a/tests/cibyl/unit/sources/zuul/test_output.py
+++ b/tests/cibyl/unit/sources/zuul/test_output.py
@@ -16,7 +16,31 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from cibyl.sources.zuul.output import QueryOutputBuilder
+from cibyl.sources.zuul.output import QueryOutputBuilder, QueryOutputMode
+
+
+class TestQueryOutputMode(TestCase):
+    """Tests for :class:`QueryOutputMode`.
+    """
+
+    def test_from_key(self):
+        """Test that the correct modes are returned for the indicated keys.
+        """
+        self.assertEqual(
+            QueryOutputMode.NORMAL,
+            QueryOutputMode.from_key('normal')
+        )
+
+        self.assertEqual(
+            QueryOutputMode.VERBOSE,
+            QueryOutputMode.from_key('verbose')
+        )
+
+    def test_error_if_unknown(self):
+        """Checks that an error is thrown if the key cannot be parsed.
+        """
+        with self.assertRaises(NotImplementedError):
+            QueryOutputMode.from_key('unknown')
 
 
 class TestQueryOutputBuilder(TestCase):


### PR DESCRIPTION
The Zuul source now provides two ways of functioning:
- Normal mode -> Will not be able to list jobs below pipelines, much faster in exchange.
- Verbose mode -> Lists jobs below pipelines, takes much longer.

Mode is selected with '--mode', being 'normal' the default.