### PR TITLE
Fixing null pointer for variants that have no context

### DIFF
--- a/cibyl/sources/zuul/transactions/__init__.py
+++ b/cibyl/sources/zuul/transactions/__init__.py
@@ -676,7 +676,10 @@ class VariantResponse:
         result = self._variant.branches
 
         if not result:
-            result = [self._variant.context.branch]
+            context = self._variant.context
+
+            if context:
+                result = [context.branch]
 
         return result
 


### PR DESCRIPTION
Cibyl would crash when dealing with the rare case where a variant had no source context. This PR makes Cibyl be aware of the case and capable of handling it.