### PR TITLE
Fixing a bug where the Zuul source crashed when features where requested.

### DIFF
--- a/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
+++ b/cibyl/plugins/openstack/sources/zuul/deployments/arguments.py
@@ -30,7 +30,10 @@ class ArgumentReview:
         :return: True if the user requested the release to be part of the
             deployment, False if not.
         """
-        return any(arg in kwargs for arg in ('spec', 'release'))
+        return any(
+            arg in kwargs
+            for arg in ('features', 'spec', 'release')
+        )
 
     def is_infra_type_requested(self, **kwargs: Any) -> bool:
         """
@@ -38,7 +41,10 @@ class ArgumentReview:
         :return: True if the user requested the infra type to be part of the
             deployment, False if not.
         """
-        return any(arg in kwargs for arg in ('spec', 'infra_type'))
+        return any(
+            arg in kwargs
+            for arg in ('features', 'spec', 'infra_type')
+        )
 
     def is_nodes_requested(self, **kwargs: Any) -> bool:
         """
@@ -46,7 +52,10 @@ class ArgumentReview:
         :return: True if the user requested the nodes to be part of the
             deployment, False if not.
         """
-        return any(arg in kwargs for arg in ('spec', 'nodes', 'controllers'))
+        return any(
+            arg in kwargs
+            for arg in ('features', 'spec', 'nodes', 'controllers')
+        )
 
     def is_topology_requested(self, **kwargs: Any) -> bool:
         """
@@ -54,7 +63,10 @@ class ArgumentReview:
         :return: True if the user requested the topology to be part of the
             deployment, False if not.
         """
-        return any(arg in kwargs for arg in ('spec', 'topology'))
+        return any(
+            arg in kwargs
+            for arg in ('features', 'spec', 'topology')
+        )
 
     def is_cinder_backend_requested(self, **kwargs: Any) -> bool:
         """
@@ -62,7 +74,10 @@ class ArgumentReview:
         :return: True if the user requested the cinder backend to be part
             of the deployment, False if not.
         """
-        return any(arg in kwargs for arg in ('spec', 'cinder_backend'))
+        return any(
+            arg in kwargs
+            for arg in ('features', 'spec', 'cinder_backend')
+        )
 
     def is_network_backend_requested(self, **kwargs: Any) -> bool:
         """
@@ -70,7 +85,10 @@ class ArgumentReview:
         :return: True if the user requested the network backend to be part
             of the deployment, False if not.
         """
-        return any(arg in kwargs for arg in ('spec', 'network_backend'))
+        return any(
+            arg in kwargs
+            for arg in ('features', 'spec', 'network_backend')
+        )
 
     def is_ip_version_requested(self, **kwargs: Any) -> bool:
         """
@@ -78,7 +96,10 @@ class ArgumentReview:
         :return: True if the user requested the ip version to be part of the
             deployment, False if not.
         """
-        return any(arg in kwargs for arg in ('spec', 'ip_version'))
+        return any(
+            arg in kwargs
+            for arg in ('features', 'spec', 'ip_version')
+        )
 
     def is_tls_everywhere_requested(self, **kwargs: Any) -> bool:
         """
@@ -86,7 +107,10 @@ class ArgumentReview:
         :return: True if the user requested tls everywhere to be part of the
             deployment, False if not.
         """
-        return any(arg in kwargs for arg in ('spec',))
+        return any(
+            arg in kwargs
+            for arg in ('features', 'spec')
+        )
 
     def is_ml2_driver_requested(self, **kwargs: Any) -> bool:
         """
@@ -94,7 +118,10 @@ class ArgumentReview:
         :return: True if the user requested ml2 driver to be part of the
             deployment, False if not.
         """
-        return any(arg in kwargs for arg in ('spec', 'ml2_driver'))
+        return any(
+            arg in kwargs
+            for arg in ('features', 'spec', 'ml2_driver')
+        )
 
 
 class SpecArgumentHandler:

--- a/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_arguments.py
+++ b/tests/cibyl/unit/plugins/openstack/sources/zuul/deployments/test_arguments.py
@@ -32,6 +32,7 @@ class TestArgumentReview(TestCase):
 
         self.assertTrue(review.is_release_requested(**{'release': None}))
         self.assertTrue(review.is_release_requested(**{'spec': None}))
+        self.assertTrue(review.is_release_requested(**{'features': None}))
 
     def test_is_infra_type_requested(self):
         """Checks the conditions required for the infra type to be requested.
