### PR TITLE
Adding the '--look-for-pipelines' argument to trigger verbose queries.

### DIFF
--- a/cibyl/models/ci/zuul/pipeline.py
+++ b/cibyl/models/ci/zuul/pipeline.py
@@ -38,7 +38,7 @@ class Pipeline(Model):
                     func='get_jobs'
                 ),
                 Argument(
-                    name='--look-for-pipelines',
+                    name='--fetch-pipelines',
                     arg_type=str, nargs=0,
                     description='Show the job below the pipelines that '
                                 'trigger it. '

--- a/cibyl/models/ci/zuul/pipeline.py
+++ b/cibyl/models/ci/zuul/pipeline.py
@@ -36,6 +36,14 @@ class Pipeline(Model):
                     arg_type=str, nargs='*',
                     description='Jobs belonging to pipeline',
                     func='get_jobs'
+                ),
+                Argument(
+                    name='--look-for-pipelines',
+                    arg_type=str, nargs=0,
+                    description='Show the job below the pipelines that '
+                                'trigger it. '
+                                'Warning, this operation may take long to '
+                                'perform.'
                 )
             ]
         }

--- a/cibyl/sources/zuul/queries/composition/factory.py
+++ b/cibyl/sources/zuul/queries/composition/factory.py
@@ -14,6 +14,7 @@
 #    under the License.
 """
 from cibyl.sources.zuul.apis import ZuulAPI as Zuul
+from cibyl.sources.zuul.queries.composition.quick import QuickQuery
 from cibyl.sources.zuul.queries.composition.verbose import VerboseQuery
 
 
@@ -29,4 +30,7 @@ class AggregatedQueryFactory:
         :param kwargs: Random set of arguments.
         :return: The query instance.
         """
-        return VerboseQuery(api)
+        if 'look_for_pipelines' in kwargs:
+            return VerboseQuery(api)
+
+        return QuickQuery(api)

--- a/cibyl/sources/zuul/queries/composition/factory.py
+++ b/cibyl/sources/zuul/queries/composition/factory.py
@@ -30,7 +30,7 @@ class AggregatedQueryFactory:
         :param kwargs: Random set of arguments.
         :return: The query instance.
         """
-        if 'look_for_pipelines' in kwargs:
+        if 'fetch_pipelines' in kwargs:
             return VerboseQuery(api)
 
         return QuickQuery(api)

--- a/tests/cibyl/unit/sources/zuul/queries/composition/test_factory.py
+++ b/tests/cibyl/unit/sources/zuul/queries/composition/test_factory.py
@@ -34,7 +34,7 @@ class TestAggregatedQueryFactory(TestCase):
         self.assertIsInstance(
             factory.from_kwargs(
                 api=Mock(),
-                **{'look_for_pipelines': None}
+                **{'fetch_pipelines': None}
             ),
             VerboseQuery
         )

--- a/tests/cibyl/unit/sources/zuul/queries/composition/test_factory.py
+++ b/tests/cibyl/unit/sources/zuul/queries/composition/test_factory.py
@@ -1,0 +1,53 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from cibyl.sources.zuul.queries.composition.factory import \
+    AggregatedQueryFactory
+from cibyl.sources.zuul.queries.composition.quick import QuickQuery
+from cibyl.sources.zuul.queries.composition.verbose import VerboseQuery
+
+
+class TestAggregatedQueryFactory(TestCase):
+    """Tests for :class:`AggregatedQueryFactory`.
+    """
+
+    def test_verbose_query(self):
+        """Checks conditions that make the verbose query be returned.
+        """
+        factory = AggregatedQueryFactory()
+
+        self.assertIsInstance(
+            factory.from_kwargs(
+                api=Mock(),
+                **{'look_for_pipelines': None}
+            ),
+            VerboseQuery
+        )
+
+    def test_quick_query(self):
+        """Checks conditions that make the quick query be returned.
+        """
+        factory = AggregatedQueryFactory()
+
+        self.assertIsInstance(
+            factory.from_kwargs(
+                api=Mock(),
+                **{}
+            ),
+            QuickQuery
+        )


### PR DESCRIPTION
Being figuring out the pipelines that trigger a build the only reason to ever use verbose query on the Zuul source, I have added a simple argument to trigger that path. Much simpler than working with different modes at printer level.