### PR TITLE
Adapt system printers for features subcommand

### DIFF
--- a/cibyl/cli/query.py
+++ b/cibyl/cli/query.py
@@ -26,8 +26,6 @@ class QueryType(IntFlag):
     """No data from host is requested."""
     FEATURES = auto()
     """Retrieve data using features."""
-    FEATURES_JOBS = auto()
-    """Retrieve data using features and jobs."""
     TENANTS = auto()
     """Only retrieve data concerning tenants."""
     PROJECTS = auto()
@@ -97,10 +95,7 @@ class QuerySelector:
             result |= QueryType.TESTS
 
         if command == 'features':
-            if job_args:
-                result |= QueryType.FEATURES_JOBS
-            else:
-                result |= QueryType.FEATURES
+            result |= QueryType.FEATURES
 
         return result
 

--- a/cibyl/outputs/cli/ci/system/common/features.py
+++ b/cibyl/outputs/cli/ci/system/common/features.py
@@ -1,0 +1,36 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from cibyl.cli.query import QueryType
+
+
+def is_features_query(query: QueryType) -> bool:
+    """Checks the query involves a feature command. This might be a features
+    call with or without --jobs flag.
+
+    :param query: The query to check.
+    :return: True if the query involves a features subcommand, False if not.
+    """
+    return QueryType.FEATURES in query
+
+
+def is_pure_features_query(query: QueryType) -> bool:
+    """Checks the query involves a feature command without calling for --jobs.
+
+    :param query: The query to check.
+    :return: True if the query involves a features subcommand without a --jobs
+        flag, False if not.
+    """
+    return is_features_query(query) and QueryType.JOBS not in query

--- a/cibyl/outputs/cli/ci/system/impls/base/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/colored.py
@@ -20,6 +20,7 @@ from overrides import overrides
 from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.system import System
 from cibyl.models.product.feature import Feature
+from cibyl.outputs.cli.ci.system.common.features import is_features_query
 from cibyl.outputs.cli.ci.system.printer import CISystemPrinter
 from cibyl.outputs.cli.ci.system.utils.sorting.builds import SortBuildsByUUID
 from cibyl.outputs.cli.ci.system.utils.sorting.jobs import SortJobsByName
@@ -64,7 +65,7 @@ class ColoredBaseSystemPrinter(ColoredPrinter, CISystemPrinter):
         if self.verbosity > 0:
             printer[-1].append(f' (type: {system.system_type.value})')
 
-        if self.query in (QueryType.FEATURES_JOBS, QueryType.FEATURES):
+        if is_features_query(self.query):
             for feature in system.features.values():
                 printer.add(self.print_feature(feature), 1)
 

--- a/cibyl/outputs/cli/ci/system/impls/base/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/base/serialized.py
@@ -21,6 +21,7 @@ from overrides import overrides
 from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.system import System
 from cibyl.models.product.feature import Feature
+from cibyl.outputs.cli.ci.system.common.features import is_features_query
 from cibyl.outputs.cli.ci.system.printer import CISystemPrinter
 from cibyl.outputs.cli.printer import JSON, PROV, STDJSON, SerializedPrinter
 
@@ -40,7 +41,7 @@ class SerializedBaseSystemPrinter(
             'type': system.system_type.value
         }
 
-        if self.query in (QueryType.FEATURES_JOBS, QueryType.FEATURES):
+        if is_features_query(self.query):
             result['features'] = []
 
             for feature in system.features.values():