@@ -42,6 +43,7 @@ class TestArgumentReview(TestCase):
 
         self.assertTrue(review.is_infra_type_requested(**{'infra_type': None}))
         self.assertTrue(review.is_infra_type_requested(**{'spec': None}))
+        self.assertTrue(review.is_infra_type_requested(**{'features': None}))
 
     def test_is_nodes_requested(self):
         """Checks the conditions required for the nodes list to be
@@ -54,6 +56,7 @@ class TestArgumentReview(TestCase):
         self.assertTrue(review.is_nodes_requested(**{'controllers': None}))
         self.assertTrue(review.is_nodes_requested(**{'nodes': None}))
         self.assertTrue(review.is_nodes_requested(**{'spec': None}))
+        self.assertTrue(review.is_nodes_requested(**{'features': None}))
 
     def test_is_topology_requested(self):
         """Checks the conditions required for the topology to be requested.
@@ -64,6 +67,7 @@ class TestArgumentReview(TestCase):
 
         self.assertTrue(review.is_topology_requested(**{'topology': None}))
         self.assertTrue(review.is_topology_requested(**{'spec': None}))
+        self.assertTrue(review.is_topology_requested(**{'features': None}))
 
     def test_is_cinder_backend_requested(self):
         """Checks the conditions required for the cinder backend to be
@@ -81,6 +85,10 @@ class TestArgumentReview(TestCase):
 
         self.assertTrue(
             review.is_cinder_backend_requested(**{'spec': None})
+        )
+
+        self.assertTrue(
+            review.is_cinder_backend_requested(**{'features': None})
         )
 
     def test_is_network_backend_requested(self):
@@ -101,6 +109,10 @@ class TestArgumentReview(TestCase):
             review.is_network_backend_requested(**{'spec': None})
         )
 
+        self.assertTrue(
+            review.is_network_backend_requested(**{'features': None})
+        )
+
     def test_is_ip_version_requested(self):
         """Checks the conditions required for the ip version to be requested.
         """
@@ -110,15 +122,24 @@ class TestArgumentReview(TestCase):
 
         self.assertTrue(review.is_ip_version_requested(**{'ip_version': None}))
         self.assertTrue(review.is_ip_version_requested(**{'spec': None}))
+        self.assertTrue(review.is_ip_version_requested(**{'features': None}))
 
     def test_is_tls_everywhere_requested(self):
         """Checks the conditions required for tls everywhere to be requested.
         """
         review = ArgumentReview()
 
-        self.assertFalse(review.is_tls_everywhere_requested(**{}))
+        self.assertFalse(
+            review.is_tls_everywhere_requested(**{})
+        )
 
-        self.assertTrue(review.is_tls_everywhere_requested(**{'spec': None}))
+        self.assertTrue(
+            review.is_tls_everywhere_requested(**{'spec': None})
+        )
+
+        self.assertTrue(
+            review.is_tls_everywhere_requested(**{'features': None})
+        )
 
     def test_is_ml2_driver_requested(self):
         """Checks the conditions required for ml2 driver to be requested.
@@ -129,6 +150,7 @@ class TestArgumentReview(TestCase):
 
         self.assertTrue(review.is_ml2_driver_requested(**{'spec': None}))
         self.assertTrue(review.is_ml2_driver_requested(**{'ml2_driver': None}))
+        self.assertTrue(review.is_ml2_driver_requested(**{'features': None}))
 
 
 class TestSpecArgumentHandler(TestCase):


### PR DESCRIPTION
Deployments where not being calculated for the 'features' argument. This made Cibyl crash because the option was counting on that information to be present but is was not. This PR attempts to fix the problem by making Cibyl get the complete deployment of each job for the 'features' command to use.