### PR TITLE
Fixing a bug where variants with a branch pattern would fail to fetch their spec

### DIFF
--- a/cibyl/sources/zuul/utils/variants/hierarchy.py
+++ b/cibyl/sources/zuul/utils/variants/hierarchy.py
@@ -128,7 +128,12 @@ class VariantFinder:
             for candidate in job.variants().get():
                 for condition in candidate.branches:
                     for branch in variant.branches:
+                        # See if parent pattern matches with my branch
                         if matches_regex(condition, branch):
+                            return candidate
+
+                        # See if my pattern matches with my parent's branch
+                        if matches_regex(branch, condition):
                             return candidate
 
             raise SearchError(

--- a/cibyl/sources/zuul/utils/variants/hierarchy.py
+++ b/cibyl/sources/zuul/utils/variants/hierarchy.py
@@ -128,11 +128,11 @@ class VariantFinder:
             for candidate in job.variants().get():
                 for condition in candidate.branches:
                     for branch in variant.branches:
-                        # See if parent pattern matches with my branch
+                        # See if parent pattern matches my branch
                         if matches_regex(condition, branch):
                             return candidate
 
-                        # See if my pattern matches with my parent's branch
+                        # See if my pattern matches my parent's branch
                         if matches_regex(branch, condition):
                             return candidate
 


### PR DESCRIPTION
If the spec was requested for a variant whose branch is '.*', Cibyl failed to understand that and could not continue. This change makes Cibyl see that that is a pattern and it can be used to match against the variant's parent branches.