### PR TITLE
Allowing multiple query types through the use of a bitmasks.

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -118,7 +118,8 @@ class QuerySelector:
         if self.query_selector_functions:
             plugins_query = max([get_query(**kwargs) for get_query in
                                  self.query_selector_functions])
-        return max(core_query, plugins_query)
+
+        return core_query | plugins_query
 
 
 def get_query_type(command: Optional[str] = None, **kwargs) -> QueryType:

--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -116,8 +116,8 @@ class QuerySelector:
         core_query = self.get_query_type_core(command=command, **kwargs)
         plugins_query = QueryType.NONE
         if self.query_selector_functions:
-            plugins_query = max([get_query(**kwargs) for get_query in
-                                 self.query_selector_functions])
+            for get_query in self.query_selector_functions:
+                plugins_query |= get_query(**kwargs)
 
         return core_query | plugins_query
 

--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -13,35 +13,35 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-from enum import IntEnum
+from enum import IntFlag, auto
 from typing import Optional
 
 from cibyl.utils.dicts import subset
 
 
-class QueryType(IntEnum):
+class QueryType(IntFlag):
     """Defines the hierarchy level at which a query is meant to be performed.
     """
     NONE = 0
     """No data from host is requested."""
-    FEATURES = 1
+    FEATURES = auto()
     """Retrieve data using features."""
-    TENANTS = 2
-    """Only retrieve data concerning tenants."""
-    PROJECTS = 3
-    """Retrieve data concerning projects and above."""
-    PIPELINES = 4
-    """Retrieve data concerning pipelines and above."""
-    JOBS = 5
-    """Retrieve data concerning jobs and above."""
-    VARIANTS = 6
-    """Retrieve data concerning job variants and above."""
-    BUILDS = 7
-    """Retrieve data concerning builds and above."""
-    TESTS = 8
-    """Retrieve data concerning tests and above."""
-    FEATURES_JOBS = 9
+    FEATURES_JOBS = auto()
     """Retrieve data using features and jobs."""
+    TENANTS = auto()
+    """Only retrieve data concerning tenants."""
+    PROJECTS = auto()
+    """Retrieve data concerning projects and above."""
+    PIPELINES = auto()
+    """Retrieve data concerning pipelines and above."""
+    JOBS = auto()
+    """Retrieve data concerning jobs and above."""
+    VARIANTS = auto()
+    """Retrieve data concerning job variants and above."""
+    BUILDS = auto()
+    """Retrieve data concerning builds and above."""
+    TESTS = auto()
+    """Retrieve data concerning tests and above."""
 
 
 class QuerySelector:
@@ -72,34 +72,34 @@ class QuerySelector:
         result = QueryType.NONE
 
         if 'tenants' in kwargs:
-            result = QueryType.TENANTS
+            result |= QueryType.TENANTS
 
         if 'projects' in kwargs:
-            result = QueryType.PROJECTS
+            result |= QueryType.PROJECTS
 
         if 'pipelines' in kwargs:
-            result = QueryType.PIPELINES
+            result |= QueryType.PIPELINES
 
         job_args = subset(kwargs, ["jobs", "job_url"])
         if job_args:
-            result = QueryType.JOBS
+            result |= QueryType.JOBS
 
         if 'variants' in kwargs:
-            result = QueryType.VARIANTS
+            result |= QueryType.VARIANTS
 
         build_args = subset(kwargs, ["builds", "last_build", "build_status"])
         if build_args:
-            result = QueryType.BUILDS
+            result |= QueryType.BUILDS
 
         test_args = subset(kwargs, ["tests", "test_result", "test_duration"])
         if test_args:
-            result = QueryType.TESTS
+            result |= QueryType.TESTS
 
         if command == 'features':
             if job_args:
-                result = QueryType.FEATURES_JOBS
+                result |= QueryType.FEATURES_JOBS
             else:
-                result = QueryType.FEATURES
+                result |= QueryType.FEATURES
 
         return result
 

