### PR TITLE
Fix crash while retrieving a job's spec

### DIFF
--- a/tests/cibyl/unit/sources/zuul/utils/variants/test_hierarchy.py
+++ b/tests/cibyl/unit/sources/zuul/utils/variants/test_hierarchy.py
@@ -208,6 +208,45 @@ class TestHierarchyCrawler(TestCase):
         with self.assertRaises(StopIteration):
             next(iterator)
 
+    def test_stops_if_error_in_search(self):
+        """Checks that if an error occurs while looking for the parent
+        variant, the iteration stops prematurely.
+        """
+
+        def parent_of(vrnt):
+            if vrnt == variant:
+                return parent
+
+            if vrnt == parent:
+                raise SearchError
+
+            return None
+
+        parent = Mock()
+        variant = Mock()
+
+        finder = Mock()
+        finder.find = Mock()
+        finder.find.return_value = Mock()
+        finder.find.return_value.parent_of = Mock()
+        finder.find.return_value.parent_of.side_effect = parent_of
+
+        tools = Mock()
+        tools.variants = finder
+
+        crawler = HierarchyCrawler(
+            variant=variant,
+            tools=tools
+        )
+
+        iterator = iter(crawler)
+
+        self.assertEqual(variant, next(iterator))
+        self.assertEqual(parent, next(iterator))
+
+        with self.assertRaises(StopIteration):
+            next(iterator)
+
 
 class TestHierarchyCrawlerFactory(TestCase):
     """Tests for :class:`HierarchyCrawlerFactory`.


### PR DESCRIPTION
When the parent of a job is not present on the Zuul host, Cibyl will now continue with whatever information it could gather until that point instead of just crashing. A warning message is shown indicating that the problem happened, but it could be saved.