--- a/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/colored.py
@@ -15,6 +15,7 @@
 """
 from overrides import overrides
 
+import cibyl.outputs.cli.ci.system.common.features as features_queries
 from cibyl.cli.output import OutputStyle
 from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.build import Build
@@ -51,7 +52,9 @@ class ColoredJobsSystemPrinter(ColoredBaseSystemPrinter):
 
             if not system.is_queried():
                 printer.add(self.palette.blue('No query performed'), 1)
-            elif self.query != QueryType.FEATURES:
+            elif not features_queries.is_pure_features_query(self.query):
+                # avoid printing the number of jobs in case of having requested
+                # only features without jobs flag
                 header = 'Total jobs found in query: '
 
                 printer.add(self.palette.blue(header), 1)
@@ -74,7 +77,7 @@ class ColoredJobsSystemPrinter(ColoredBaseSystemPrinter):
                 printer.add(self.palette.blue('URL: '), 1)
                 printer[-1].append(job.url.value)
 
-        if self.query in (QueryType.FEATURES_JOBS, QueryType.FEATURES):
+        if features_queries.is_features_query(self.query):
             # if features are used, do not print further below
             return printer.build()
 

--- a/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
+++ b/cibyl/outputs/cli/ci/system/impls/jobs/serialized.py
@@ -24,6 +24,7 @@ from cibyl.models.ci.base.build import Build, Test
 from cibyl.models.ci.base.job import Job
 from cibyl.models.ci.base.stage import Stage
 from cibyl.models.ci.base.system import System
+from cibyl.outputs.cli.ci.system.common.features import is_features_query
 from cibyl.outputs.cli.ci.system.common.models import (get_plugin_section,
                                                        has_plugin_section)
 from cibyl.outputs.cli.ci.system.impls.base.serialized import \
@@ -62,7 +63,7 @@ class SerializedJobsSystemPrinter(SerializedBaseSystemPrinter[PROV], ABC):
             'name': job.name.value
         }
 
-        if self.query in (QueryType.FEATURES_JOBS, QueryType.FEATURES):
+        if is_features_query(self.query):
             return self.provider.dump(result)
 
         if self.query >= QueryType.BUILDS:

--- a/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
+++ b/cibyl/outputs/cli/ci/system/impls/zuul/colored.py
@@ -17,6 +17,7 @@ import logging
 
 from overrides import overrides
 
+import cibyl.outputs.cli.ci.system.common.features as features_query
 from cibyl.cli.output import OutputStyle
 from cibyl.cli.query import QueryType
 from cibyl.models.ci.base.build import Build
@@ -107,6 +108,10 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
             result.add(self.palette.blue('Job: '), 0)
             result[-1].append(job.name.value)
 
+            if features_query.is_features_query(self.query):
+                # if features are used, do not print further below
+                return result.build()
+
             if self.query >= QueryType.BUILDS:
                 builds = apply_filters(
                     job.builds.values(),
@@ -147,6 +152,10 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
 
             result.add(self.palette.blue('Job: '), 0)
             result[-1].append(job.name.value)
+
+            if features_query.is_features_query(self.query):
+                # if features are used, do not print further below
+                return result.build()
 
             if self.verbosity > 0:
                 if job.url.value:
@@ -319,7 +328,7 @@ class ColoredZuulSystemPrinter(ColoredBaseSystemPrinter):
         # Begin with the text common to all systems
         printer.add(super().print_system(system), 0)
 
-        if self.query == QueryType.FEATURES:
+        if features_query.is_pure_features_query(self.query):
             # if the user has only requested features, there is no need to
             # print anything else
             return printer.build()

--- a/tests/cibyl/intr/outputs/test_output_colored_openstack.py
+++ b/tests/cibyl/intr/outputs/test_output_colored_openstack.py
@@ -87,6 +87,7 @@ class TestOutputZuulSystemWithOpenstackPlugin(OpenstackPluginWithZuulSystem):
         # check that output is five lines long(system line, one line per job
         # and the line for total number of jobs)
         self.assertEqual(14, len(output.split("\n")))
+
         expected = "System: test-system\n"
         expected += "  Tenant: tenant\n"
         expected += "    Projects: \n"

--- a/tests/cibyl/unit/cli/test_query.py
+++ b/tests/cibyl/unit/cli/test_query.py
@@ -159,10 +159,9 @@ class TestGetQueryType(TestCase):
             'jobs': None
         }
 
-        self.assertIn(
-            QueryType.FEATURES_JOBS,
-            get_query_type(command="features", **args)
-        )
+        query = get_query_type(command="features", **args)
+        self.assertIn(QueryType.FEATURES, query)
+        self.assertIn(QueryType.JOBS, query)
 
     def test_get_feature_jobs_no_command(self):
         """Checks that "JOBS" is returned for "--feature" and

--- a/tests/cibyl/unit/outputs/cli/ci/system/common/test_features.py
+++ b/tests/cibyl/unit/outputs/cli/ci/system/common/test_features.py
@@ -1,0 +1,99 @@
+"""
+#    Copyright 2022 Red Hat
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""
+from unittest import TestCase
+
+import cibyl.outputs.cli.ci.system.common.features as features_query
+from cibyl.cli.query import QueryType
+
+
+class TestIsFeaturesQuery(TestCase):
+    """Tests for :func:`features_query.is_features_query`
+    """
+
+    def test_none_query(self):
+        """Checks result is false if the query passed is none.
+        """
+        query = QueryType.NONE
+
+        self.assertFalse(features_query.is_features_query(query))
+
+    def test_jobs_query(self):
+        """Checks result is false if the query passed is JOBS.
+        """
+        query = QueryType.JOBS
+
+        self.assertFalse(features_query.is_features_query(query))
+
+    def test_features_query(self):
+        """Checks result is true if the query passed is FEATURES.
+        """
+        query = QueryType.FEATURES
+
+        self.assertTrue(features_query.is_features_query(query))
+
+    def test_features_jobs_query(self):
+        """Checks result is true if the query passed is FEATURES and JOBS.
+        """
+        query = QueryType.FEATURES | QueryType.JOBS
+
+        self.assertTrue(features_query.is_features_query(query))
+
+    def test_builds_jobs_query(self):
+        """Checks result is false if the query passed is BUILDS and JOBS.
+        """
+        query = QueryType.BUILDS | QueryType.JOBS
+
+        self.assertFalse(features_query.is_features_query(query))
+
+
+class TestIsPureFeaturesQuery(TestCase):
+    """Tests for :func:`features_query.is_pure_features_query`
+    """
+
+    def test_none_query(self):
+        """Checks result is false if the query passed is none.
+        """
+        query = QueryType.NONE
+
+        self.assertFalse(features_query.is_pure_features_query(query))
+
+    def test_jobs_query(self):
+        """Checks result is false if the query passed is JOBS.
+        """
+        query = QueryType.JOBS
+
+        self.assertFalse(features_query.is_pure_features_query(query))
+
+    def test_features_query(self):
+        """Checks result is true if the query passed is FEATURES.
+        """
+        query = QueryType.FEATURES
+
+        self.assertTrue(features_query.is_pure_features_query(query))
+
+    def test_features_jobs_query(self):
+        """Checks result is false if the query passed is FEATURES and JOBS.
+        """
+        query = QueryType.FEATURES | QueryType.JOBS
+
+        self.assertFalse(features_query.is_pure_features_query(query))
+
+    def test_builds_jobs_query(self):
+        """Checks result is false if the query passed is BUILDS and JOBS.
+        """
+        query = QueryType.BUILDS | QueryType.JOBS
+
+        self.assertFalse(features_query.is_pure_features_query(query))


### PR DESCRIPTION
After latest changes to printers to simplify Zuul output, features
commands were not printing the expected output. This change adapts the
features part of the printers to use the bitmask QueryType, removing the
need for a FEATURES_JOBS type.