--- a/tests/cibyl/unit/cli/test_query.py
+++ b/tests/cibyl/unit/cli/test_query.py
@@ -59,22 +59,18 @@ class TestGetQueryType(TestCase):
         self.assertEqual(QueryType.PIPELINES, get_query_type(**args))
 
     def test_get_jobs(self):
-        """Checks that "Jobs" is returned for "--jobs", winning over
-        "--tenants".
+        """Checks that "Jobs" is returned for "--jobs".
         """
         args = {
-            'tenants': None,
             'jobs': None
         }
 
         self.assertEqual(QueryType.JOBS, get_query_type(**args))
 
     def test_get_builds(self):
-        """Checks that "Builds" is returned for "--builds", winning over
-        "--jobs".
+        """Checks that "Builds" is returned for "--builds".
         """
         args = {
-            'jobs': None,
             'builds': None
         }
 
@@ -163,8 +159,10 @@ class TestGetQueryType(TestCase):
             'jobs': None
         }
 
-        self.assertEqual(QueryType.FEATURES_JOBS,
-                         get_query_type(command="features", **args))
+        self.assertIn(
+            QueryType.FEATURES_JOBS,
+            get_query_type(command="features", **args)
+        )
 
     def test_get_feature_jobs_no_command(self):
         """Checks that "JOBS" is returned for "--feature" and
@@ -183,7 +181,7 @@ class TestGetQueryType(TestCase):
             'last_build': None
         }
 
-        self.assertEqual(QueryType.TESTS, get_query_type(**args))
+        self.assertIn(QueryType.TESTS, get_query_type(**args))
 
 
 class TestGetQueryTypeOpenstackPlugin(OpenstackPluginWithJobSystem):

--- a/tests/cibyl/unit/cli/test_query.py
+++ b/tests/cibyl/unit/cli/test_query.py
@@ -336,7 +336,7 @@ class TestGetQueryTypeOpenstackPlugin(OpenstackPluginWithJobSystem):
             'cinder_backend': None
         }
 
-        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+        self.assertIn(QueryType.JOBS, get_query_type(**args))
 
     def test_get_spec_packages(self):
         """Checks that "Jobs" is returned for "--packages" if the
@@ -348,7 +348,7 @@ class TestGetQueryTypeOpenstackPlugin(OpenstackPluginWithJobSystem):
             'packages': None
         }
 
-        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+        self.assertIn(QueryType.JOBS, get_query_type(**args))
 
     def test_get_spec_services(self):
         """Checks that "Jobs" is returned for "--services" if the
@@ -360,7 +360,7 @@ class TestGetQueryTypeOpenstackPlugin(OpenstackPluginWithJobSystem):
             'services': None
         }
 
-        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+        self.assertIn(QueryType.JOBS, get_query_type(**args))
 
     def test_get_spec_containers(self):
         """Checks that "Jobs" is returned for "--containers" if the
@@ -372,4 +372,4 @@ class TestGetQueryTypeOpenstackPlugin(OpenstackPluginWithJobSystem):
             'containers': None
         }
 
-        self.assertEqual(QueryType.JOBS, get_query_type(**args))
+        self.assertIn(QueryType.JOBS, get_query_type(**args))


### PR DESCRIPTION
The QueryType enumeration was meant to list on a waterfall all possible queries a user could make. From those, the idea was to analyze the arguments the user provided and return the deepest query requested on them.

That approach has become a bit insufficient nowadays, as now we are faced with the need to to not only know about the hardest query being made, but the ones made above it as well.

For such thing, this PR transforms the QueryType enumeration into a bit mask. Allowing for more than one option to be returned in a single value. This way, the printers will receive something like: QueryType.TENANTS|JOBS|BUILDS, which provides more insight on what the user requested that just QueryType.BUILDS. The printer can later check what it is working with the use of the 'in' keyword: QueryType.JOBS in **my_query**. 