### PR TITLE
Support --last-completed-build in Elasticsearch

### DIFF
--- a/cibyl/sources/jenkins.py
+++ b/cibyl/sources/jenkins.py
@@ -18,7 +18,6 @@ import json
 import logging
 import re
 from datetime import datetime, timezone
-from enum import Enum
 from functools import partial
 from typing import Callable, Dict, List
 from urllib.parse import urlparse
@@ -39,7 +38,7 @@ from cibyl.utils.filtering import (apply_filters,
                                    satisfy_case_insensitive_match,
                                    satisfy_exact_match, satisfy_range_match,
                                    satisfy_regex_match)
-from cibyl.utils.models import has_builds_job, has_tests_job
+from cibyl.utils.models import LastBuildEnum, has_builds_job, has_tests_job
 
 LOG = logging.getLogger(__name__)
 
@@ -209,14 +208,6 @@ def get_start_time_from_epoch(epoch_time: str) -> str:
     # remove timezone info from string representation
     start_time = start_time.replace(tzinfo=None)
     return str(start_time.isoformat(sep=" ", timespec="seconds"))
-
-
-class LastBuildEnum(str, Enum):
-    lastBuild = "lastBuild"
-    # Jenkins meaning of lastCompletedBuild is slightly different from what we
-    # have used, lastCompletedBuild will return also builds that failed,
-    # lastSuccessfulBuild is what we want
-    lastCompletedBuild = "lastSuccessfulBuild"
 
 
 # pylint: disable=no-member

--- a/cibyl/utils/models.py
+++ b/cibyl/utils/models.py
@@ -13,8 +13,17 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
+from enum import Enum
 
 from cibyl.models.ci.base.job import Job
+
+
+class LastBuildEnum(str, Enum):
+    lastBuild = "lastBuild"
+    # Jenkins meaning of lastCompletedBuild is slightly different from what we
+    # have used, lastCompletedBuild will return also builds that failed,
+    # lastSuccessfulBuild is what we want
+    lastCompletedBuild = "lastSuccessfulBuild"
 
 
 def has_tests_job(job: Job) -> bool:

--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -75,7 +75,7 @@ Arguments Matrix
      - | The last non-failed build of a job
      - |:ballot_box_with_check:|
      - |:ballot_box_with_check:|
-     - |:black_square_button:|
+     - |:ballot_box_with_check:|
      - |:x:|
      - |:x:|
    * - --build-status

--- a/tests/cibyl/unit/sources/elasticsearch/test_api.py
+++ b/tests/cibyl/unit/sources/elasticsearch/test_api.py
@@ -259,6 +259,25 @@ class TestElasticSearch(TestCase):
         self.assertEqual(build.status.value, "FAIL")
 
     @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
+    def test_get_builds_with_last_completed_build(self,
+                                                  mock_query_hits) -> None:
+        """Tests that the internal logic from
+           :meth:`ElasticSearch.get_builds` is correct.
+        """
+        mock_query_hits.side_effect = [self.build_hits]
+
+        builds_kwargs = Mock(spec=Argument)
+        builds_kwargs.value = []
+        builds = self.es_api.get_builds(last_completed_build=builds_kwargs)
+
+        test_builds = builds['test'].builds
+        self.assertEqual(len(test_builds), 1)
+
+        build = test_builds['1']
+        self.assertEqual(build.build_id.value, '1')
+        self.assertEqual(build.status.value, "SUCCESS")
+
+    @patch.object(ElasticSearch, '_ElasticSearch__query_get_hits')
     def test_last_build_filter_no_builds(self,
                                          mock_query_hits: object) -> None:
         """Tests that the internal logic from

--- a/tox.ini
+++ b/tox.ini
@@ -71,5 +71,5 @@ commands =
 deps =
     -r{toxinidir}/docs/requirements.txt
     -e.
-whitelist_externals = bash
+allowlist_externals = bash
 commands = bash -c 'cd docs && make clean && make html'


### PR DESCRIPTION
Add support for the --last-completed-build argument in the Elasticsearch
source. This will query for all jobs the last build that did not fail.
